### PR TITLE
Remove `GUARANTEED_ALLOCATED` parameter of `BumpPool(Guard)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **breaking:** `(Fixed)BumpString::as_mut_vec` now return `&mut` as they should instead of `&`.
+
 ## 0.5.9 (2024-08-25)
 - **improved:** removed a branch when bumping downwards (#25)
 - **fixed:** UB when using a base allocator with an alignment greater than `2 * size_of::<usize>()` (#32)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ zerocopy = { version = "0.7.34", default-features = false, optional = true }
 [features]
 default = ["std"]
 
-## Adds `BumpPool` and implementations of `std::io` traits for `BumpBox` and `{Fixed, Mut}BumpVec`.
+## Adds `BumpPool` and implementations of `std::io` traits for `BumpBox` and vectors.
 std = ["allocator-api2/std", "alloc"]
 
 ## Adds `Global` as the default allocator, `BumpBox::into_box` and some interactions with `alloc` collections.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ assert_eq!(bump.stats().allocated(), 4);
 ```
 
 ## Feature Flags
-* **`std`** *(enabled by default)* —  Adds `BumpPool` and implementations of `std::io` traits for `BumpBox` and `{Fixed, Mut}BumpVec`.
+* **`std`** *(enabled by default)* —  Adds `BumpPool` and implementations of `std::io` traits for `BumpBox` and vectors.
 * **`alloc`** —  Adds `Global` as the default allocator, `BumpBox::into_box` and some interactions with `alloc` collections.
 * **`serde`** —  Adds `Serialize` implementations for `BumpBox`, strings and vectors, and `DeserializeSeed` for strings and vectors.
 * **`zerocopy`** —  Adds `alloc_zeroed(_slice)`, `init_zeroed`, `resize_zeroed` and `extend_zeroed`.

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -360,7 +360,7 @@ impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCA
     /// safety, as `BumpString`s must be valid UTF-8.
     #[must_use]
     #[inline(always)]
-    pub unsafe fn as_mut_vec(&mut self) -> &BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
+    pub unsafe fn as_mut_vec(&mut self) -> &mut BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
         &mut self.vec
     }
 

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -255,7 +255,7 @@ impl<'a> FixedBumpString<'a> {
     /// safety, as `FixedBumpString`s must be valid UTF-8.
     #[must_use]
     #[inline(always)]
-    pub unsafe fn as_mut_vec(&mut self) -> &FixedBumpVec<'a, u8> {
+    pub unsafe fn as_mut_vec(&mut self) -> &mut FixedBumpVec<'a, u8> {
         &mut self.vec
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@
 //! ```
 //!
 //! # Feature Flags
-//! * **`std`** *(enabled by default)* —  Adds `BumpPool` and implementations of `std::io` traits for `BumpBox` and `{Fixed, Mut}BumpVec`.
+//! * **`std`** *(enabled by default)* —  Adds `BumpPool` and implementations of `std::io` traits for `BumpBox` and vectors.
 //! * **`alloc`** —  Adds `Global` as the default allocator, `BumpBox::into_box` and some interactions with `alloc` collections.
 //! * **`serde`** —  Adds `Serialize` implementations for `BumpBox`, strings and vectors, and `DeserializeSeed` for strings and vectors.
 //! * **`zerocopy`** —  Adds `alloc_zeroed(_slice)`, `init_zeroed`, `resize_zeroed` and `extend_zeroed`.


### PR DESCRIPTION
The parameter is useless, it's always `true`. This is a breaking change.