### PR TITLE
Deallocate `BumpVec` on drop and `into_iter`, shrink on `into_*slice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- **added:** `from_parts` and `into_parts` to `BumpVec` and `BumpString`
+- **added:** `FixedBumpString::into_string` returning a `BumpString`
+- **breaking:** `BumpVec` and `BumpString` now deallocate on drop, and shrink when calling `into_(boxed_)slice`
+
 ## 0.8.2 (2024-09-15)
 - **added:** `NoDrop` blanket impl for `[T]` is more general, replacing `Copy` bound with `NoDrop`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **added:** `from_parts` and `into_parts` to `BumpVec` and `BumpString`
 - **added:** `FixedBumpString::into_string` returning a `BumpString`
 - **breaking:** `BumpVec` and `BumpString` now deallocate on drop, and shrink when calling `into_(boxed_)slice`
+- **breaking:** `BumpVec::into_iter` now returns `bump_vec::IntoIter` which deallocates on drop
 
 ## 0.8.2 (2024-09-15)
 - **added:** `NoDrop` blanket impl for `[T]` is more general, replacing `Copy` bound with `NoDrop`

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/down.asm
@@ -100,7 +100,7 @@ inspect_asm::alloc_fmt::down:
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 24]
 	mov rdx, qword ptr [rdx]
-	cmp rcx, qword ptr [rdx]
+	cmp qword ptr [rdx], rcx
 	jne .LBB0_9
 	add rcx, qword ptr [rsp + 16]
 	mov qword ptr [rdx], rcx

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/down.asm
@@ -1,41 +1,47 @@
 inspect_asm::alloc_fmt::down:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	jne .LBB0_4
+	jne .LBB0_8
 	mov rsi, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 8]
-	mov r15, qword ptr [rsp + 24]
-	mov rax, qword ptr [r15]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_0
-	mov r14, rsi
-	jmp .LBB0_3
-.LBB0_0:
 	mov rax, qword ptr [rsp + 16]
+	mov r12, qword ptr [rsp + 24]
+	mov rcx, qword ptr [r12]
+	mov rcx, qword ptr [rcx]
+	cmp rsi, rcx
+	je .LBB0_1
+	mov r14, rsi
+	cmp r14, rcx
+	je .LBB0_4
+.LBB0_0:
+	mov r15, r14
+	jmp .LBB0_7
+.LBB0_1:
 	add rax, rsi
 	xor r14d, r14d
 	sub rax, rbx
@@ -44,21 +50,60 @@ inspect_asm::alloc_fmt::down:
 	mov rdi, r14
 	mov rdx, rbx
 	cmp rax, r14
-	jbe .LBB0_1
+	jbe .LBB0_2
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_2
-.LBB0_1:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	jmp .LBB0_3
 .LBB0_2:
-	mov rax, qword ptr [r15]
-	mov qword ptr [rax], r14
+	call qword ptr [rip + memcpy@GOTPCREL]
 .LBB0_3:
-	mov rax, r14
+	mov rax, qword ptr [r12]
+	mov qword ptr [rax], r14
+	mov rax, qword ptr [r12]
+	mov rcx, qword ptr [rax]
+	mov rax, rbx
+	cmp r14, rcx
+	jne .LBB0_0
+.LBB0_4:
+	add rax, rcx
+	xor edx, edx
+	sub rax, rbx
+	cmovae rdx, rax
+	lea rax, [rbx + rcx]
+	mov r15, rdx
+	sub r15, rcx
+	add r15, r14
+	mov rdi, r15
+	mov rsi, r14
+	cmp rax, rdx
+	jbe .LBB0_5
 	mov rdx, rbx
-	add rsp, 112
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_6
+.LBB0_5:
+	mov rdx, rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_6:
+	mov rax, qword ptr [r12]
+	mov qword ptr [rax], r15
+.LBB0_7:
+	mov rax, r15
+	mov rdx, rbx
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
-.LBB0_4:
+.LBB0_8:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
+	ud2
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rcx, qword ptr [rdx]
+	jne .LBB0_9
+	add rcx, qword ptr [rsp + 16]
+	mov qword ptr [rdx], rcx
+.LBB0_9:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/down_a.asm
@@ -99,14 +99,16 @@ inspect_asm::alloc_fmt::down_a:
 .LBB0_8:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
 	ud2
-	mov rcx, qword ptr [rsp]
-	mov rdx, qword ptr [rsp + 24]
-	mov rdx, qword ptr [rdx]
-	cmp rcx, qword ptr [rdx]
+	mov rdx, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
+	cmp qword ptr [rcx], rdx
 	jne .LBB0_9
-	add rcx, qword ptr [rsp + 16]
-	and rcx, -4
-	mov qword ptr [rdx], rcx
+	mov rsi, qword ptr [rsp + 16]
+	add rdx, rsi
+	add rdx, 3
+	and rdx, -4
+	mov qword ptr [rcx], rdx
 .LBB0_9:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/down_a.asm
@@ -1,41 +1,47 @@
 inspect_asm::alloc_fmt::down_a:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	jne .LBB0_4
+	jne .LBB0_8
 	mov rsi, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 8]
-	mov r15, qword ptr [rsp + 24]
-	mov rax, qword ptr [r15]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_0
-	mov r14, rsi
-	jmp .LBB0_3
-.LBB0_0:
 	mov rax, qword ptr [rsp + 16]
+	mov r12, qword ptr [rsp + 24]
+	mov rcx, qword ptr [r12]
+	mov rcx, qword ptr [rcx]
+	cmp rsi, rcx
+	je .LBB0_1
+	mov r14, rsi
+	cmp r14, rcx
+	je .LBB0_4
+.LBB0_0:
+	mov r15, r14
+	jmp .LBB0_7
+.LBB0_1:
 	add rax, rsi
 	xor r14d, r14d
 	sub rax, rbx
@@ -45,21 +51,62 @@ inspect_asm::alloc_fmt::down_a:
 	mov rdi, r14
 	mov rdx, rbx
 	cmp rax, r14
-	jbe .LBB0_1
+	jbe .LBB0_2
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_2
-.LBB0_1:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	jmp .LBB0_3
 .LBB0_2:
-	mov rax, qword ptr [r15]
-	mov qword ptr [rax], r14
+	call qword ptr [rip + memcpy@GOTPCREL]
 .LBB0_3:
-	mov rax, r14
+	mov rax, qword ptr [r12]
+	mov qword ptr [rax], r14
+	mov rax, qword ptr [r12]
+	mov rcx, qword ptr [rax]
+	mov rax, rbx
+	cmp r14, rcx
+	jne .LBB0_0
+.LBB0_4:
+	add rax, rcx
+	xor edx, edx
+	sub rax, rbx
+	cmovae rdx, rax
+	and rdx, -4
+	lea rax, [rbx + rcx]
+	mov r15, rdx
+	sub r15, rcx
+	add r15, r14
+	mov rdi, r15
+	mov rsi, r14
+	cmp rax, rdx
+	jbe .LBB0_5
 	mov rdx, rbx
-	add rsp, 112
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_6
+.LBB0_5:
+	mov rdx, rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_6:
+	mov rax, qword ptr [r12]
+	mov qword ptr [rax], r15
+.LBB0_7:
+	mov rax, r15
+	mov rdx, rbx
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
-.LBB0_4:
+.LBB0_8:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
+	ud2
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rcx, qword ptr [rdx]
+	jne .LBB0_9
+	add rcx, qword ptr [rsp + 16]
+	and rcx, -4
+	mov qword ptr [rdx], rcx
+.LBB0_9:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_down.asm
@@ -1,65 +1,117 @@
 inspect_asm::alloc_fmt::try_down:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	je .LBB0_0
-	xor eax, eax
-	jmp .LBB0_4
+	je .LBB0_1
+	mov rax, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
+	cmp rax, qword ptr [rcx]
+	jne .LBB0_0
+	add rax, qword ptr [rsp + 16]
+	mov qword ptr [rcx], rax
 .LBB0_0:
+	xor eax, eax
+	jmp .LBB0_9
+.LBB0_1:
 	mov rsi, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 8]
-	mov r14, qword ptr [rsp + 24]
-	mov rax, qword ptr [r14]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_1
-	mov rax, rsi
-	jmp .LBB0_4
-.LBB0_1:
 	mov rax, qword ptr [rsp + 16]
-	add rax, rsi
-	xor edi, edi
-	sub rax, rbx
-	cmovae rdi, rax
-	lea rax, [rbx + rsi]
-	mov r15, rdi
-	mov rdx, rbx
-	cmp rax, rdi
-	jbe .LBB0_2
-	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_3
+	mov r15, qword ptr [rsp + 24]
+	mov rcx, qword ptr [r15]
+	mov rcx, qword ptr [rcx]
+	cmp rsi, rcx
+	je .LBB0_3
+	mov r14, rsi
+	cmp r14, rcx
+	je .LBB0_6
 .LBB0_2:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	mov rax, r14
+	jmp .LBB0_9
 .LBB0_3:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-.LBB0_4:
+	add rax, rsi
+	xor r14d, r14d
+	sub rax, rbx
+	cmovae r14, rax
+	lea rax, [rbx + rsi]
+	mov rdi, r14
 	mov rdx, rbx
-	add rsp, 112
+	cmp rax, r14
+	jbe .LBB0_4
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_5
+.LBB0_4:
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_5:
+	mov rax, qword ptr [r15]
+	mov qword ptr [rax], r14
+	mov rax, qword ptr [r15]
+	mov rcx, qword ptr [rax]
+	mov rax, rbx
+	cmp r14, rcx
+	jne .LBB0_2
+.LBB0_6:
+	add rax, rcx
+	xor edx, edx
+	sub rax, rbx
+	cmovae rdx, rax
+	lea rax, [rbx + rcx]
+	mov rdi, rdx
+	sub rdi, rcx
+	add rdi, r14
+	mov r12, rdi
+	mov rsi, r14
+	cmp rax, rdx
+	jbe .LBB0_7
+	mov rdx, rbx
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_8
+.LBB0_7:
+	mov rdx, rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_8:
+	mov rcx, qword ptr [r15]
+	mov rax, r12
+	mov qword ptr [rcx], r12
+.LBB0_9:
+	mov rdx, rbx
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rcx, qword ptr [rdx]
+	jne .LBB0_10
+	add rcx, qword ptr [rsp + 16]
+	mov qword ptr [rdx], rcx
+.LBB0_10:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_down.asm
@@ -30,7 +30,7 @@ inspect_asm::alloc_fmt::try_down:
 	mov rax, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 24]
 	mov rcx, qword ptr [rcx]
-	cmp rax, qword ptr [rcx]
+	cmp qword ptr [rcx], rax
 	jne .LBB0_0
 	add rax, qword ptr [rsp + 16]
 	mov qword ptr [rcx], rax
@@ -108,7 +108,7 @@ inspect_asm::alloc_fmt::try_down:
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 24]
 	mov rdx, qword ptr [rdx]
-	cmp rcx, qword ptr [rdx]
+	cmp qword ptr [rdx], rcx
 	jne .LBB0_10
 	add rcx, qword ptr [rsp + 16]
 	mov qword ptr [rdx], rcx

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_down_a.asm
@@ -1,66 +1,121 @@
 inspect_asm::alloc_fmt::try_down_a:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	je .LBB0_0
-	xor eax, eax
-	jmp .LBB0_4
+	je .LBB0_1
+	mov rax, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
+	cmp rax, qword ptr [rcx]
+	jne .LBB0_0
+	add rax, qword ptr [rsp + 16]
+	and rax, -4
+	mov qword ptr [rcx], rax
 .LBB0_0:
+	xor eax, eax
+	jmp .LBB0_9
+.LBB0_1:
 	mov rsi, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 8]
-	mov r14, qword ptr [rsp + 24]
-	mov rax, qword ptr [r14]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_1
-	mov rax, rsi
-	jmp .LBB0_4
-.LBB0_1:
 	mov rax, qword ptr [rsp + 16]
-	add rax, rsi
-	xor edi, edi
-	sub rax, rbx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rbx + rsi]
-	mov r15, rdi
-	mov rdx, rbx
-	cmp rax, rdi
-	jbe .LBB0_2
-	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_3
+	mov r15, qword ptr [rsp + 24]
+	mov rcx, qword ptr [r15]
+	mov rcx, qword ptr [rcx]
+	cmp rsi, rcx
+	je .LBB0_3
+	mov r14, rsi
+	cmp r14, rcx
+	je .LBB0_6
 .LBB0_2:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	mov rax, r14
+	jmp .LBB0_9
 .LBB0_3:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-.LBB0_4:
+	add rax, rsi
+	xor r14d, r14d
+	sub rax, rbx
+	cmovae r14, rax
+	and r14, -4
+	lea rax, [rbx + rsi]
+	mov rdi, r14
 	mov rdx, rbx
-	add rsp, 112
+	cmp rax, r14
+	jbe .LBB0_4
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_5
+.LBB0_4:
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_5:
+	mov rax, qword ptr [r15]
+	mov qword ptr [rax], r14
+	mov rax, qword ptr [r15]
+	mov rcx, qword ptr [rax]
+	mov rax, rbx
+	cmp r14, rcx
+	jne .LBB0_2
+.LBB0_6:
+	add rax, rcx
+	xor edx, edx
+	sub rax, rbx
+	cmovae rdx, rax
+	and rdx, -4
+	lea rax, [rbx + rcx]
+	mov rdi, rdx
+	sub rdi, rcx
+	add rdi, r14
+	mov r12, rdi
+	mov rsi, r14
+	cmp rax, rdx
+	jbe .LBB0_7
+	mov rdx, rbx
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_8
+.LBB0_7:
+	mov rdx, rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_8:
+	mov rcx, qword ptr [r15]
+	mov rax, r12
+	mov qword ptr [rcx], r12
+.LBB0_9:
+	mov rdx, rbx
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rcx, qword ptr [rdx]
+	jne .LBB0_10
+	add rcx, qword ptr [rsp + 16]
+	and rcx, -4
+	mov qword ptr [rdx], rcx
+.LBB0_10:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_down_a.asm
@@ -27,14 +27,16 @@ inspect_asm::alloc_fmt::try_down_a:
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
 	je .LBB0_1
-	mov rax, qword ptr [rsp]
-	mov rcx, qword ptr [rsp + 24]
-	mov rcx, qword ptr [rcx]
-	cmp rax, qword ptr [rcx]
+	mov rcx, qword ptr [rsp]
+	mov rax, qword ptr [rsp + 24]
+	mov rax, qword ptr [rax]
+	cmp qword ptr [rax], rcx
 	jne .LBB0_0
-	add rax, qword ptr [rsp + 16]
-	and rax, -4
-	mov qword ptr [rcx], rax
+	mov rdx, qword ptr [rsp + 16]
+	add rcx, rdx
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rax], rcx
 .LBB0_0:
 	xor eax, eax
 	jmp .LBB0_9
@@ -108,14 +110,16 @@ inspect_asm::alloc_fmt::try_down_a:
 	pop r14
 	pop r15
 	ret
-	mov rcx, qword ptr [rsp]
-	mov rdx, qword ptr [rsp + 24]
-	mov rdx, qword ptr [rdx]
-	cmp rcx, qword ptr [rdx]
+	mov rdx, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
+	cmp qword ptr [rcx], rdx
 	jne .LBB0_10
-	add rcx, qword ptr [rsp + 16]
-	and rcx, -4
-	mov qword ptr [rdx], rcx
+	mov rsi, qword ptr [rsp + 16]
+	add rdx, rsi
+	add rdx, 3
+	and rdx, -4
+	mov qword ptr [rcx], rdx
 .LBB0_10:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up.asm
@@ -22,23 +22,57 @@ inspect_asm::alloc_fmt::try_up:
 	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	je .LBB0_0
+	je .LBB0_1
+	mov rax, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rsp + 16]
+	add rdx, rax
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_0
+	mov qword ptr [rcx], rax
+.LBB0_0:
 	xor eax, eax
 	add rsp, 120
 	ret
-.LBB0_0:
+.LBB0_1:
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
-	mov rcx, qword ptr [rsp + 24]
 	mov rsi, qword ptr [rsp + 16]
+	mov r8, qword ptr [rsp + 24]
+	lea r9, [rax + rsi]
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	cmp r9, rdi
+	je .LBB0_3
 	add rsi, rax
-	mov rcx, qword ptr [rcx]
-	cmp rsi, qword ptr [rcx]
-	je .LBB0_1
+	cmp rsi, rdi
+	je .LBB0_4
+.LBB0_2:
 	add rsp, 120
 	ret
-.LBB0_1:
+.LBB0_3:
+	lea rsi, [rdx + rax]
+	mov qword ptr [rcx], rsi
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	mov rsi, rdx
+	add rsi, rax
+	cmp rsi, rdi
+	jne .LBB0_2
+.LBB0_4:
 	lea rsi, [rdx + rax]
 	mov qword ptr [rcx], rsi
 	add rsp, 120
 	ret
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rsi, qword ptr [rsp + 16]
+	add rsi, rcx
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_5
+	mov qword ptr [rdx], rcx
+.LBB0_5:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
@@ -22,25 +22,65 @@ inspect_asm::alloc_fmt::try_up_a:
 	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	je .LBB0_0
+	je .LBB0_1
+	mov rax, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rsp + 16]
+	add rdx, rax
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_0
+	add rax, 3
+	and rax, -4
+	mov qword ptr [rcx], rax
+.LBB0_0:
 	xor eax, eax
 	add rsp, 120
 	ret
-.LBB0_0:
+.LBB0_1:
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
-	mov rcx, qword ptr [rsp + 24]
 	mov rsi, qword ptr [rsp + 16]
+	mov r8, qword ptr [rsp + 24]
+	lea r9, [rax + rsi]
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	cmp r9, rdi
+	je .LBB0_3
 	add rsi, rax
-	mov rcx, qword ptr [rcx]
-	cmp rsi, qword ptr [rcx]
-	je .LBB0_1
+	cmp rsi, rdi
+	je .LBB0_4
+.LBB0_2:
 	add rsp, 120
 	ret
-.LBB0_1:
+.LBB0_3:
+	lea rsi, [rax + rdx]
+	add rsi, 3
+	and rsi, -4
+	mov qword ptr [rcx], rsi
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	mov rsi, rdx
+	add rsi, rax
+	cmp rsi, rdi
+	jne .LBB0_2
+.LBB0_4:
 	lea rsi, [rax + rdx]
 	add rsi, 3
 	and rsi, -4
 	mov qword ptr [rcx], rsi
 	add rsp, 120
 	ret
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rsi, qword ptr [rsp + 16]
+	add rsi, rcx
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_5
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rdx], rcx
+.LBB0_5:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
@@ -30,8 +30,6 @@ inspect_asm::alloc_fmt::try_up_a:
 	mov rcx, qword ptr [rcx]
 	cmp rdx, qword ptr [rcx]
 	jne .LBB0_0
-	add rax, 3
-	and rax, -4
 	mov qword ptr [rcx], rax
 .LBB0_0:
 	xor eax, eax
@@ -78,8 +76,6 @@ inspect_asm::alloc_fmt::try_up_a:
 	mov rdx, qword ptr [rdx]
 	cmp rsi, qword ptr [rdx]
 	jne .LBB0_5
-	add rcx, 3
-	and rcx, -4
 	mov qword ptr [rdx], rcx
 .LBB0_5:
 	mov rdi, rax

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/up.asm
@@ -22,21 +22,47 @@ inspect_asm::alloc_fmt::up:
 	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	jne .LBB0_1
+	jne .LBB0_3
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
-	mov rcx, qword ptr [rsp + 24]
 	mov rsi, qword ptr [rsp + 16]
+	mov r8, qword ptr [rsp + 24]
+	lea r9, [rax + rsi]
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	cmp r9, rdi
+	je .LBB0_1
 	add rsi, rax
-	mov rcx, qword ptr [rcx]
-	cmp rsi, qword ptr [rcx]
-	je .LBB0_0
+	cmp rsi, rdi
+	je .LBB0_2
+.LBB0_0:
 	add rsp, 120
 	ret
-.LBB0_0:
+.LBB0_1:
+	lea rsi, [rdx + rax]
+	mov qword ptr [rcx], rsi
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	mov rsi, rdx
+	add rsi, rax
+	cmp rsi, rdi
+	jne .LBB0_0
+.LBB0_2:
 	lea rsi, [rdx + rax]
 	mov qword ptr [rcx], rsi
 	add rsp, 120
 	ret
-.LBB0_1:
+.LBB0_3:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
+	ud2
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rsi, qword ptr [rsp + 16]
+	add rsi, rcx
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_4
+	mov qword ptr [rdx], rcx
+.LBB0_4:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/up_a.asm
@@ -66,8 +66,6 @@ inspect_asm::alloc_fmt::up_a:
 	mov rdx, qword ptr [rdx]
 	cmp rsi, qword ptr [rdx]
 	jne .LBB0_4
-	add rcx, 3
-	and rcx, -4
 	mov qword ptr [rdx], rcx
 .LBB0_4:
 	mov rdi, rax

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/up_a.asm
@@ -22,23 +22,53 @@ inspect_asm::alloc_fmt::up_a:
 	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	jne .LBB0_1
+	jne .LBB0_3
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
-	mov rcx, qword ptr [rsp + 24]
 	mov rsi, qword ptr [rsp + 16]
+	mov r8, qword ptr [rsp + 24]
+	lea r9, [rax + rsi]
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	cmp r9, rdi
+	je .LBB0_1
 	add rsi, rax
-	mov rcx, qword ptr [rcx]
-	cmp rsi, qword ptr [rcx]
-	je .LBB0_0
+	cmp rsi, rdi
+	je .LBB0_2
+.LBB0_0:
 	add rsp, 120
 	ret
-.LBB0_0:
+.LBB0_1:
+	lea rsi, [rax + rdx]
+	add rsi, 3
+	and rsi, -4
+	mov qword ptr [rcx], rsi
+	mov rcx, qword ptr [r8]
+	mov rdi, qword ptr [rcx]
+	mov rsi, rdx
+	add rsi, rax
+	cmp rsi, rdi
+	jne .LBB0_0
+.LBB0_2:
 	lea rsi, [rax + rdx]
 	add rsi, 3
 	and rsi, -4
 	mov qword ptr [rcx], rsi
 	add rsp, 120
 	ret
-.LBB0_1:
+.LBB0_3:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
+	ud2
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 24]
+	mov rsi, qword ptr [rsp + 16]
+	add rsi, rcx
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_4
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rdx], rcx
+.LBB0_4:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
@@ -136,15 +136,14 @@ inspect_asm::alloc_iter_u32::down:
 	jmp .LBB0_0
 .LBB0_15:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
-	mov rdx, qword ptr [rsp + 8]
-	mov rcx, qword ptr [rsp + 32]
-	mov rcx, qword ptr [rcx]
-	cmp rdx, qword ptr [rcx]
+	mov rcx, qword ptr [rsp + 8]
+	mov rdx, qword ptr [rsp + 32]
+	mov rdx, qword ptr [rdx]
+	cmp qword ptr [rdx], rcx
 	jne .LBB0_16
 	mov rsi, qword ptr [rsp + 24]
-	lea rdx, [rdx + 4*rsi]
-	and rdx, -4
-	mov qword ptr [rcx], rdx
+	lea rcx, [rcx + 4*rsi]
+	mov qword ptr [rdx], rcx
 .LBB0_16:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
@@ -8,10 +8,10 @@ inspect_asm::alloc_iter_u32::down:
 	sub rsp, 40
 	mov rbx, rdi
 	test rdx, rdx
-	je .LBB0_5
+	je .LBB0_4
 	mov rax, rdx
 	shr rax, 61
-	jne .LBB0_11
+	jne .LBB0_15
 	mov r15, rsi
 	lea r12, [4*rdx]
 	mov rcx, qword ptr [rbx]
@@ -19,7 +19,7 @@ inspect_asm::alloc_iter_u32::down:
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r12, rsi
-	ja .LBB0_10
+	ja .LBB0_14
 	sub rax, r12
 	and rax, -4
 	mov qword ptr [rcx], rax
@@ -51,41 +51,73 @@ inspect_asm::alloc_iter_u32::down:
 .LBB0_3:
 	mov rsi, qword ptr [rsp + 8]
 	mov rbx, qword ptr [rsp + 32]
-	mov rax, qword ptr [rbx]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_6
+	jmp .LBB0_5
 .LBB0_4:
-	mov rax, rsi
-	jmp .LBB0_9
-.LBB0_5:
 	mov qword ptr [rsp + 24], rdx
 	mov esi, 4
 	xor r14d, r14d
+.LBB0_5:
+	lea r15, [4*r14]
 	mov rax, qword ptr [rbx]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_4
+	mov rax, qword ptr [rax]
+	cmp rsi, rax
+	je .LBB0_7
+	mov r12, rsi
+	cmp r12, rax
+	je .LBB0_10
 .LBB0_6:
-	lea rdx, [4*r14]
+	mov rax, r12
+	jmp .LBB0_13
+.LBB0_7:
 	mov rax, qword ptr [rsp + 24]
 	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
-	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_7
+	xor r12d, r12d
+	sub rax, r15
+	cmovae r12, rax
+	and r12, -4
+	lea rax, [r15 + rsi]
+	mov rdi, r12
+	mov rdx, r15
+	cmp rax, r12
+	jbe .LBB0_8
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_8
-.LBB0_7:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	jmp .LBB0_9
 .LBB0_8:
-	mov rcx, qword ptr [rbx]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-	mov qword ptr [rsp + 24], r14
+	call qword ptr [rip + memcpy@GOTPCREL]
 .LBB0_9:
+	mov rax, qword ptr [rbx]
+	mov qword ptr [rax], r12
+	mov qword ptr [rsp + 24], r14
+	mov rax, qword ptr [rbx]
+	mov rax, qword ptr [rax]
+	cmp r12, rax
+	jne .LBB0_6
+.LBB0_10:
+	mov rcx, qword ptr [rsp + 24]
+	lea rcx, [rax + 4*rcx]
+	xor edx, edx
+	sub rcx, r15
+	cmovae rdx, rcx
+	and rdx, -4
+	lea rcx, [r15 + rax]
+	mov rdi, rdx
+	sub rdi, rax
+	add rdi, r12
+	mov r13, rdi
+	mov rsi, r12
+	cmp rcx, rdx
+	jbe .LBB0_11
+	mov rdx, r15
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_12
+.LBB0_11:
+	mov rdx, r15
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_12:
+	mov rcx, qword ptr [rbx]
+	mov rax, r13
+	mov qword ptr [rcx], r13
+.LBB0_13:
 	mov rdx, r14
 	add rsp, 40
 	pop rbx
@@ -95,12 +127,24 @@ inspect_asm::alloc_iter_u32::down:
 	pop r15
 	pop rbp
 	ret
-.LBB0_10:
+.LBB0_14:
 	mov rdi, rbx
 	mov rsi, rdx
 	mov r14, rdx
 	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
 	mov rdx, r14
 	jmp .LBB0_0
-.LBB0_11:
+.LBB0_15:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
+	mov rdx, qword ptr [rsp + 8]
+	mov rcx, qword ptr [rsp + 32]
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_16
+	mov rsi, qword ptr [rsp + 24]
+	lea rdx, [rdx + 4*rsi]
+	and rdx, -4
+	mov qword ptr [rcx], rdx
+.LBB0_16:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
@@ -138,10 +138,11 @@ inspect_asm::alloc_iter_u32::down_a:
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 32]
 	mov rcx, qword ptr [rcx]
-	cmp rdx, qword ptr [rcx]
+	cmp qword ptr [rcx], rdx
 	jne .LBB0_16
 	mov rsi, qword ptr [rsp + 24]
 	lea rdx, [rdx + 4*rsi]
+	add rdx, 3
 	and rdx, -4
 	mov qword ptr [rcx], rdx
 .LBB0_16:

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
@@ -8,10 +8,10 @@ inspect_asm::alloc_iter_u32::down_a:
 	sub rsp, 40
 	mov r14, rdi
 	test rdx, rdx
-	je .LBB0_5
+	je .LBB0_4
 	mov rax, rdx
 	shr rax, 61
-	jne .LBB0_11
+	jne .LBB0_15
 	mov r15, rsi
 	lea r12, [4*rdx]
 	mov rcx, qword ptr [r14]
@@ -19,7 +19,7 @@ inspect_asm::alloc_iter_u32::down_a:
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r12, rsi
-	ja .LBB0_10
+	ja .LBB0_14
 	sub rax, r12
 	mov qword ptr [rcx], rax
 .LBB0_0:
@@ -50,41 +50,73 @@ inspect_asm::alloc_iter_u32::down_a:
 .LBB0_3:
 	mov rsi, qword ptr [rsp + 8]
 	mov r14, qword ptr [rsp + 32]
-	mov rax, qword ptr [r14]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_6
+	jmp .LBB0_5
 .LBB0_4:
-	mov rax, rsi
-	jmp .LBB0_9
-.LBB0_5:
 	mov qword ptr [rsp + 24], rdx
 	mov esi, 4
 	xor ebx, ebx
+.LBB0_5:
+	lea r15, [4*rbx]
 	mov rax, qword ptr [r14]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_4
+	mov rax, qword ptr [rax]
+	cmp rsi, rax
+	je .LBB0_7
+	mov r12, rsi
+	cmp r12, rax
+	je .LBB0_10
 .LBB0_6:
-	lea rdx, [4*rbx]
+	mov rax, r12
+	jmp .LBB0_13
+.LBB0_7:
 	mov rax, qword ptr [rsp + 24]
 	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
-	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_7
+	xor r12d, r12d
+	sub rax, r15
+	cmovae r12, rax
+	and r12, -4
+	lea rax, [r15 + rsi]
+	mov rdi, r12
+	mov rdx, r15
+	cmp rax, r12
+	jbe .LBB0_8
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_8
-.LBB0_7:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	jmp .LBB0_9
 .LBB0_8:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-	mov qword ptr [rsp + 24], rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
 .LBB0_9:
+	mov rax, qword ptr [r14]
+	mov qword ptr [rax], r12
+	mov qword ptr [rsp + 24], rbx
+	mov rax, qword ptr [r14]
+	mov rax, qword ptr [rax]
+	cmp r12, rax
+	jne .LBB0_6
+.LBB0_10:
+	mov rcx, qword ptr [rsp + 24]
+	lea rcx, [rax + 4*rcx]
+	xor edx, edx
+	sub rcx, r15
+	cmovae rdx, rcx
+	and rdx, -4
+	lea rcx, [r15 + rax]
+	mov rdi, rdx
+	sub rdi, rax
+	add rdi, r12
+	mov r13, rdi
+	mov rsi, r12
+	cmp rcx, rdx
+	jbe .LBB0_11
+	mov rdx, r15
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_12
+.LBB0_11:
+	mov rdx, r15
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_12:
+	mov rcx, qword ptr [r14]
+	mov rax, r13
+	mov qword ptr [rcx], r13
+.LBB0_13:
 	mov rdx, rbx
 	add rsp, 40
 	pop rbx
@@ -94,12 +126,24 @@ inspect_asm::alloc_iter_u32::down_a:
 	pop r15
 	pop rbp
 	ret
-.LBB0_10:
+.LBB0_14:
 	mov rdi, r14
 	mov rsi, rdx
 	mov rbx, rdx
 	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
 	mov rdx, rbx
 	jmp .LBB0_0
-.LBB0_11:
+.LBB0_15:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
+	mov rdx, qword ptr [rsp + 8]
+	mov rcx, qword ptr [rsp + 32]
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_16
+	mov rsi, qword ptr [rsp + 24]
+	lea rdx, [rdx + 4*rsi]
+	and rdx, -4
+	mov qword ptr [rcx], rdx
+.LBB0_16:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
@@ -135,15 +135,14 @@ inspect_asm::alloc_iter_u32::try_down:
 	pop rbp
 	ret
 .LBB0_16:
-	mov rcx, qword ptr [rsp + 8]
-	mov rax, qword ptr [rsp + 32]
-	mov rax, qword ptr [rax]
-	cmp rcx, qword ptr [rax]
+	mov rax, qword ptr [rsp + 8]
+	mov rcx, qword ptr [rsp + 32]
+	mov rcx, qword ptr [rcx]
+	cmp qword ptr [rcx], rax
 	jne .LBB0_0
 	mov rdx, qword ptr [rsp + 24]
-	lea rcx, [rcx + 4*rdx]
-	and rcx, -4
-	mov qword ptr [rax], rcx
+	lea rax, [rax + 4*rdx]
+	mov qword ptr [rcx], rax
 	jmp .LBB0_0
 .LBB0_17:
 	mov rdi, r14
@@ -154,15 +153,14 @@ inspect_asm::alloc_iter_u32::try_down:
 	test rax, rax
 	jne .LBB0_3
 	jmp .LBB0_0
-	mov rdx, qword ptr [rsp + 8]
-	mov rcx, qword ptr [rsp + 32]
-	mov rcx, qword ptr [rcx]
-	cmp rdx, qword ptr [rcx]
+	mov rcx, qword ptr [rsp + 8]
+	mov rdx, qword ptr [rsp + 32]
+	mov rdx, qword ptr [rdx]
+	cmp qword ptr [rdx], rcx
 	jne .LBB0_18
 	mov rsi, qword ptr [rsp + 24]
-	lea rdx, [rdx + 4*rsi]
-	and rdx, -4
-	mov qword ptr [rcx], rdx
+	lea rcx, [rcx + 4*rsi]
+	mov qword ptr [rdx], rcx
 .LBB0_18:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
@@ -6,93 +6,125 @@ inspect_asm::alloc_iter_u32::try_down:
 	push r12
 	push rbx
 	sub rsp, 40
+	mov r14, rdi
 	test rdx, rdx
 	je .LBB0_1
 	mov rax, rdx
 	shr rax, 61
-	je .LBB0_3
+	je .LBB0_2
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_11
+	jmp .LBB0_15
 .LBB0_1:
 	mov qword ptr [rsp + 24], rdx
 	mov esi, 4
 	xor ebx, ebx
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_8
+	jmp .LBB0_7
 .LBB0_2:
-	mov rax, rsi
-	jmp .LBB0_11
-.LBB0_3:
-	mov r14, rsi
+	mov r15, rsi
 	lea r12, [4*rdx]
-	mov rcx, qword ptr [rdi]
+	mov rcx, qword ptr [r14]
 	mov rax, qword ptr [rcx]
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r12, rsi
-	ja .LBB0_12
+	ja .LBB0_17
 	sub rax, r12
 	and rax, -4
 	mov qword ptr [rcx], rax
-	je .LBB0_12
-.LBB0_4:
+	je .LBB0_17
+.LBB0_3:
 	mov qword ptr [rsp + 8], rax
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdx
-	mov qword ptr [rsp + 32], rdi
+	mov qword ptr [rsp + 32], r14
 	xor r13d, r13d
-	lea r15, [rsp + 8]
+	lea r14, [rsp + 8]
 	xor ebx, ebx
-	jmp .LBB0_6
-.LBB0_5:
+	jmp .LBB0_5
+.LBB0_4:
 	mov dword ptr [rax + 4*rbx], ebp
 	inc rbx
 	mov qword ptr [rsp + 16], rbx
 	add r13, 4
 	cmp r12, r13
-	je .LBB0_7
-.LBB0_6:
-	mov ebp, dword ptr [r14 + r13]
+	je .LBB0_6
+.LBB0_5:
+	mov ebp, dword ptr [r15 + r13]
 	cmp qword ptr [rsp + 24], rbx
-	jne .LBB0_5
-	mov rdi, r15
+	jne .LBB0_4
+	mov rdi, r14
 	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_cold
 	test al, al
-	jne .LBB0_0
+	jne .LBB0_16
 	mov rax, qword ptr [rsp + 8]
 	mov rbx, qword ptr [rsp + 16]
-	jmp .LBB0_5
-.LBB0_7:
+	jmp .LBB0_4
+.LBB0_6:
 	mov rsi, qword ptr [rsp + 8]
-	mov rdi, qword ptr [rsp + 32]
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_2
+	mov r14, qword ptr [rsp + 32]
+.LBB0_7:
+	lea r15, [4*rbx]
+	mov rax, qword ptr [r14]
+	mov rax, qword ptr [rax]
+	cmp rsi, rax
+	je .LBB0_9
+	mov r12, rsi
+	cmp r12, rax
+	je .LBB0_12
 .LBB0_8:
-	mov r14, rdi
-	lea rdx, [4*rbx]
+	mov rax, r12
+	jmp .LBB0_15
+.LBB0_9:
 	mov rax, qword ptr [rsp + 24]
 	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
-	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_9
+	xor r12d, r12d
+	sub rax, r15
+	cmovae r12, rax
+	and r12, -4
+	lea rax, [r15 + rsi]
+	mov rdi, r12
+	mov rdx, r15
+	cmp rax, r12
+	jbe .LBB0_10
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_10
-.LBB0_9:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	jmp .LBB0_11
 .LBB0_10:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-	mov qword ptr [rsp + 24], rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
 .LBB0_11:
+	mov rax, qword ptr [r14]
+	mov qword ptr [rax], r12
+	mov qword ptr [rsp + 24], rbx
+	mov rax, qword ptr [r14]
+	mov rax, qword ptr [rax]
+	cmp r12, rax
+	jne .LBB0_8
+.LBB0_12:
+	mov rcx, qword ptr [rsp + 24]
+	lea rcx, [rax + 4*rcx]
+	xor edx, edx
+	sub rcx, r15
+	cmovae rdx, rcx
+	and rdx, -4
+	lea rcx, [r15 + rax]
+	mov rdi, rdx
+	sub rdi, rax
+	add rdi, r12
+	mov r13, rdi
+	mov rsi, r12
+	cmp rcx, rdx
+	jbe .LBB0_13
+	mov rdx, r15
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_14
+.LBB0_13:
+	mov rdx, r15
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_14:
+	mov rcx, qword ptr [r14]
+	mov rax, r13
+	mov qword ptr [rcx], r13
+.LBB0_15:
 	mov rdx, rbx
 	add rsp, 40
 	pop rbx
@@ -102,13 +134,35 @@ inspect_asm::alloc_iter_u32::try_down:
 	pop r15
 	pop rbp
 	ret
-.LBB0_12:
-	mov rbx, rdi
-	mov rsi, rdx
-	mov r15, rdx
-	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
-	mov rdx, r15
-	mov rdi, rbx
-	test rax, rax
-	jne .LBB0_4
+.LBB0_16:
+	mov rcx, qword ptr [rsp + 8]
+	mov rax, qword ptr [rsp + 32]
+	mov rax, qword ptr [rax]
+	cmp rcx, qword ptr [rax]
+	jne .LBB0_0
+	mov rdx, qword ptr [rsp + 24]
+	lea rcx, [rcx + 4*rdx]
+	and rcx, -4
+	mov qword ptr [rax], rcx
 	jmp .LBB0_0
+.LBB0_17:
+	mov rdi, r14
+	mov rsi, rdx
+	mov rbx, rdx
+	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
+	mov rdx, rbx
+	test rax, rax
+	jne .LBB0_3
+	jmp .LBB0_0
+	mov rdx, qword ptr [rsp + 8]
+	mov rcx, qword ptr [rsp + 32]
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_18
+	mov rsi, qword ptr [rsp + 24]
+	lea rdx, [rdx + 4*rsi]
+	and rdx, -4
+	mov qword ptr [rcx], rdx
+.LBB0_18:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
@@ -137,10 +137,11 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	mov rcx, qword ptr [rsp + 8]
 	mov rax, qword ptr [rsp + 32]
 	mov rax, qword ptr [rax]
-	cmp rcx, qword ptr [rax]
+	cmp qword ptr [rax], rcx
 	jne .LBB0_0
 	mov rdx, qword ptr [rsp + 24]
 	lea rcx, [rcx + 4*rdx]
+	add rcx, 3
 	and rcx, -4
 	mov qword ptr [rax], rcx
 	jmp .LBB0_0
@@ -156,10 +157,11 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 32]
 	mov rcx, qword ptr [rcx]
-	cmp rdx, qword ptr [rcx]
+	cmp qword ptr [rcx], rdx
 	jne .LBB0_18
 	mov rsi, qword ptr [rsp + 24]
 	lea rdx, [rdx + 4*rsi]
+	add rdx, 3
 	and rdx, -4
 	mov qword ptr [rcx], rdx
 .LBB0_18:

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
@@ -6,92 +6,124 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	push r12
 	push rbx
 	sub rsp, 40
+	mov r14, rdi
 	test rdx, rdx
 	je .LBB0_1
 	mov rax, rdx
 	shr rax, 61
-	je .LBB0_3
+	je .LBB0_2
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_11
+	jmp .LBB0_15
 .LBB0_1:
 	mov qword ptr [rsp + 24], rdx
 	mov esi, 4
 	xor ebx, ebx
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_8
+	jmp .LBB0_7
 .LBB0_2:
-	mov rax, rsi
-	jmp .LBB0_11
-.LBB0_3:
-	mov r14, rsi
+	mov r15, rsi
 	lea r12, [4*rdx]
-	mov rcx, qword ptr [rdi]
+	mov rcx, qword ptr [r14]
 	mov rax, qword ptr [rcx]
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r12, rsi
-	ja .LBB0_12
+	ja .LBB0_17
 	sub rax, r12
 	mov qword ptr [rcx], rax
-	je .LBB0_12
-.LBB0_4:
+	je .LBB0_17
+.LBB0_3:
 	mov qword ptr [rsp + 8], rax
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdx
-	mov qword ptr [rsp + 32], rdi
+	mov qword ptr [rsp + 32], r14
 	xor r13d, r13d
-	lea r15, [rsp + 8]
+	lea r14, [rsp + 8]
 	xor ebx, ebx
-	jmp .LBB0_6
-.LBB0_5:
+	jmp .LBB0_5
+.LBB0_4:
 	mov dword ptr [rax + 4*rbx], ebp
 	inc rbx
 	mov qword ptr [rsp + 16], rbx
 	add r13, 4
 	cmp r12, r13
-	je .LBB0_7
-.LBB0_6:
-	mov ebp, dword ptr [r14 + r13]
+	je .LBB0_6
+.LBB0_5:
+	mov ebp, dword ptr [r15 + r13]
 	cmp qword ptr [rsp + 24], rbx
-	jne .LBB0_5
-	mov rdi, r15
+	jne .LBB0_4
+	mov rdi, r14
 	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_cold
 	test al, al
-	jne .LBB0_0
+	jne .LBB0_16
 	mov rax, qword ptr [rsp + 8]
 	mov rbx, qword ptr [rsp + 16]
-	jmp .LBB0_5
-.LBB0_7:
+	jmp .LBB0_4
+.LBB0_6:
 	mov rsi, qword ptr [rsp + 8]
-	mov rdi, qword ptr [rsp + 32]
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_2
+	mov r14, qword ptr [rsp + 32]
+.LBB0_7:
+	lea r15, [4*rbx]
+	mov rax, qword ptr [r14]
+	mov rax, qword ptr [rax]
+	cmp rsi, rax
+	je .LBB0_9
+	mov r12, rsi
+	cmp r12, rax
+	je .LBB0_12
 .LBB0_8:
-	mov r14, rdi
-	lea rdx, [4*rbx]
+	mov rax, r12
+	jmp .LBB0_15
+.LBB0_9:
 	mov rax, qword ptr [rsp + 24]
 	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
-	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_9
+	xor r12d, r12d
+	sub rax, r15
+	cmovae r12, rax
+	and r12, -4
+	lea rax, [r15 + rsi]
+	mov rdi, r12
+	mov rdx, r15
+	cmp rax, r12
+	jbe .LBB0_10
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_10
-.LBB0_9:
-	call qword ptr [rip + memcpy@GOTPCREL]
+	jmp .LBB0_11
 .LBB0_10:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-	mov qword ptr [rsp + 24], rbx
+	call qword ptr [rip + memcpy@GOTPCREL]
 .LBB0_11:
+	mov rax, qword ptr [r14]
+	mov qword ptr [rax], r12
+	mov qword ptr [rsp + 24], rbx
+	mov rax, qword ptr [r14]
+	mov rax, qword ptr [rax]
+	cmp r12, rax
+	jne .LBB0_8
+.LBB0_12:
+	mov rcx, qword ptr [rsp + 24]
+	lea rcx, [rax + 4*rcx]
+	xor edx, edx
+	sub rcx, r15
+	cmovae rdx, rcx
+	and rdx, -4
+	lea rcx, [r15 + rax]
+	mov rdi, rdx
+	sub rdi, rax
+	add rdi, r12
+	mov r13, rdi
+	mov rsi, r12
+	cmp rcx, rdx
+	jbe .LBB0_13
+	mov rdx, r15
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_14
+.LBB0_13:
+	mov rdx, r15
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_14:
+	mov rcx, qword ptr [r14]
+	mov rax, r13
+	mov qword ptr [rcx], r13
+.LBB0_15:
 	mov rdx, rbx
 	add rsp, 40
 	pop rbx
@@ -101,13 +133,35 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	pop r15
 	pop rbp
 	ret
-.LBB0_12:
-	mov rbx, rdi
-	mov rsi, rdx
-	mov r15, rdx
-	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
-	mov rdx, r15
-	mov rdi, rbx
-	test rax, rax
-	jne .LBB0_4
+.LBB0_16:
+	mov rcx, qword ptr [rsp + 8]
+	mov rax, qword ptr [rsp + 32]
+	mov rax, qword ptr [rax]
+	cmp rcx, qword ptr [rax]
+	jne .LBB0_0
+	mov rdx, qword ptr [rsp + 24]
+	lea rcx, [rcx + 4*rdx]
+	and rcx, -4
+	mov qword ptr [rax], rcx
 	jmp .LBB0_0
+.LBB0_17:
+	mov rdi, r14
+	mov rsi, rdx
+	mov rbx, rdx
+	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
+	mov rdx, rbx
+	test rax, rax
+	jne .LBB0_3
+	jmp .LBB0_0
+	mov rdx, qword ptr [rsp + 8]
+	mov rcx, qword ptr [rsp + 32]
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_18
+	mov rsi, qword ptr [rsp + 24]
+	lea rdx, [rdx + 4*rsi]
+	and rdx, -4
+	mov qword ptr [rcx], rdx
+.LBB0_18:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
@@ -99,10 +99,10 @@ inspect_asm::alloc_iter_u32::try_up:
 .LBB0_11:
 	mov rax, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 16]
-	lea rdx, [rax + 4*rcx]
-	mov rcx, qword ptr [rsp + 24]
-	mov rcx, qword ptr [rcx]
-	cmp rdx, qword ptr [rcx]
+	mov rdx, qword ptr [rsp + 24]
+	lea rsi, [rax + 4*rcx]
+	mov rcx, qword ptr [rdx]
+	cmp rsi, qword ptr [rcx]
 	jne .LBB0_0
 	mov qword ptr [rcx], rax
 	jmp .LBB0_0
@@ -118,10 +118,10 @@ inspect_asm::alloc_iter_u32::try_up:
 	jmp .LBB0_0
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 16]
-	lea rsi, [rcx + 4*rdx]
-	mov rdx, qword ptr [rsp + 24]
-	mov rdx, qword ptr [rdx]
-	cmp rsi, qword ptr [rdx]
+	mov rsi, qword ptr [rsp + 24]
+	lea rdi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsi]
+	cmp rdi, qword ptr [rdx]
 	jne .LBB0_13
 	mov qword ptr [rdx], rcx
 .LBB0_13:

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
@@ -9,31 +9,16 @@ inspect_asm::alloc_iter_u32::try_up:
 	je .LBB0_1
 	mov rax, rdx
 	shr rax, 61
-	je .LBB0_4
+	je .LBB0_2
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_3
+	jmp .LBB0_8
 .LBB0_1:
 	mov eax, 4
 	xor edx, edx
 	xor ecx, ecx
-	add rcx, rax
-	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_3
+	jmp .LBB0_7
 .LBB0_2:
-	lea rcx, [rax + 4*rdx]
-	mov qword ptr [rsi], rcx
-	mov qword ptr [rsp + 16], rdx
-.LBB0_3:
-	add rsp, 32
-	pop rbx
-	pop r12
-	pop r14
-	pop r15
-	pop rbp
-	ret
-.LBB0_4:
 	mov rbx, rsi
 	lea r15, [4*rdx]
 	mov rcx, qword ptr [rdi]
@@ -43,12 +28,12 @@ inspect_asm::alloc_iter_u32::try_up:
 	and rax, -4
 	sub rsi, rax
 	cmp r15, rsi
-	ja .LBB0_9
+	ja .LBB0_12
 	lea rsi, [rax + r15]
 	mov qword ptr [rcx], rsi
 	test rax, rax
-	je .LBB0_9
-.LBB0_5:
+	je .LBB0_12
+.LBB0_3:
 	mov qword ptr [rsp], rax
 	mov qword ptr [rsp + 8], 0
 	mov qword ptr [rsp + 16], rdx
@@ -56,36 +41,72 @@ inspect_asm::alloc_iter_u32::try_up:
 	xor r12d, r12d
 	mov r14, rsp
 	xor edx, edx
-	jmp .LBB0_7
-.LBB0_6:
+	jmp .LBB0_5
+.LBB0_4:
 	mov dword ptr [rax + 4*rdx], ebp
 	inc rdx
 	mov qword ptr [rsp + 8], rdx
 	add r12, 4
 	cmp r15, r12
-	je .LBB0_8
-.LBB0_7:
+	je .LBB0_6
+.LBB0_5:
 	mov ebp, dword ptr [rbx + r12]
 	cmp qword ptr [rsp + 16], rdx
-	jne .LBB0_6
+	jne .LBB0_4
 	mov rdi, r14
 	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_cold
 	test al, al
-	jne .LBB0_0
+	jne .LBB0_11
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
-	jmp .LBB0_6
-.LBB0_8:
+	jmp .LBB0_4
+.LBB0_6:
 	mov rax, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
+.LBB0_7:
+	lea r9, [rax + rcx]
 	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_3
-	jmp .LBB0_2
+	mov r8, qword ptr [rsi]
+	cmp r9, r8
+	je .LBB0_9
+	add rcx, rax
+	cmp rcx, r8
+	je .LBB0_10
+.LBB0_8:
+	add rsp, 32
+	pop rbx
+	pop r12
+	pop r14
+	pop r15
+	pop rbp
+	ret
 .LBB0_9:
+	lea rcx, [4*rdx]
+	lea r8, [rax + 4*rdx]
+	mov qword ptr [rsi], r8
+	mov qword ptr [rsp + 16], rdx
+	mov rsi, qword ptr [rdi]
+	mov r8, qword ptr [rsi]
+	add rcx, rax
+	cmp rcx, r8
+	jne .LBB0_8
+.LBB0_10:
+	lea rcx, [rax + 4*rdx]
+	mov qword ptr [rsi], rcx
+	jmp .LBB0_8
+.LBB0_11:
+	mov rax, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 16]
+	lea rdx, [rax + 4*rcx]
+	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_0
+	mov qword ptr [rcx], rax
+	jmp .LBB0_0
+.LBB0_12:
 	mov r14, rdi
 	mov rsi, rdx
 	mov r12, rdx
@@ -93,5 +114,16 @@ inspect_asm::alloc_iter_u32::try_up:
 	mov rdx, r12
 	mov rdi, r14
 	test rax, rax
-	jne .LBB0_5
+	jne .LBB0_3
 	jmp .LBB0_0
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 16]
+	lea rsi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_13
+	mov qword ptr [rdx], rcx
+.LBB0_13:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
@@ -99,13 +99,11 @@ inspect_asm::alloc_iter_u32::try_up_a:
 .LBB0_11:
 	mov rax, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 16]
-	lea rdx, [rax + 4*rcx]
-	mov rcx, qword ptr [rsp + 24]
-	mov rcx, qword ptr [rcx]
-	cmp rdx, qword ptr [rcx]
+	mov rdx, qword ptr [rsp + 24]
+	lea rsi, [rax + 4*rcx]
+	mov rcx, qword ptr [rdx]
+	cmp rsi, qword ptr [rcx]
 	jne .LBB0_0
-	add rax, 3
-	and rax, -4
 	mov qword ptr [rcx], rax
 	jmp .LBB0_0
 .LBB0_12:
@@ -120,13 +118,11 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	jmp .LBB0_0
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 16]
-	lea rsi, [rcx + 4*rdx]
-	mov rdx, qword ptr [rsp + 24]
-	mov rdx, qword ptr [rdx]
-	cmp rsi, qword ptr [rdx]
+	mov rsi, qword ptr [rsp + 24]
+	lea rdi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsi]
+	cmp rdi, qword ptr [rdx]
 	jne .LBB0_13
-	add rcx, 3
-	and rcx, -4
 	mov qword ptr [rdx], rcx
 .LBB0_13:
 	mov rdi, rax

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
@@ -9,33 +9,16 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	je .LBB0_1
 	mov rax, rdx
 	shr rax, 61
-	je .LBB0_4
+	je .LBB0_2
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_3
+	jmp .LBB0_8
 .LBB0_1:
 	mov eax, 4
 	xor edx, edx
 	xor ecx, ecx
-	add rcx, rax
-	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_3
+	jmp .LBB0_7
 .LBB0_2:
-	lea rcx, [rax + 4*rdx]
-	add rcx, 3
-	and rcx, -4
-	mov qword ptr [rsi], rcx
-	mov qword ptr [rsp + 16], rdx
-.LBB0_3:
-	add rsp, 32
-	pop rbx
-	pop r12
-	pop r14
-	pop r15
-	pop rbp
-	ret
-.LBB0_4:
 	mov rbx, rsi
 	lea r15, [4*rdx]
 	mov rcx, qword ptr [rdi]
@@ -43,10 +26,10 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	mov rsi, qword ptr [rcx + 8]
 	sub rsi, rax
 	cmp r15, rsi
-	ja .LBB0_9
+	ja .LBB0_12
 	lea rsi, [r15 + rax]
 	mov qword ptr [rcx], rsi
-.LBB0_5:
+.LBB0_3:
 	mov qword ptr [rsp], rax
 	mov qword ptr [rsp + 8], 0
 	mov qword ptr [rsp + 16], rdx
@@ -54,36 +37,78 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	xor r12d, r12d
 	mov r14, rsp
 	xor edx, edx
-	jmp .LBB0_7
-.LBB0_6:
+	jmp .LBB0_5
+.LBB0_4:
 	mov dword ptr [rax + 4*rdx], ebp
 	inc rdx
 	mov qword ptr [rsp + 8], rdx
 	add r12, 4
 	cmp r15, r12
-	je .LBB0_8
-.LBB0_7:
+	je .LBB0_6
+.LBB0_5:
 	mov ebp, dword ptr [rbx + r12]
 	cmp qword ptr [rsp + 16], rdx
-	jne .LBB0_6
+	jne .LBB0_4
 	mov rdi, r14
 	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_cold
 	test al, al
-	jne .LBB0_0
+	jne .LBB0_11
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
-	jmp .LBB0_6
-.LBB0_8:
+	jmp .LBB0_4
+.LBB0_6:
 	mov rax, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
+.LBB0_7:
+	lea r9, [rax + rcx]
 	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_3
-	jmp .LBB0_2
+	mov r8, qword ptr [rsi]
+	cmp r9, r8
+	je .LBB0_9
+	add rcx, rax
+	cmp rcx, r8
+	je .LBB0_10
+.LBB0_8:
+	add rsp, 32
+	pop rbx
+	pop r12
+	pop r14
+	pop r15
+	pop rbp
+	ret
 .LBB0_9:
+	lea rcx, [4*rdx]
+	lea r8, [rax + 4*rdx]
+	add r8, 3
+	and r8, -4
+	mov qword ptr [rsi], r8
+	mov qword ptr [rsp + 16], rdx
+	mov rsi, qword ptr [rdi]
+	mov r8, qword ptr [rsi]
+	add rcx, rax
+	cmp rcx, r8
+	jne .LBB0_8
+.LBB0_10:
+	lea rcx, [rax + 4*rdx]
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rsi], rcx
+	jmp .LBB0_8
+.LBB0_11:
+	mov rax, qword ptr [rsp]
+	mov rcx, qword ptr [rsp + 16]
+	lea rdx, [rax + 4*rcx]
+	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
+	cmp rdx, qword ptr [rcx]
+	jne .LBB0_0
+	add rax, 3
+	and rax, -4
+	mov qword ptr [rcx], rax
+	jmp .LBB0_0
+.LBB0_12:
 	mov r14, rdi
 	mov rsi, rdx
 	mov r12, rdx
@@ -91,5 +116,18 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	mov rdx, r12
 	mov rdi, r14
 	test rax, rax
-	jne .LBB0_5
+	jne .LBB0_3
 	jmp .LBB0_0
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 16]
+	lea rsi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_13
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rdx], rcx
+.LBB0_13:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
@@ -6,10 +6,10 @@ inspect_asm::alloc_iter_u32::up:
 	push rbx
 	sub rsp, 32
 	test rdx, rdx
-	je .LBB0_6
+	je .LBB0_4
 	mov rax, rdx
 	shr rax, 61
-	jne .LBB0_8
+	jne .LBB0_10
 	mov rbx, rsi
 	lea r15, [4*rdx]
 	mov rcx, qword ptr [rdi]
@@ -19,7 +19,7 @@ inspect_asm::alloc_iter_u32::up:
 	and rax, -4
 	sub rsi, rax
 	cmp r15, rsi
-	ja .LBB0_7
+	ja .LBB0_9
 	lea rsi, [rax + r15]
 	mov qword ptr [rcx], rsi
 .LBB0_0:
@@ -52,15 +52,21 @@ inspect_asm::alloc_iter_u32::up:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
-	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_5
+	jmp .LBB0_5
 .LBB0_4:
-	lea rcx, [rax + 4*rdx]
-	mov qword ptr [rsi], rcx
-	mov qword ptr [rsp + 16], rdx
+	mov eax, 4
+	xor edx, edx
+	xor ecx, ecx
 .LBB0_5:
+	lea r9, [rax + rcx]
+	mov rsi, qword ptr [rdi]
+	mov r8, qword ptr [rsi]
+	cmp r9, r8
+	je .LBB0_7
+	add rcx, rax
+	cmp rcx, r8
+	je .LBB0_8
+.LBB0_6:
 	add rsp, 32
 	pop rbx
 	pop r12
@@ -68,16 +74,21 @@ inspect_asm::alloc_iter_u32::up:
 	pop r15
 	pop rbp
 	ret
-.LBB0_6:
-	mov eax, 4
-	xor edx, edx
-	xor ecx, ecx
-	add rcx, rax
-	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_5
-	jmp .LBB0_4
 .LBB0_7:
+	lea rcx, [4*rdx]
+	lea r8, [rax + 4*rdx]
+	mov qword ptr [rsi], r8
+	mov qword ptr [rsp + 16], rdx
+	mov rsi, qword ptr [rdi]
+	mov r8, qword ptr [rsi]
+	add rcx, rax
+	cmp rcx, r8
+	jne .LBB0_6
+.LBB0_8:
+	lea rcx, [rax + 4*rdx]
+	mov qword ptr [rsi], rcx
+	jmp .LBB0_6
+.LBB0_9:
 	mov r14, rdi
 	mov rsi, rdx
 	mov r12, rdx
@@ -85,5 +96,16 @@ inspect_asm::alloc_iter_u32::up:
 	mov rdx, r12
 	mov rdi, r14
 	jmp .LBB0_0
-.LBB0_8:
+.LBB0_10:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 16]
+	lea rsi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_11
+	mov qword ptr [rdx], rcx
+.LBB0_11:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
@@ -100,10 +100,10 @@ inspect_asm::alloc_iter_u32::up:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 16]
-	lea rsi, [rcx + 4*rdx]
-	mov rdx, qword ptr [rsp + 24]
-	mov rdx, qword ptr [rdx]
-	cmp rsi, qword ptr [rdx]
+	mov rsi, qword ptr [rsp + 24]
+	lea rdi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsi]
+	cmp rdi, qword ptr [rdx]
 	jne .LBB0_11
 	mov qword ptr [rdx], rcx
 .LBB0_11:

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
@@ -6,10 +6,10 @@ inspect_asm::alloc_iter_u32::up_a:
 	push rbx
 	sub rsp, 32
 	test rdx, rdx
-	je .LBB0_6
+	je .LBB0_4
 	mov rax, rdx
 	shr rax, 61
-	jne .LBB0_8
+	jne .LBB0_10
 	mov rbx, rsi
 	lea r15, [4*rdx]
 	mov rcx, qword ptr [rdi]
@@ -17,7 +17,7 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov rsi, qword ptr [rcx + 8]
 	sub rsi, rax
 	cmp r15, rsi
-	ja .LBB0_7
+	ja .LBB0_9
 	lea rsi, [r15 + rax]
 	mov qword ptr [rcx], rsi
 .LBB0_0:
@@ -50,17 +50,21 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
-	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_5
+	jmp .LBB0_5
 .LBB0_4:
-	lea rcx, [rax + 4*rdx]
-	add rcx, 3
-	and rcx, -4
-	mov qword ptr [rsi], rcx
-	mov qword ptr [rsp + 16], rdx
+	mov eax, 4
+	xor edx, edx
+	xor ecx, ecx
 .LBB0_5:
+	lea r9, [rax + rcx]
+	mov rsi, qword ptr [rdi]
+	mov r8, qword ptr [rsi]
+	cmp r9, r8
+	je .LBB0_7
+	add rcx, rax
+	cmp rcx, r8
+	je .LBB0_8
+.LBB0_6:
 	add rsp, 32
 	pop rbx
 	pop r12
@@ -68,16 +72,25 @@ inspect_asm::alloc_iter_u32::up_a:
 	pop r15
 	pop rbp
 	ret
-.LBB0_6:
-	mov eax, 4
-	xor edx, edx
-	xor ecx, ecx
-	add rcx, rax
-	mov rsi, qword ptr [rdi]
-	cmp rcx, qword ptr [rsi]
-	jne .LBB0_5
-	jmp .LBB0_4
 .LBB0_7:
+	lea rcx, [4*rdx]
+	lea r8, [rax + 4*rdx]
+	add r8, 3
+	and r8, -4
+	mov qword ptr [rsi], r8
+	mov qword ptr [rsp + 16], rdx
+	mov rsi, qword ptr [rdi]
+	mov r8, qword ptr [rsi]
+	add rcx, rax
+	cmp rcx, r8
+	jne .LBB0_6
+.LBB0_8:
+	lea rcx, [rax + 4*rdx]
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rsi], rcx
+	jmp .LBB0_6
+.LBB0_9:
 	mov r14, rdi
 	mov rsi, rdx
 	mov r12, rdx
@@ -85,5 +98,18 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov rdx, r12
 	mov rdi, r14
 	jmp .LBB0_0
-.LBB0_8:
+.LBB0_10:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
+	mov rcx, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 16]
+	lea rsi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsp + 24]
+	mov rdx, qword ptr [rdx]
+	cmp rsi, qword ptr [rdx]
+	jne .LBB0_11
+	add rcx, 3
+	and rcx, -4
+	mov qword ptr [rdx], rcx
+.LBB0_11:
+	mov rdi, rax
+	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
@@ -102,13 +102,11 @@ inspect_asm::alloc_iter_u32::up_a:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 16]
-	lea rsi, [rcx + 4*rdx]
-	mov rdx, qword ptr [rsp + 24]
-	mov rdx, qword ptr [rdx]
-	cmp rsi, qword ptr [rdx]
+	mov rsi, qword ptr [rsp + 24]
+	lea rdi, [rcx + 4*rdx]
+	mov rdx, qword ptr [rsi]
+	cmp rdi, qword ptr [rdx]
 	jne .LBB0_11
-	add rcx, 3
-	and rcx, -4
 	mov qword ptr [rdx], rcx
 .LBB0_11:
 	mov rdi, rax

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -3,7 +3,7 @@ use core::{
     fmt::Debug,
     hash::Hash,
     iter,
-    mem::{ManuallyDrop, MaybeUninit},
+    mem::{self, ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ops::{Deref, DerefMut, Index, IndexMut, RangeBounds},
     panic::{RefUnwindSafe, UnwindSafe},
@@ -149,7 +149,11 @@ macro_rules! bump_vec_declaration {
             const MIN_ALIGN: usize = 1,
             const UP: bool = true,
             const GUARANTEED_ALLOCATED: bool = true,
-        > {
+        >
+        where
+            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+            A: BaseAllocator<GUARANTEED_ALLOCATED>,
+        {
             pub(crate) fixed: FixedBumpVec<'a, T>,
             pub(crate) bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
         }
@@ -163,6 +167,8 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 where
     T: UnwindSafe,
     A: UnwindSafe,
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
 }
 
@@ -171,11 +177,16 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 where
     T: RefUnwindSafe,
     A: RefUnwindSafe,
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
 }
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Deref
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     type Target = [T];
 
@@ -186,9 +197,24 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DerefMut
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.fixed
+    }
+}
+
+impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
+    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    fn drop(&mut self) {
+        self.clear();
+        self.shrink_to_fit();
     }
 }
 
@@ -311,6 +337,9 @@ where
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
     BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[doc = include_str!("docs/vec/capacity.md")]
     /// # Examples
@@ -1194,24 +1223,23 @@ where
     }
 
     /// Turns this `BumpVec<T>` into a `FixedBumpVec<T>`.
+    ///
+    /// This retains the unused capacity unlike <code>[into_](Self::into_slice)([boxed_](Self::into_boxed_slice))[slice](Self::into_slice)</code>.
     #[must_use]
     #[inline(always)]
     pub fn into_fixed_vec(self) -> FixedBumpVec<'a, T> {
-        self.fixed
+        self.into_parts().0
     }
 
     /// Turns this `BumpVec<T>` into a `BumpBox<[T]>`.
-    ///
-    /// You may want to call [`shrink_to_fit`](Self::shrink_to_fit) before this, so the unused capacity does not take up space.
     #[must_use]
     #[inline(always)]
-    pub fn into_boxed_slice(self) -> BumpBox<'a, [T]> {
-        self.fixed.into_boxed_slice()
+    pub fn into_boxed_slice(mut self) -> BumpBox<'a, [T]> {
+        self.shrink_to_fit();
+        self.into_fixed_vec().into_boxed_slice()
     }
 
     /// Turns this `BumpVec<T>` into a `&[T]` that is live for the entire bump scope.
-    ///
-    /// You may want to call [`shrink_to_fit`](Self::shrink_to_fit) before this, so the unused capacity does not take up space.
     ///
     /// This is only available for [`NoDrop`] types so you don't omit dropping a value for which it matters.
     ///
@@ -1223,6 +1251,54 @@ where
         [T]: NoDrop,
     {
         self.into_boxed_slice().into_mut()
+    }
+
+    /// Creates a `BumpVec<T>` from its parts.
+    ///
+    /// The provided `bump` does not have to be the one the `fixed_vec` was allocated in.
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, BumpVec };
+    /// # let bump: Bump = Bump::new();
+    /// let mut fixed_vec = bump.alloc_fixed_vec(3);
+    /// fixed_vec.push(1);
+    /// fixed_vec.push(2);
+    /// fixed_vec.push(3);
+    /// let mut vec = BumpVec::from_parts(fixed_vec, &bump);
+    /// vec.push(4);
+    /// vec.push(5);
+    /// assert_eq!(vec, [1, 2, 3, 4, 5]);
+    /// ```
+    #[must_use]
+    #[inline(always)]
+    pub fn from_parts(
+        fixed_vec: FixedBumpVec<'a, T>,
+        bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>,
+    ) -> Self {
+        Self {
+            fixed: fixed_vec,
+            bump: bump.into(),
+        }
+    }
+
+    /// Turns this `BumpVec<T>` into its parts.
+    /// ```
+    /// # use bump_scope::{ Bump, BumpVec };
+    /// # let bump: Bump = Bump::new();
+    /// let mut vec = BumpVec::new_in(&bump);
+    /// vec.reserve(3);
+    /// vec.push(1);
+    /// let mut fixed_vec = vec.into_parts().0;
+    /// assert_eq!(fixed_vec.capacity(), 3);
+    /// assert_eq!(fixed_vec, [1]);
+    /// ```
+    #[must_use]
+    #[inline(always)]
+    pub fn into_parts(self) -> (FixedBumpVec<'a, T>, &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) {
+        let mut this = ManuallyDrop::new(self);
+        let bump = this.bump;
+        let fixed = mem::take(&mut this.fixed);
+        (fixed, bump)
     }
 
     /// # Safety
@@ -1582,7 +1658,7 @@ where
     /// ```
     #[must_use]
     pub fn into_flattened(self) -> BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
-        let Self { fixed, bump } = self;
+        let (fixed, bump) = self.into_parts();
         let fixed = fixed.into_flattened();
         BumpVec { fixed, bump }
     }
@@ -1590,6 +1666,9 @@ where
 
 impl<'b, 'a: 'b, T: Debug, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Debug
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(self.as_slice(), f)
@@ -1598,6 +1677,9 @@ impl<'b, 'a: 'b, T: Debug, const MIN_ALIGN: usize, const UP: bool, const GUARANT
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, I: SliceIndex<[T]>> Index<I>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     type Output = I::Output;
 
@@ -1609,6 +1691,9 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, I: SliceIndex<[T]>>
     IndexMut<I> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
@@ -1659,6 +1744,8 @@ impl<'b0, 'a0: 'b0, 'b1, 'a1: 'b1, T, U, const MIN_ALIGN: usize, const UP: bool,
     PartialEq<BumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>
     for BumpVec<'b0, 'a0, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1675,6 +1762,8 @@ where
 impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
     PartialEq<[U; N]> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1691,6 +1780,8 @@ where
 impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
     PartialEq<&[U; N]> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1707,6 +1798,8 @@ where
 impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
     PartialEq<&mut [U; N]> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1723,6 +1816,8 @@ where
 impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<[U]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1739,6 +1834,9 @@ where
 impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<&[U]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1755,6 +1853,8 @@ where
 impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<&mut [U]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1771,6 +1871,8 @@ where
 impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
     PartialEq<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for [T]
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1787,6 +1889,8 @@ where
 impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
     PartialEq<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for &[T]
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1803,6 +1907,8 @@ where
 impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
     PartialEq<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for &mut [T]
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -1820,18 +1926,23 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     type Item = T;
     type IntoIter = IntoIter<'a, T>;
 
     #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
-        self.fixed.into_iter()
+        // FIXME: use a dellocating `IntoIter`
+        self.into_boxed_slice().into_iter()
     }
 }
 
 impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
     for &'c BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     type Item = &'c T;
     type IntoIter = slice::Iter<'c, T>;
@@ -1844,6 +1955,9 @@ impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANT
 
 impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
     for &'c mut BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     type Item = &'c mut T;
     type IntoIter = slice::IterMut<'c, T>;
@@ -1856,6 +1970,9 @@ impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANT
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsRef<[T]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn as_ref(&self) -> &[T] {
@@ -1865,6 +1982,9 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsMut<[T]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn as_mut(&mut self) -> &mut [T] {
@@ -1874,6 +1994,9 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Borrow<[T]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn borrow(&self) -> &[T] {
@@ -1883,6 +2006,9 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
 impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BorrowMut<[T]>
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn borrow_mut(&mut self) -> &mut [T] {
@@ -1892,6 +2018,9 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
 impl<'b, 'a: 'b, T: Hash, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Hash
     for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -235,7 +235,7 @@ where
                 unsafe {
                     let ptr = self.0.fixed.initialized.ptr.cast();
                     let layout = Layout::from_size_align_unchecked(self.0.fixed.capacity * T::SIZE, T::ALIGN);
-                    self.0.bump.deallocate(ptr, layout)
+                    self.0.bump.deallocate(ptr, layout);
                 }
             }
         }

--- a/src/bump_vec/into_iter.rs
+++ b/src/bump_vec/into_iter.rs
@@ -1,0 +1,281 @@
+use core::{
+    fmt::Debug,
+    iter::FusedIterator,
+    marker::PhantomData,
+    mem,
+    ptr::{self, NonNull},
+    slice,
+};
+
+use crate::{
+    polyfill::nonnull, BaseAllocator, BumpBox, BumpScope, FixedBumpVec, MinimumAlignment, SizedTypeProperties,
+    SupportedMinimumAlignment,
+};
+
+use super::BumpVec;
+
+/// An iterator that moves out of a vector.
+///
+/// This `struct` is created by the `into_iter` method on
+/// [`BumpVec`](crate::BumpVec::into_iter),
+/// (provided by the [`IntoIterator`] trait).
+// This is modelled after rust's `alloc/src/vec/into_iter.rs`
+pub struct IntoIter<
+    'b,
+    'a: 'b,
+    T,
+    A,
+    const MIN_ALIGN: usize = 1,
+    const UP: bool = true,
+    const GUARANTEED_ALLOCATED: bool = true,
+> where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    pub(super) buf: NonNull<T>,
+    pub(super) cap: usize,
+
+    pub(super) ptr: NonNull<T>,
+
+    /// If T is a ZST this is ptr + len.
+    pub(super) end: NonNull<T>,
+
+    pub(super) bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
+
+    /// Marks ownership over T. (<https://doc.rust-lang.org/nomicon/phantom-data.html#generic-parameters-and-drop-checking>)
+    pub(super) marker: PhantomData<T>,
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Debug
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+    T: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("IntoIter").field(&self.as_slice()).finish()
+    }
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
+    IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    /// Returns the remaining items of this iterator as a slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, bump_vec };
+    /// # let bump: Bump = Bump::new();
+    /// let vec = bump_vec![in bump; 1, 2, 3];
+    /// let mut into_iter = vec.into_iter();
+    /// assert_eq!(into_iter.as_slice(), &[1, 2, 3]);
+    /// assert_eq!(into_iter.next(), Some(1));
+    /// assert_eq!(into_iter.as_slice(), &[2, 3]);
+    /// assert_eq!(into_iter.next_back(), Some(3));
+    /// assert_eq!(into_iter.as_slice(), &[2]);
+    /// ```
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len()) }
+    }
+
+    /// Returns the remaining items of this iterator as a mutable slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, bump_vec };
+    /// # let bump: Bump = Bump::new();
+    /// let vec = bump_vec![in bump; 'a', 'b', 'c'];
+    /// let mut into_iter = vec.into_iter();
+    /// assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
+    /// into_iter.as_mut_slice()[2] = 'z';
+    /// assert_eq!(into_iter.next().unwrap(), 'a');
+    /// assert_eq!(into_iter.next().unwrap(), 'b');
+    /// assert_eq!(into_iter.next().unwrap(), 'z');
+    /// ```
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe { &mut *self.as_raw_mut_slice() }
+    }
+
+    #[doc = include_str!("../docs/bump.md")]
+    #[must_use]
+    #[inline(always)]
+    pub fn bump(&self) -> &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
+        self.bump
+    }
+
+    fn as_raw_mut_slice(&mut self) -> *mut [T] {
+        ptr::slice_from_raw_parts_mut(self.ptr.as_ptr(), self.len())
+    }
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsRef<[T]>
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Iterator
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ptr == self.end {
+            None
+        } else if T::IS_ZST {
+            // `ptr` has to stay where it is to remain aligned, so we reduce the length by 1 by
+            // reducing the `end`.
+            self.end = unsafe { nonnull::wrapping_byte_sub(self.end, 1) };
+
+            // Make up a value of this ZST.
+            Some(unsafe { mem::zeroed() })
+        } else {
+            let old = self.ptr;
+            self.ptr = unsafe { nonnull::add(self.ptr, 1) };
+
+            Some(unsafe { old.as_ptr().read() })
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let exact = if T::IS_ZST {
+            nonnull::addr(self.end).get().wrapping_sub(nonnull::addr(self.ptr).get())
+        } else {
+            unsafe { nonnull::sub_ptr(self.end, self.ptr) }
+        };
+        (exact, Some(exact))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DoubleEndedIterator
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.end == self.ptr {
+            None
+        } else if T::IS_ZST {
+            // See above for why 'ptr.offset' isn't used
+            self.end = unsafe { nonnull::wrapping_byte_sub(self.end, 1) };
+
+            // Make up a value of this ZST.
+            Some(unsafe { mem::zeroed() })
+        } else {
+            self.end = unsafe { nonnull::sub(self.end, 1) };
+
+            Some(unsafe { self.end.as_ptr().read() })
+        }
+    }
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> ExactSizeIterator
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> FusedIterator
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+#[cfg(feature = "nightly-trusted-len")]
+unsafe impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> core::iter::TrustedLen
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+#[cfg(not(no_global_oom_handling))]
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Clone
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        let slice = self.as_slice();
+        let boxed = self.bump.alloc_slice_clone(slice);
+        let fixed = FixedBumpVec::from_init(boxed);
+        let vec = BumpVec::from_parts(fixed, self.bump);
+        vec.into_iter()
+    }
+}
+
+impl<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
+    for IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    fn drop(&mut self) {
+        struct DropGuard<'i, 'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+            &'i mut IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
+        )
+        where
+            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+            A: BaseAllocator<GUARANTEED_ALLOCATED>;
+
+        impl<'i, 'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
+            for DropGuard<'i, 'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+        where
+            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+            A: BaseAllocator<GUARANTEED_ALLOCATED>,
+        {
+            fn drop(&mut self) {
+                unsafe {
+                    // BumpVec handles deallocation
+                    let _ = BumpVec {
+                        fixed: FixedBumpVec {
+                            initialized: BumpBox::from_raw(nonnull::slice_from_raw_parts(self.0.buf, 0)),
+                            capacity: self.0.cap,
+                        },
+                        bump: self.0.bump,
+                    };
+                }
+            }
+        }
+
+        let guard = DropGuard(self);
+        // destroy the remaining elements
+        unsafe {
+            ptr::drop_in_place(guard.0.as_raw_mut_slice());
+        }
+        // now `guard` will be dropped and do the rest
+    }
+}

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -39,6 +39,8 @@ where
 impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
     for BumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -86,6 +88,9 @@ impl Serialize for FixedBumpString<'_> {
 
 impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
     for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -7,7 +7,10 @@ use core::{
     ptr, str,
 };
 
-use crate::{error_behavior_generic_methods_if, polyfill, BumpBox, ErrorBehavior, FixedBumpVec, FromUtf8Error, NoDrop};
+use crate::{
+    error_behavior_generic_methods_if, polyfill, BaseAllocator, BumpBox, BumpScope, BumpString, ErrorBehavior, FixedBumpVec,
+    FromUtf8Error, MinimumAlignment, NoDrop, SupportedMinimumAlignment,
+};
 
 /// A [`BumpString`](crate::BumpString) but with a fixed capacity.
 ///
@@ -473,6 +476,20 @@ impl<'a> FixedBumpString<'a> {
     #[inline(always)]
     pub fn into_str(self) -> &'a mut str {
         self.into_boxed_str().into_mut()
+    }
+
+    /// Turns this `FixedBumpString<T>` into a `BumpVec<T>`.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_string<'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        self,
+        bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
+    ) -> BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+    where
+        MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+        A: BaseAllocator<GUARANTEED_ALLOCATED>,
+    {
+        BumpString::from_parts(self, bump)
     }
 }
 

--- a/src/into_iter.rs
+++ b/src/into_iter.rs
@@ -15,7 +15,6 @@ use crate::{polyfill::nonnull, BumpBox, SizedTypeProperties};
 /// This `struct` is created by the `into_iter` method on
 /// [`BumpBox`](BumpBox::into_iter),
 /// [`FixedBumpVec`](crate::FixedBumpVec::into_iter),
-/// [`BumpVec`](crate::BumpVec::into_iter),
 /// [`MutBumpVec`](crate::MutBumpVec::into_iter) and
 /// [`MutBumpVecRev`](crate::MutBumpVecRev::into_iter)
 /// (provided by the [`IntoIterator`] trait).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ mod bump_scope_guard;
 mod mut_bump_string;
 
 /// Contains [`BumpVec`] and associated types.
-mod bump_vec;
+pub mod bump_vec;
 
 /// Contains [`MutBumpVec`] and associated types.
 mod mut_bump_vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,7 @@ pub use bump_pool::{BumpPool, BumpPoolGuard};
 pub use bump_scope::BumpScope;
 pub use bump_scope_guard::{BumpScopeGuard, BumpScopeGuardRoot, Checkpoint};
 pub use bump_string::BumpString;
+#[doc(inline)]
 pub use bump_vec::BumpVec;
 pub use drain::Drain;
 pub use extract_if::ExtractIf;

--- a/src/tests/bump_vec.rs
+++ b/src/tests/bump_vec.rs
@@ -1,0 +1,30 @@
+use allocator_api2::alloc::Global;
+
+use crate::{bump_vec, Bump};
+
+use super::either_way;
+
+fn shrinks<const UP: bool>() {
+    let bump: Bump<Global, 1, UP> = Bump::new();
+    let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+    assert_eq!(bump.stats().allocated(), 4 * 4);
+    vec.pop();
+    vec.shrink_to_fit();
+    assert_eq!(bump.stats().allocated(), 3 * 4);
+    vec.clear();
+    vec.shrink_to_fit();
+    assert_eq!(bump.stats().allocated(), 0);
+}
+
+fn deallocates<const UP: bool>() {
+    let bump: Bump<Global, 1, UP> = Bump::new();
+    let vec = bump_vec![in bump; 1, 2, 3];
+    assert_eq!(bump.stats().allocated(), 3 * 4);
+    drop(vec);
+    assert_eq!(bump.stats().allocated(), 0);
+}
+
+either_way! {
+    shrinks
+    deallocates
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,28 +11,27 @@ use core::{
 };
 use std::io::IoSlice;
 
-#[cfg(feature = "nightly-coerce-unsized")]
-mod coerce_unsized;
-
+mod alloc_fmt;
 mod alloc_iter;
 mod alloc_slice;
+mod alloc_try_with;
 mod allocator_api;
+mod bump_vec;
 mod bump_vec_doc;
+mod chunk_size;
+#[cfg(feature = "nightly-coerce-unsized")]
+mod coerce_unsized;
 mod from_std;
 mod mut_bump_vec_doc;
 mod mut_bump_vec_rev_doc;
 mod mut_collections_do_not_waste_space;
 mod panic_safety;
 mod pool;
-mod unaligned_collection;
-mod vec;
-
-mod alloc_fmt;
-mod alloc_try_with;
-mod chunk_size;
 #[cfg(feature = "serde")]
 mod serde;
+mod unaligned_collection;
 mod unallocated;
+mod vec;
 
 extern crate std;
 


### PR DESCRIPTION
Currently `BumpVec` does not attempt to deallocate on drop nor when calling `into_*slice`. This is unexpected. This is unlike `Vec` or `MutBumpVec` which deallocate on drop (`MutBumpVec` never actually bumps the pointer). 

I thinks its better if it does deallocate and shrink by default. You can still get a slice without any shrinking via `into_fixed_vec().into_boxed_slice()`.

## Todo
- [x] implement a deallocating `IntoIter`