### PR TITLE
Don't implement string types as vector wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **added:** missing string methods to `BumpBox<str>`: `len`, `is_empty`, `set_len`, `retain`, `clear`, `as_ptr`, `as_mut_ptr`, `remove`, `as_mut_bytes`
 - **added:** `Default` for `FixedBumpString`
 - **added:** string methods `pop`, `truncate`
+- **added:** made more `len` and `is_empty` methods `const`
 
 ## 0.10.1 (2024-10-14)
 - **added:** `MutBumpVecRev::{ append, into_flattened, unchecked_push(_with), as_non_null_{ptr, slice} }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Unreleased
-- **added:** missing string methods to `BumpBox<str>`: `len`, `is_empty`, `set_len`, `retain`, `clear`, `as_ptr`, `as_mut_ptr`, `remove`
+- **added:** missing string methods to `BumpBox<str>`: `len`, `is_empty`, `set_len`, `retain`, `clear`, `as_ptr`, `as_mut_ptr`, `remove`, `as_mut_bytes`
 - **added:** `Default` for `FixedBumpString`
+- **added:** string methods `pop`, `truncate`
 
 ## 0.10.1 (2024-10-14)
 - **added:** `MutBumpVecRev::{ append, into_flattened, unchecked_push(_with), as_non_null_{ptr, slice} }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- **added:** missing string methods to `BumpBox<str>`: `len`, `is_empty`, `set_len`, `retain`, `clear`, `as_ptr`, `as_mut_ptr`, `remove`
+- **added:** `Default` for `FixedBumpString`
+
 ## 0.10.1 (2024-10-14)
 - **added:** `MutBumpVecRev::{ append, into_flattened, unchecked_push(_with), as_non_null_{ptr, slice} }`
 - **fixed:** `MutBumpVecRev::extend_from_within_clone` doing nothing for ZSTs

--- a/src/bump_box.rs
+++ b/src/bump_box.rs
@@ -355,6 +355,33 @@ impl<'a> BumpBox<'a, str> {
         self.len() == 0
     }
 
+    /// Removes the last character from the string buffer and returns it.
+    ///
+    /// Returns [`None`] if this string is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::Bump;
+    /// # let bump: Bump = Bump::new();
+    /// let mut s = bump.alloc_str("abč");
+    ///
+    /// assert_eq!(s.pop(), Some('č'));
+    /// assert_eq!(s.pop(), Some('b'));
+    /// assert_eq!(s.pop(), Some('a'));
+    ///
+    /// assert_eq!(s.pop(), None);
+    /// ```
+    #[inline]
+    pub fn pop(&mut self) -> Option<char> {
+        let ch = self.chars().rev().next()?;
+        let new_len = self.len() - ch.len_utf8();
+        unsafe {
+            self.set_len(new_len);
+        }
+        Some(ch)
+    }
+
     /// Truncates this string, removing all contents.
     ///
     /// # Examples

--- a/src/bump_box.rs
+++ b/src/bump_box.rs
@@ -419,7 +419,7 @@ impl<'a> BumpBox<'a, str> {
     ///
     /// s.truncate(2);
     ///
-    /// assert_eq!("he", s);
+    /// assert_eq!(s, "he");
     /// ```
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -434,7 +434,7 @@ where
     ///
     /// s.truncate(2);
     ///
-    /// assert_eq!("he", s);
+    /// assert_eq!(s, "he");
     /// ```
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -221,6 +221,28 @@ where
         self.fixed.is_empty()
     }
 
+    /// Removes the last character from the string buffer and returns it.
+    ///
+    /// Returns [`None`] if this string is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, BumpString };
+    /// # let bump: Bump = Bump::new();
+    /// let mut s = BumpString::from_str_in("abč", &bump);
+    ///
+    /// assert_eq!(s.pop(), Some('č'));
+    /// assert_eq!(s.pop(), Some('b'));
+    /// assert_eq!(s.pop(), Some('a'));
+    ///
+    /// assert_eq!(s.pop(), None);
+    /// ```
+    #[inline]
+    pub fn pop(&mut self) -> Option<char> {
+        self.fixed.pop()
+    }
+
     /// Truncates this `BumpString`, removing all contents.
     ///
     /// While this means the `BumpString` will have a length of zero, it does not

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -218,7 +218,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.fixed.is_empty()
     }
 
     /// Truncates this `BumpString`, removing all contents.

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -210,14 +210,14 @@ where
     /// length of the string.
     #[must_use]
     #[inline(always)]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.fixed.len()
     }
 
     /// Returns `true` if this `BumpString` has a length of zero, and `false` otherwise.
     #[must_use]
     #[inline(always)]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.fixed.is_empty()
     }
 
@@ -703,7 +703,7 @@ where
     }
 
     unsafe fn insert_bytes<B: ErrorBehavior>(&mut self, idx: usize, bytes: &[u8]) -> Result<(), B> {
-        let vec = unsafe { self.as_mut_vec() };
+        let vec = self.as_mut_vec();
 
         let len = vec.len();
         let amt = bytes.len();

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -243,6 +243,34 @@ where
         self.fixed.pop()
     }
 
+    /// Shortens this string to the specified length.
+    ///
+    /// If `new_len` is greater than or equal to the string's current length, this has no
+    /// effect.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the string
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len` does not lie on a [`char`] boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, BumpString };
+    /// # let bump: Bump = Bump::new();
+    /// let mut s = BumpString::from_str_in("hello", &bump);
+    ///
+    /// s.truncate(2);
+    ///
+    /// assert_eq!("he", s);
+    /// ```
+    #[inline]
+    pub fn truncate(&mut self, new_len: usize) {
+        self.fixed.truncate(new_len);
+    }
+
     /// Truncates this `BumpString`, removing all contents.
     ///
     /// While this means the `BumpString` will have a length of zero, it does not

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -3,8 +3,10 @@ use allocator_api2::alloc::Allocator;
 #[cfg(not(no_global_oom_handling))]
 use crate::Infallibly;
 use crate::{
-    error_behavior_generic_methods_allocation_failure, polyfill, BaseAllocator, BumpBox, BumpScope, BumpVec, ErrorBehavior,
-    FixedBumpString, FromUtf8Error, GuaranteedAllocatedStats, MinimumAlignment, Stats, SupportedMinimumAlignment,
+    error_behavior_generic_methods_allocation_failure,
+    polyfill::{self, transmute_mut},
+    BaseAllocator, BumpBox, BumpScope, BumpVec, ErrorBehavior, FixedBumpString, FromUtf8Error, GuaranteedAllocatedStats,
+    MinimumAlignment, Stats, SupportedMinimumAlignment,
 };
 use core::{
     alloc::Layout,
@@ -399,7 +401,7 @@ where
     pub unsafe fn as_mut_vec(&mut self) -> &mut BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
         // SAFETY: `BumpVec<u8>` and `BumpString` have the same representation;
         // only the invariant that the bytes are utf8 is different.
-        mem::transmute(self)
+        transmute_mut(self)
     }
 
     /// Removes a [`char`] from this string at a byte position and returns it.
@@ -682,7 +684,6 @@ where
     /// ```
     pub fn shrink_to_fit(&mut self) {
         let vec = unsafe { self.as_mut_vec() };
-
         vec.shrink_to_fit();
     }
 

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -147,6 +147,8 @@ macro_rules! bump_vec_declaration {
         ///
         /// assert_eq!(slice, [1, 2, 3]);
         /// ```
+        // `BumpString` and `BumpVec<u8>` have the same repr.
+        #[repr(C)]
         pub struct BumpVec<
             'b,
             'a: 'b,

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -401,7 +401,7 @@ where
     #[must_use]
     #[inline(always)]
     pub const fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.fixed.is_empty()
     }
 
     #[doc = include_str!("docs/vec/pop.md")]

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -117,6 +117,35 @@ impl<'a> FixedBumpString<'a> {
         self.initialized.pop()
     }
 
+    /// Shortens this string to the specified length.
+    ///
+    /// If `new_len` is greater than or equal to the string's current length, this has no
+    /// effect.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the string
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len` does not lie on a [`char`] boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::Bump;
+    /// # let bump: Bump = Bump::new();
+    /// let mut s = bump.alloc_fixed_string(5);
+    /// s.push_str("hello");
+    ///
+    /// s.truncate(2);
+    ///
+    /// assert_eq!("he", s);
+    /// ```
+    #[inline]
+    pub fn truncate(&mut self, new_len: usize) {
+        self.initialized.truncate(new_len);
+    }
+
     /// Truncates this `FixedBumpString`, removing all contents.
     ///
     /// While this means the `FixedBumpString` will have a length of zero, it does not

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -1,6 +1,6 @@
 use crate::{
     error_behavior_generic_methods_if,
-    polyfill::{self, nonnull},
+    polyfill::{self, nonnull, transmute_mut},
     BaseAllocator, BumpBox, BumpScope, BumpString, ErrorBehavior, FixedBumpVec, FromUtf8Error, MinimumAlignment, NoDrop,
     SupportedMinimumAlignment,
 };
@@ -275,7 +275,7 @@ impl<'a> FixedBumpString<'a> {
     pub unsafe fn as_mut_vec(&mut self) -> &mut FixedBumpVec<'a, u8> {
         // SAFETY: `BumpVec<u8>` and `BumpString` have the same representation;
         // only the invariant that the bytes are utf8 is different.
-        mem::transmute(self)
+        transmute_mut(self)
     }
 
     /// Removes a [`char`] from this string at a byte position and returns it.

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -577,6 +577,12 @@ impl Display for FixedBumpString<'_> {
     }
 }
 
+impl Default for FixedBumpString<'_> {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
 impl Deref for FixedBumpString<'_> {
     type Target = str;
 

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -94,6 +94,29 @@ impl<'a> FixedBumpString<'a> {
         self.initialized.is_empty()
     }
 
+    /// Removes the last character from the string buffer and returns it.
+    ///
+    /// Returns [`None`] if this string is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::Bump;
+    /// # let bump: Bump = Bump::new();
+    /// let mut s = bump.alloc_fixed_string(4);
+    /// s.push_str("abč");
+    ///
+    /// assert_eq!(s.pop(), Some('č'));
+    /// assert_eq!(s.pop(), Some('b'));
+    /// assert_eq!(s.pop(), Some('a'));
+    ///
+    /// assert_eq!(s.pop(), None);
+    /// ```
+    #[inline]
+    pub fn pop(&mut self) -> Option<char> {
+        self.initialized.pop()
+    }
+
     /// Truncates this `FixedBumpString`, removing all contents.
     ///
     /// While this means the `FixedBumpString` will have a length of zero, it does not

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -83,14 +83,14 @@ impl<'a> FixedBumpString<'a> {
     /// length of the string.
     #[must_use]
     #[inline(always)]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.initialized.len()
     }
 
     /// Returns `true` if this `FixedBumpString` has a length of zero, and `false` otherwise.
     #[must_use]
     #[inline(always)]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.initialized.is_empty()
     }
 
@@ -567,7 +567,7 @@ impl<'a> FixedBumpString<'a> {
     }
 
     unsafe fn insert_bytes<B: ErrorBehavior>(&mut self, idx: usize, bytes: &[u8]) -> Result<(), B> {
-        let vec = unsafe { self.as_mut_vec() };
+        let vec = self.as_mut_vec();
 
         let len = vec.len();
         let amt = bytes.len();

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -314,7 +314,7 @@ impl<'a> FixedBumpString<'a> {
     ///
     /// s.truncate(2);
     ///
-    /// assert_eq!("he", s);
+    /// assert_eq!(s, "he");
     /// ```
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -111,27 +111,6 @@ impl<'a, T> FixedBumpVec<'a, T> {
         self.len() >= self.capacity
     }
 
-    /// Turns this `FixedBumpVec<T>` into a `BumpVec<T>`.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_vec<'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
-        self,
-        bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-    ) -> BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-    where
-        MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-        A: BaseAllocator<GUARANTEED_ALLOCATED>,
-    {
-        BumpVec::from_parts(self, bump)
-    }
-
-    /// Turns this `FixedBumpVec<T>` into a `BumpBox<[T]>`.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_boxed_slice(self) -> BumpBox<'a, [T]> {
-        self.initialized
-    }
-
     /// Turns this `FixedBumpVec<T>` into a `&[T]` that is live for this bump scope.
     ///
     /// This is only available for [`NoDrop`] types so you don't omit dropping a value for which it matters.
@@ -144,6 +123,27 @@ impl<'a, T> FixedBumpVec<'a, T> {
         [T]: NoDrop,
     {
         self.into_boxed_slice().into_mut()
+    }
+
+    /// Turns this `FixedBumpVec<T>` into a `BumpBox<[T]>`.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_boxed_slice(self) -> BumpBox<'a, [T]> {
+        self.initialized
+    }
+
+    /// Turns this `FixedBumpVec<T>` into a `BumpVec<T>`.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_vec<'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        self,
+        bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
+    ) -> BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+    where
+        MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+        A: BaseAllocator<GUARANTEED_ALLOCATED>,
+    {
+        BumpVec::from_parts(self, bump)
     }
 
     #[doc = include_str!("docs/vec/pop.md")]

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -101,7 +101,7 @@ impl<'a, T> FixedBumpVec<'a, T> {
     #[must_use]
     #[inline(always)]
     pub const fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.initialized.is_empty()
     }
 
     /// Returns `true` if the vector has reached its capacity.

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -38,6 +38,8 @@ use core::{
 /// [`alloc_fixed_vec`]: crate::Bump::alloc_fixed_vec
 /// [`from_uninit`]: FixedBumpVec::from_uninit
 /// [`from_init`]: FixedBumpVec::from_init
+// `FixedBumpString` and `FixedBumpVec<u8>` have the same repr.
+#[repr(C)]
 pub struct FixedBumpVec<'a, T> {
     pub(crate) initialized: BumpBox<'a, [T]>,
     pub(crate) capacity: usize,
@@ -1268,12 +1270,12 @@ impl<'a, T> FixedBumpVec<'a, T> {
     }
 
     #[inline(always)]
-    fn into_raw_parts(self) -> (BumpBox<'a, [T]>, usize) {
+    pub(crate) fn into_raw_parts(self) -> (BumpBox<'a, [T]>, usize) {
         (self.initialized, self.capacity)
     }
 
     #[inline(always)]
-    unsafe fn from_raw_parts(initialized: BumpBox<'a, [T]>, capacity: usize) -> Self {
+    pub(crate) unsafe fn from_raw_parts(initialized: BumpBox<'a, [T]>, capacity: usize) -> Self {
         Self { initialized, capacity }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
     clippy::partialeq_ne_impl,
     clippy::collapsible_else_if,
     clippy::items_after_statements,
+    clippy::missing_transmute_annotations,
     unknown_lints,
     rustdoc::redundant_explicit_links, // for cargo-rdme
     stable_features, // for const_refs_to_static

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -242,6 +242,34 @@ impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCA
         self.fixed.pop()
     }
 
+    /// Shortens this string to the specified length.
+    ///
+    /// If `new_len` is greater than or equal to the string's current length, this has no
+    /// effect.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the string
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len` does not lie on a [`char`] boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, MutBumpString };
+    /// # let mut bump: Bump = Bump::new();
+    /// let mut s = MutBumpString::from_str_in("hello", &mut bump);
+    ///
+    /// s.truncate(2);
+    ///
+    /// assert_eq!("he", s);
+    /// ```
+    #[inline]
+    pub fn truncate(&mut self, new_len: usize) {
+        self.fixed.truncate(new_len);
+    }
+
     /// Truncates this `MutBumpString`, removing all contents.
     ///
     /// While this means the `MutBumpString` will have a length of zero, it does not

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -217,7 +217,7 @@ impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCA
     #[must_use]
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.fixed.is_empty()
     }
 
     /// Truncates this `MutBumpString`, removing all contents.

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -209,14 +209,14 @@ impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCA
     /// length of the string.
     #[must_use]
     #[inline(always)]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.fixed.len()
     }
 
     /// Returns `true` if this `MutBumpString` has a length of zero, and `false` otherwise.
     #[must_use]
     #[inline(always)]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.fixed.is_empty()
     }
 
@@ -702,7 +702,7 @@ where
     }
 
     unsafe fn insert_bytes<B: ErrorBehavior>(&mut self, idx: usize, bytes: &[u8]) -> Result<(), B> {
-        let vec = unsafe { self.as_mut_vec() };
+        let vec = self.as_mut_vec();
 
         let len = vec.len();
         let amt = bytes.len();

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -220,6 +220,28 @@ impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCA
         self.fixed.is_empty()
     }
 
+    /// Removes the last character from the string buffer and returns it.
+    ///
+    /// Returns [`None`] if this string is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, MutBumpString };
+    /// # let mut bump: Bump = Bump::new();
+    /// let mut s = MutBumpString::from_str_in("abč", &mut bump);
+    ///
+    /// assert_eq!(s.pop(), Some('č'));
+    /// assert_eq!(s.pop(), Some('b'));
+    /// assert_eq!(s.pop(), Some('a'));
+    ///
+    /// assert_eq!(s.pop(), None);
+    /// ```
+    #[inline]
+    pub fn pop(&mut self) -> Option<char> {
+        self.fixed.pop()
+    }
+
     /// Truncates this `MutBumpString`, removing all contents.
     ///
     /// While this means the `MutBumpString` will have a length of zero, it does not

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -409,7 +409,7 @@ impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCA
     ///
     /// s.truncate(2);
     ///
-    /// assert_eq!("he", s);
+    /// assert_eq!(s, "he");
     /// ```
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -327,7 +327,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     #[must_use]
     #[inline(always)]
     pub const fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.fixed.is_empty()
     }
 
     #[doc = include_str!("docs/vec/pop.md")]

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -124,6 +124,7 @@ macro_rules! mut_bump_vec_declaration {
         // If we want to reset the bump pointer to a previous chunk, we use a bump scope.
         // We could do it here, by resetting to the last non-empty chunk but that would require a loop.
         // Chunk allocations are supposed to be very rare, so this wouldn't be worth it.
+        #[repr(C)]
         pub struct MutBumpVec<
             'b,
             'a: 'b,

--- a/src/polyfill/mod.rs
+++ b/src/polyfill/mod.rs
@@ -66,3 +66,7 @@ macro_rules! cfg_const {
 }
 
 pub(crate) use cfg_const;
+
+pub(crate) unsafe fn transmute_mut<A, B>(a: &mut A) -> &mut B {
+    &mut *(a as *mut A).cast::<B>()
+}

--- a/src/tests/alloc_fmt.rs
+++ b/src/tests/alloc_fmt.rs
@@ -26,13 +26,16 @@ fn nothing<const UP: bool>() {
 
 fn nothing_extra<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
-    bump.alloc_fmt(format_args!("ext{Nothing}ra"));
+    let string = bump.alloc_fmt(format_args!("ext{Nothing}ra"));
+    assert_eq!(string, "extra");
     assert_eq!(bump.stats().allocated(), 5);
 }
 
 fn nothing_extra_mut<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    bump.alloc_fmt_mut(format_args!("ext{Nothing}ra"));
+    let string = bump.alloc_fmt_mut(format_args!("ext{Nothing}ra"));
+    assert_eq!(string, "extra");
+    drop(string);
     assert_eq!(bump.stats().allocated(), 5);
 }
 


### PR DESCRIPTION
Currently strings are implemented as wrappers around their respective vector type.

If we instead implement string types as their own hierarchy, mirroring the vector types then we can reuse functions from `BumpString` to `FixedBumpString` up to `BumpBox<str>`.

We still want to have `as_mut_vec` for strings. We do that by making all vectors and strings `#[repr(C)]` so we can soundly transmute between them.

This PR also adds missing string methods.