### PR TITLE
feat!: implement collections using a `BumpAllocator` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- **fixed:** `BumpVec::split_off` now retains the capacity of `self` like the docs say
+- **improved:** removed implicit `shrink_to_fit` from `(Fixed)BumpVec::from_iter` and inside `Splice` (TODO: confirm in tests)
+- **improved:** no more temporary allocation taking up permanent space in `Splice`'s drop (TODO: confirm in tests)
+
 ## 0.10.11 (2024-11-11)
 - **added:** `map_in_place` to `(Mut)BumpVec`
 - **added:** allow `map_in_place` to ZSTs regardless of alignment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **fixed:** `BumpVec::split_off` now retains the capacity of `self` like the docs say
 - **improved:** removed implicit `shrink_to_fit` from `(Fixed)BumpVec::from_iter` and inside `Splice` (TODO: confirm in tests)
 - **improved:** no more temporary allocation taking up permanent space in `Splice`'s drop (TODO: confirm in tests)
+- **breaking:** `bump` methods on vectors and strings has been renamed to `allocator`, the old `allocator` method which returned the base allocator is gone
 
 ## 0.10.11 (2024-11-11)
 - **added:** `map_in_place` to `(Mut)BumpVec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 - **fixed:** `BumpVec::split_off` now retains the capacity of `self` like the docs say
-- **improved:** removed implicit `shrink_to_fit` from `(Fixed)BumpVec::from_iter` and inside `Splice` (TODO: confirm in tests)
-- **improved:** no more temporary allocation taking up permanent space in `Splice`'s drop (TODO: confirm in tests)
 - **breaking:** vectors and strings now take a single `A` generic parameter instead of the `'b, 'a, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool` of before
 - **breaking:** `bump` methods on vectors and strings has been renamed to `allocator`, the old `allocator` method which returned the base allocator is gone
 - **breaking:** `vec`-like macros now take the bump allocator as is instead of by `$bump.as_scope()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **breaking:** vectors and strings now take a single `A` generic parameter instead of the `'b, 'a, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool` of before
 - **breaking:** `bump` methods on vectors and strings has been renamed to `allocator`, the old `allocator` method which returned the base allocator is gone
 - **breaking:** `vec`-like macros now take the bump allocator as is instead of by `$bump.as_scope()`
+- **breaking:** `WithLifetime` has been removed
 
 ## 0.10.11 (2024-11-11)
 - **added:** `map_in_place` to `(Mut)BumpVec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 - **fixed:** `BumpVec::split_off` now retains the capacity of `self` like the docs say
 - **improved:** removed implicit `shrink_to_fit` from `(Fixed)BumpVec::from_iter` and inside `Splice` (TODO: confirm in tests)
 - **improved:** no more temporary allocation taking up permanent space in `Splice`'s drop (TODO: confirm in tests)
+- **breaking:** vectors and strings now take a single `A` generic parameter instead of the `'b, 'a, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool` of before
 - **breaking:** `bump` methods on vectors and strings has been renamed to `allocator`, the old `allocator` method which returned the base allocator is gone
+- **breaking:** `vec`-like macros now take the bump allocator as is instead of by `$bump.as_scope()`
 
 ## 0.10.11 (2024-11-11)
 - **added:** `map_in_place` to `(Mut)BumpVec`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bump-scope"
-version = "0.10.11"
+version = "0.11.0-dev"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bump-scope"
-version = "0.10.11"
+version = "0.11.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A fast bump allocator that supports allocation scopes / checkpoints. Aka an arena for values of arbitrary types."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.release]
 allow-branch = ["main"]
-pre-release-hook = ["just", "all"]
+pre-release-hook = ["just", "pre-release"]
 pre-release-commit-message = "release: version {{version}}"
 pre-release-replacements = [
     { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}} ({{date}})" },

--- a/crates/fuzzing-support/Cargo.lock
+++ b/crates/fuzzing-support/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "bump-scope"
-version = "0.10.11"
+version = "0.11.0-dev"
 dependencies = [
  "allocator-api2",
  "sptr",

--- a/crates/fuzzing-support/src/many_vecs.rs
+++ b/crates/fuzzing-support/src/many_vecs.rs
@@ -1,5 +1,5 @@
 use arbitrary::Arbitrary;
-use bump_scope::{allocator_api2::alloc::Global, Bump, BumpVec, MinimumAlignment, SupportedMinimumAlignment};
+use bump_scope::{allocator_api2::alloc::Global, Bump, BumpAllocator, BumpVec, MinimumAlignment, SupportedMinimumAlignment};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::MinAlign;
@@ -111,7 +111,7 @@ impl<'a> VecObj<'a> {
         T: Default + FromBytes + IntoBytes + Immutable + 'static,
     {
         Self {
-            vec: Box::new(BumpVec::<T, Global, MIN_ALIGN, UP>::new_in(bump)),
+            vec: Box::new(BumpVec::<T, _>::new_in(bump)),
             bit_pattern,
         }
     }
@@ -127,9 +127,9 @@ impl<'a> VecObj<'a> {
     }
 }
 
-impl<T, const MIN_ALIGN: usize, const UP: bool> VecTrait for BumpVec<'_, '_, T, Global, MIN_ALIGN, UP>
+impl<T, A> VecTrait for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BumpAllocator,
     T: Default + FromBytes + IntoBytes + Immutable,
 {
     fn push(&mut self, bit_pattern: u8) {

--- a/crates/inspect-asm/Cargo.lock
+++ b/crates/inspect-asm/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "bump-scope"
-version = "0.10.11"
+version = "0.11.0-dev"
 dependencies = [
  "allocator-api2",
  "sptr",

--- a/crates/inspect-asm/justfile
+++ b/crates/inspect-asm/justfile
@@ -8,7 +8,7 @@ default:
 asm *args:
   ^cargo asm --color --simplify --target-cpu x86-64 {{args}} | lines | filter { ($in | str length) > 0 } | str join "\n"
 
-@inspect *args:
+@inspect-asm *args:
   nu inspect-asm.nu x86-64 {{args}} --target-cpu x86-64
 
 @inspect-wasm:

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/down.asm
@@ -1,75 +1,77 @@
 inspect_asm::alloc_fmt::down:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	jne .LBB0_4
-	mov rsi, qword ptr [rsp]
+	jne .LBB0_3
+	mov r14, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 8]
-	mov r15, qword ptr [rsp + 24]
-	mov rax, qword ptr [r15]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_0
-	mov r14, rsi
-	jmp .LBB0_3
-.LBB0_0:
+	mov r12, qword ptr [rsp + 24]
+	mov rax, qword ptr [r12]
+	cmp qword ptr [rax], r14
+	jne .LBB0_2
 	mov rax, qword ptr [rsp + 16]
-	add rax, rsi
-	xor r14d, r14d
+	add rax, r14
+	xor r15d, r15d
 	sub rax, rbx
-	cmovae r14, rax
-	lea rax, [rbx + rsi]
-	mov rdi, r14
+	cmovae r15, rax
+	lea rax, [rbx + r14]
+	mov rdi, r15
+	mov rsi, r14
 	mov rdx, rbx
-	cmp rax, r14
-	jbe .LBB0_1
+	cmp rax, r15
+	jbe .LBB0_0
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_2
-.LBB0_1:
+	jmp .LBB0_1
+.LBB0_0:
 	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_1:
+	mov rax, qword ptr [r12]
+	mov qword ptr [rax], r15
+	test r15, r15
+	cmovne r14, r15
 .LBB0_2:
-	mov rax, qword ptr [r15]
-	mov qword ptr [rax], r14
-.LBB0_3:
 	mov rax, r14
 	mov rdx, rbx
-	add rsp, 112
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
-.LBB0_4:
+.LBB0_3:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
 	ud2
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 24]
 	mov rdx, qword ptr [rdx]
 	cmp qword ptr [rdx], rcx
-	jne .LBB0_5
+	jne .LBB0_4
 	add rcx, qword ptr [rsp + 16]
 	mov qword ptr [rdx], rcx
-.LBB0_5:
+.LBB0_4:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/down_a.asm
@@ -1,79 +1,81 @@
 inspect_asm::alloc_fmt::down_a:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
-	jne .LBB0_4
-	mov rsi, qword ptr [rsp]
+	jne .LBB0_3
+	mov r14, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 8]
-	mov r15, qword ptr [rsp + 24]
-	mov rax, qword ptr [r15]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_0
-	mov r14, rsi
-	jmp .LBB0_3
-.LBB0_0:
+	mov r12, qword ptr [rsp + 24]
+	mov rax, qword ptr [r12]
+	cmp qword ptr [rax], r14
+	jne .LBB0_2
 	mov rax, qword ptr [rsp + 16]
-	add rax, rsi
-	xor r14d, r14d
+	add rax, r14
+	xor r15d, r15d
 	sub rax, rbx
-	cmovae r14, rax
-	and r14, -4
-	lea rax, [rbx + rsi]
-	mov rdi, r14
+	cmovae r15, rax
+	and r15, -4
+	lea rax, [rbx + r14]
+	mov rdi, r15
+	mov rsi, r14
 	mov rdx, rbx
-	cmp rax, r14
-	jbe .LBB0_1
+	cmp rax, r15
+	jbe .LBB0_0
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_2
-.LBB0_1:
+	jmp .LBB0_1
+.LBB0_0:
 	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_1:
+	mov rax, qword ptr [r12]
+	mov qword ptr [rax], r15
+	test r15, r15
+	cmovne r14, r15
 .LBB0_2:
-	mov rax, qword ptr [r15]
-	mov qword ptr [rax], r14
-.LBB0_3:
 	mov rax, r14
 	mov rdx, rbx
-	add rsp, 112
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
-.LBB0_4:
+.LBB0_3:
 	call qword ptr [rip + bump_scope::private::format_trait_error@GOTPCREL]
 	ud2
 	mov rdx, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 24]
 	mov rcx, qword ptr [rcx]
 	cmp qword ptr [rcx], rdx
-	jne .LBB0_5
+	jne .LBB0_4
 	mov rsi, qword ptr [rsp + 16]
 	add rdx, rsi
 	add rdx, 3
 	and rdx, -4
 	mov qword ptr [rcx], rdx
-.LBB0_5:
+.LBB0_4:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_down.asm
@@ -1,28 +1,29 @@
 inspect_asm::alloc_fmt::try_down:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
 	je .LBB0_1
@@ -35,39 +36,41 @@ inspect_asm::alloc_fmt::try_down:
 	mov qword ptr [rcx], rax
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_5
-.LBB0_1:
-	mov rsi, qword ptr [rsp]
-	mov rbx, qword ptr [rsp + 8]
-	mov r14, qword ptr [rsp + 24]
-	mov rax, qword ptr [r14]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_2
-	mov rax, rsi
-	jmp .LBB0_5
-.LBB0_2:
-	mov rax, qword ptr [rsp + 16]
-	add rax, rsi
-	xor edi, edi
-	sub rax, rbx
-	cmovae rdi, rax
-	lea rax, [rbx + rsi]
-	mov r15, rdi
-	mov rdx, rbx
-	cmp rax, rdi
-	jbe .LBB0_3
-	call qword ptr [rip + memmove@GOTPCREL]
 	jmp .LBB0_4
-.LBB0_3:
-	call qword ptr [rip + memcpy@GOTPCREL]
-.LBB0_4:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-.LBB0_5:
+.LBB0_1:
+	mov rax, qword ptr [rsp]
+	mov rbx, qword ptr [rsp + 8]
+	mov r15, qword ptr [rsp + 24]
+	mov rcx, qword ptr [r15]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_4
+	mov rcx, qword ptr [rsp + 16]
+	add rcx, rax
+	xor r14d, r14d
+	sub rcx, rbx
+	cmovae r14, rcx
+	lea rcx, [rbx + rax]
+	mov rdi, r14
+	mov r12, rax
+	mov rsi, rax
 	mov rdx, rbx
-	add rsp, 112
+	cmp rcx, r14
+	jbe .LBB0_2
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_3
+.LBB0_2:
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_3:
+	mov rax, qword ptr [r15]
+	mov qword ptr [rax], r14
+	test r14, r14
+	mov rax, r12
+	cmovne rax, r14
+.LBB0_4:
+	mov rdx, rbx
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
@@ -75,9 +78,9 @@ inspect_asm::alloc_fmt::try_down:
 	mov rdx, qword ptr [rsp + 24]
 	mov rdx, qword ptr [rdx]
 	cmp qword ptr [rdx], rcx
-	jne .LBB0_6
+	jne .LBB0_5
 	add rcx, qword ptr [rsp + 16]
 	mov qword ptr [rdx], rcx
-.LBB0_6:
+.LBB0_5:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_down_a.asm
@@ -1,28 +1,29 @@
 inspect_asm::alloc_fmt::try_down_a:
 	push r15
 	push r14
+	push r12
 	push rbx
-	sub rsp, 112
-	mov qword ptr [rsp + 32], rsi
-	mov qword ptr [rsp + 40], rdx
-	lea rax, [rsp + 32]
-	mov qword ptr [rsp + 48], rax
-	lea rax, [rip + <&T as core::fmt::Display>::fmt]
+	sub rsp, 120
+	mov qword ptr [rsp + 40], rsi
+	mov qword ptr [rsp + 48], rdx
+	lea rax, [rsp + 40]
 	mov qword ptr [rsp + 56], rax
-	lea rax, [rip + .L__unnamed_0]
+	lea rax, [rip + <&T as core::fmt::Display>::fmt]
 	mov qword ptr [rsp + 64], rax
-	mov qword ptr [rsp + 72], 2
-	mov qword ptr [rsp + 96], 0
-	lea rax, [rsp + 48]
-	mov qword ptr [rsp + 80], rax
-	mov qword ptr [rsp + 88], 1
+	lea rax, [rip + .L__unnamed_0]
+	mov qword ptr [rsp + 72], rax
+	mov qword ptr [rsp + 80], 2
+	mov qword ptr [rsp + 104], 0
+	lea rax, [rsp + 56]
+	mov qword ptr [rsp + 88], rax
+	mov qword ptr [rsp + 96], 1
 	movups xmm0, xmmword ptr [rip + .L__unnamed_1]
 	movaps xmmword ptr [rsp], xmm0
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdi
 	lea rsi, [rip + .L__unnamed_2]
 	mov rdi, rsp
-	lea rdx, [rsp + 64]
+	lea rdx, [rsp + 72]
 	call qword ptr [rip + core::fmt::write@GOTPCREL]
 	test al, al
 	je .LBB0_1
@@ -38,40 +39,42 @@ inspect_asm::alloc_fmt::try_down_a:
 	mov qword ptr [rax], rcx
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_5
-.LBB0_1:
-	mov rsi, qword ptr [rsp]
-	mov rbx, qword ptr [rsp + 8]
-	mov r14, qword ptr [rsp + 24]
-	mov rax, qword ptr [r14]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_2
-	mov rax, rsi
-	jmp .LBB0_5
-.LBB0_2:
-	mov rax, qword ptr [rsp + 16]
-	add rax, rsi
-	xor edi, edi
-	sub rax, rbx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rbx + rsi]
-	mov r15, rdi
-	mov rdx, rbx
-	cmp rax, rdi
-	jbe .LBB0_3
-	call qword ptr [rip + memmove@GOTPCREL]
 	jmp .LBB0_4
-.LBB0_3:
-	call qword ptr [rip + memcpy@GOTPCREL]
-.LBB0_4:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-.LBB0_5:
+.LBB0_1:
+	mov rax, qword ptr [rsp]
+	mov rbx, qword ptr [rsp + 8]
+	mov r15, qword ptr [rsp + 24]
+	mov rcx, qword ptr [r15]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_4
+	mov rcx, qword ptr [rsp + 16]
+	add rcx, rax
+	xor r14d, r14d
+	sub rcx, rbx
+	cmovae r14, rcx
+	and r14, -4
+	lea rcx, [rbx + rax]
+	mov rdi, r14
+	mov r12, rax
+	mov rsi, rax
 	mov rdx, rbx
-	add rsp, 112
+	cmp rcx, r14
+	jbe .LBB0_2
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_3
+.LBB0_2:
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_3:
+	mov rax, qword ptr [r15]
+	mov qword ptr [rax], r14
+	test r14, r14
+	mov rax, r12
+	cmovne rax, r14
+.LBB0_4:
+	mov rdx, rbx
+	add rsp, 120
 	pop rbx
+	pop r12
 	pop r14
 	pop r15
 	ret
@@ -79,12 +82,12 @@ inspect_asm::alloc_fmt::try_down_a:
 	mov rcx, qword ptr [rsp + 24]
 	mov rcx, qword ptr [rcx]
 	cmp qword ptr [rcx], rdx
-	jne .LBB0_6
+	jne .LBB0_5
 	mov rsi, qword ptr [rsp + 16]
 	add rdx, rsi
 	add rdx, 3
 	and rdx, -4
 	mov qword ptr [rcx], rdx
-.LBB0_6:
+.LBB0_5:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up.asm
@@ -39,9 +39,9 @@ inspect_asm::alloc_fmt::try_up:
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
 	mov rsi, qword ptr [rsp + 16]
 	add rsi, rax
-	mov rcx, qword ptr [rcx]
 	cmp rsi, qword ptr [rcx]
 	je .LBB0_2
 	add rsp, 120

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up.asm
@@ -39,9 +39,9 @@ inspect_asm::alloc_fmt::try_up:
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 24]
-	mov rcx, qword ptr [rcx]
 	mov rsi, qword ptr [rsp + 16]
 	add rsi, rax
+	mov rcx, qword ptr [rcx]
 	cmp rsi, qword ptr [rcx]
 	je .LBB0_2
 	add rsp, 120

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
@@ -39,9 +39,9 @@ inspect_asm::alloc_fmt::try_up_a:
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 24]
+	mov rcx, qword ptr [rcx]
 	mov rsi, qword ptr [rsp + 16]
 	add rsi, rax
-	mov rcx, qword ptr [rcx]
 	cmp rsi, qword ptr [rcx]
 	je .LBB0_2
 	add rsp, 120

--- a/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_fmt/try_up_a.asm
@@ -39,9 +39,9 @@ inspect_asm::alloc_fmt::try_up_a:
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 24]
-	mov rcx, qword ptr [rcx]
 	mov rsi, qword ptr [rsp + 16]
 	add rsi, rax
+	mov rcx, qword ptr [rcx]
 	cmp rsi, qword ptr [rcx]
 	je .LBB0_2
 	add rsp, 120

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
@@ -43,7 +43,7 @@ inspect_asm::alloc_iter_u32::down:
 	cmp qword ptr [rsp + 16], rdx
 	jne .LBB0_1
 	mov rdi, rbx
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down.asm
@@ -7,10 +7,10 @@ inspect_asm::alloc_iter_u32::down:
 	sub rsp, 32
 	mov rbx, rdi
 	test rdx, rdx
-	je .LBB0_5
+	je .LBB0_4
 	mov rax, rdx
 	shr rax, 61
-	jne .LBB0_11
+	jne .LBB0_10
 	mov r14, rsi
 	lea r15, [4*rdx]
 	mov rcx, qword ptr [rbx]
@@ -18,7 +18,7 @@ inspect_asm::alloc_iter_u32::down:
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r15, rsi
-	ja .LBB0_10
+	ja .LBB0_9
 	sub rax, r15
 	and rax, -4
 	mov qword ptr [rcx], rax
@@ -48,44 +48,46 @@ inspect_asm::alloc_iter_u32::down:
 	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_1
 .LBB0_3:
-	mov rsi, qword ptr [rsp]
+	mov rax, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 24]
-	mov rax, qword ptr [rbx]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_6
-.LBB0_4:
-	mov rax, rsi
-	jmp .LBB0_9
-.LBB0_5:
-	mov qword ptr [rsp + 16], rdx
-	mov esi, 4
-	xor edx, edx
-	mov rax, qword ptr [rbx]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_4
-.LBB0_6:
-	mov r14, rdx
-	lea rdx, [4*rdx]
-	mov rax, qword ptr [rsp + 16]
-	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
-	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_7
-	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_8
-.LBB0_7:
-	call qword ptr [rip + memcpy@GOTPCREL]
-.LBB0_8:
 	mov rcx, qword ptr [rbx]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-	mov rdx, r14
-.LBB0_9:
+	cmp qword ptr [rcx], rax
+	jne .LBB0_8
+	jmp .LBB0_5
+.LBB0_4:
+	mov qword ptr [rsp + 16], rdx
+	mov eax, 4
+	xor edx, edx
+	mov rcx, qword ptr [rbx]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_8
+.LBB0_5:
+	mov r15, rdx
+	lea rdx, [4*rdx]
+	mov rcx, qword ptr [rsp + 16]
+	lea rcx, [rax + 4*rcx]
+	xor r14d, r14d
+	sub rcx, rdx
+	cmovae r14, rcx
+	and r14, -4
+	lea rcx, [rdx + rax]
+	mov rdi, r14
+	mov r12, rax
+	mov rsi, rax
+	cmp rcx, r14
+	jbe .LBB0_6
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_7
+.LBB0_6:
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_7:
+	mov rax, qword ptr [rbx]
+	mov qword ptr [rax], r14
+	test r14, r14
+	mov rax, r12
+	cmovne rax, r14
+	mov rdx, r15
+.LBB0_8:
 	add rsp, 32
 	pop rbx
 	pop r12
@@ -93,23 +95,23 @@ inspect_asm::alloc_iter_u32::down:
 	pop r15
 	pop rbp
 	ret
-.LBB0_10:
+.LBB0_9:
 	mov rdi, rbx
 	mov rsi, rdx
 	mov r12, rdx
 	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
 	mov rdx, r12
 	jmp .LBB0_0
-.LBB0_11:
+.LBB0_10:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
 	mov rcx, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 24]
 	mov rdx, qword ptr [rdx]
 	cmp qword ptr [rdx], rcx
-	jne .LBB0_12
+	jne .LBB0_11
 	mov rsi, qword ptr [rsp + 16]
 	lea rcx, [rcx + 4*rsi]
 	mov qword ptr [rdx], rcx
-.LBB0_12:
+.LBB0_11:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
@@ -42,7 +42,7 @@ inspect_asm::alloc_iter_u32::down_a:
 	cmp qword ptr [rsp + 16], rdx
 	jne .LBB0_1
 	mov rdi, rbx
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/down_a.asm
@@ -7,10 +7,10 @@ inspect_asm::alloc_iter_u32::down_a:
 	sub rsp, 32
 	mov rbx, rdi
 	test rdx, rdx
-	je .LBB0_5
+	je .LBB0_4
 	mov rax, rdx
 	shr rax, 61
-	jne .LBB0_11
+	jne .LBB0_10
 	mov r14, rsi
 	lea r15, [4*rdx]
 	mov rcx, qword ptr [rbx]
@@ -18,7 +18,7 @@ inspect_asm::alloc_iter_u32::down_a:
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r15, rsi
-	ja .LBB0_10
+	ja .LBB0_9
 	sub rax, r15
 	mov qword ptr [rcx], rax
 .LBB0_0:
@@ -47,44 +47,46 @@ inspect_asm::alloc_iter_u32::down_a:
 	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_1
 .LBB0_3:
-	mov rsi, qword ptr [rsp]
+	mov rax, qword ptr [rsp]
 	mov rbx, qword ptr [rsp + 24]
-	mov rax, qword ptr [rbx]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_6
-.LBB0_4:
-	mov rax, rsi
-	jmp .LBB0_9
-.LBB0_5:
-	mov qword ptr [rsp + 16], rdx
-	mov esi, 4
-	xor edx, edx
-	mov rax, qword ptr [rbx]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_4
-.LBB0_6:
-	mov r14, rdx
-	lea rdx, [4*rdx]
-	mov rax, qword ptr [rsp + 16]
-	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
-	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_7
-	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_8
-.LBB0_7:
-	call qword ptr [rip + memcpy@GOTPCREL]
-.LBB0_8:
 	mov rcx, qword ptr [rbx]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-	mov rdx, r14
-.LBB0_9:
+	cmp qword ptr [rcx], rax
+	jne .LBB0_8
+	jmp .LBB0_5
+.LBB0_4:
+	mov qword ptr [rsp + 16], rdx
+	mov eax, 4
+	xor edx, edx
+	mov rcx, qword ptr [rbx]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_8
+.LBB0_5:
+	mov r15, rdx
+	lea rdx, [4*rdx]
+	mov rcx, qword ptr [rsp + 16]
+	lea rcx, [rax + 4*rcx]
+	xor r14d, r14d
+	sub rcx, rdx
+	cmovae r14, rcx
+	and r14, -4
+	lea rcx, [rdx + rax]
+	mov rdi, r14
+	mov r12, rax
+	mov rsi, rax
+	cmp rcx, r14
+	jbe .LBB0_6
+	call qword ptr [rip + memmove@GOTPCREL]
+	jmp .LBB0_7
+.LBB0_6:
+	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_7:
+	mov rax, qword ptr [rbx]
+	mov qword ptr [rax], r14
+	test r14, r14
+	mov rax, r12
+	cmovne rax, r14
+	mov rdx, r15
+.LBB0_8:
 	add rsp, 32
 	pop rbx
 	pop r12
@@ -92,25 +94,25 @@ inspect_asm::alloc_iter_u32::down_a:
 	pop r15
 	pop rbp
 	ret
-.LBB0_10:
+.LBB0_9:
 	mov rdi, rbx
 	mov rsi, rdx
 	mov r12, rdx
 	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
 	mov rdx, r12
 	jmp .LBB0_0
-.LBB0_11:
+.LBB0_10:
 	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
 	mov rdx, qword ptr [rsp]
 	mov rcx, qword ptr [rsp + 24]
 	mov rcx, qword ptr [rcx]
 	cmp qword ptr [rcx], rdx
-	jne .LBB0_12
+	jne .LBB0_11
 	mov rsi, qword ptr [rsp + 16]
 	lea rdx, [rdx + 4*rsi]
 	add rdx, 3
 	and rdx, -4
 	mov qword ptr [rcx], rdx
-.LBB0_12:
+.LBB0_11:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_down.asm
@@ -48,9 +48,8 @@ inspect_asm::alloc_iter_u32::mut_down:
 	mov rcx, r12
 	cmp qword ptr [rsp + 24], r12
 	jne .LBB0_1
-	mov esi, 1
 	lea rdi, [rsp + 8]
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 16]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_down_a.asm
@@ -47,9 +47,8 @@ inspect_asm::alloc_iter_u32::mut_down_a:
 	mov rcx, r12
 	cmp qword ptr [rsp + 24], r12
 	jne .LBB0_1
-	mov esi, 1
 	lea rdi, [rsp + 8]
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 16]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_down.asm
@@ -51,9 +51,8 @@ inspect_asm::alloc_iter_u32::mut_rev_down:
 	mov ebp, dword ptr [r15 + r13]
 	cmp qword ptr [rsp + 32], rcx
 	jne .LBB0_1
-	mov esi, 1
 	mov rdi, r12
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 24]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_down_a.asm
@@ -50,9 +50,8 @@ inspect_asm::alloc_iter_u32::mut_rev_down_a:
 	mov ebp, dword ptr [r15 + r13]
 	cmp qword ptr [rsp + 32], rcx
 	jne .LBB0_1
-	mov esi, 1
 	mov rdi, r12
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 24]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_up.asm
@@ -51,9 +51,8 @@ inspect_asm::alloc_iter_u32::mut_rev_up:
 	mov r13d, dword ptr [r15 + rbp]
 	cmp qword ptr [rsp + 32], r12
 	jne .LBB0_1
-	mov esi, 1
 	lea rdi, [rsp + 8]
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, qword ptr [rsp + 8]
 	mov r12, qword ptr [rsp + 24]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_rev_up_a.asm
@@ -47,9 +47,8 @@ inspect_asm::alloc_iter_u32::mut_rev_up_a:
 	mov r13d, dword ptr [r15 + rbp]
 	cmp qword ptr [rsp + 32], r12
 	jne .LBB0_1
-	mov esi, 1
 	lea rdi, [rsp + 8]
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, qword ptr [rsp + 8]
 	mov r12, qword ptr [rsp + 24]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_up.asm
@@ -49,9 +49,8 @@ inspect_asm::alloc_iter_u32::mut_up:
 	mov ebp, dword ptr [r15 + r13]
 	cmp qword ptr [rsp + 24], rdx
 	jne .LBB0_1
-	mov esi, 1
 	mov rdi, r12
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp + 8]
 	mov rdx, qword ptr [rsp + 16]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/mut_up_a.asm
@@ -45,9 +45,8 @@ inspect_asm::alloc_iter_u32::mut_up_a:
 	mov ebp, dword ptr [r15 + r13]
 	cmp qword ptr [rsp + 24], rdx
 	jne .LBB0_1
-	mov esi, 1
 	mov rdi, r12
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp + 8]
 	mov rdx, qword ptr [rsp + 16]
 	jmp .LBB0_1

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
@@ -10,21 +10,19 @@ inspect_asm::alloc_iter_u32::try_down:
 	je .LBB0_1
 	mov rax, rdx
 	shr rax, 61
-	je .LBB0_3
+	je .LBB0_2
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_11
+	jmp .LBB0_10
 .LBB0_1:
 	mov qword ptr [rsp + 24], rdx
-	mov esi, 4
+	mov eax, 4
 	xor ebx, ebx
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_8
+	mov rcx, qword ptr [rdi]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_10
+	jmp .LBB0_7
 .LBB0_2:
-	mov rax, rsi
-	jmp .LBB0_11
-.LBB0_3:
 	mov r14, rsi
 	lea r12, [4*rdx]
 	mov rcx, qword ptr [rdi]
@@ -32,12 +30,12 @@ inspect_asm::alloc_iter_u32::try_down:
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r12, rsi
-	ja .LBB0_13
+	ja .LBB0_12
 	sub rax, r12
 	and rax, -4
 	mov qword ptr [rcx], rax
-	je .LBB0_13
-.LBB0_4:
+	je .LBB0_12
+.LBB0_3:
 	mov qword ptr [rsp + 8], rax
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdx
@@ -45,53 +43,57 @@ inspect_asm::alloc_iter_u32::try_down:
 	xor r13d, r13d
 	lea r15, [rsp + 8]
 	xor ebx, ebx
-	jmp .LBB0_6
-.LBB0_5:
+	jmp .LBB0_5
+.LBB0_4:
 	mov dword ptr [rax + 4*rbx], ebp
 	inc rbx
 	mov qword ptr [rsp + 16], rbx
 	add r13, 4
 	cmp r12, r13
-	je .LBB0_7
-.LBB0_6:
+	je .LBB0_6
+.LBB0_5:
 	mov ebp, dword ptr [r14 + r13]
 	cmp qword ptr [rsp + 24], rbx
-	jne .LBB0_5
+	jne .LBB0_4
 	mov rdi, r15
 	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	test al, al
-	jne .LBB0_12
+	jne .LBB0_11
 	mov rax, qword ptr [rsp + 8]
 	mov rbx, qword ptr [rsp + 16]
-	jmp .LBB0_5
-.LBB0_7:
-	mov rsi, qword ptr [rsp + 8]
+	jmp .LBB0_4
+.LBB0_6:
+	mov rax, qword ptr [rsp + 8]
 	mov rdi, qword ptr [rsp + 32]
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_2
-.LBB0_8:
-	mov r14, rdi
-	lea rdx, [4*rbx]
-	mov rax, qword ptr [rsp + 24]
-	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
+	mov rcx, qword ptr [rdi]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_10
+.LBB0_7:
 	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_9
+	lea rdx, [4*rbx]
+	mov rcx, qword ptr [rsp + 24]
+	lea rcx, [rax + 4*rcx]
+	xor r14d, r14d
+	sub rcx, rdx
+	cmovae r14, rcx
+	and r14, -4
+	lea rcx, [rdx + rax]
+	mov rdi, r14
+	mov r12, rax
+	mov rsi, rax
+	cmp rcx, r14
+	jbe .LBB0_8
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_10
-.LBB0_9:
+	jmp .LBB0_9
+.LBB0_8:
 	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_9:
+	mov rax, qword ptr [r15]
+	mov qword ptr [rax], r14
+	test r14, r14
+	mov rax, r12
+	cmovne rax, r14
 .LBB0_10:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-.LBB0_11:
 	mov rdx, rbx
 	add rsp, 40
 	pop rbx
@@ -101,7 +103,7 @@ inspect_asm::alloc_iter_u32::try_down:
 	pop r15
 	pop rbp
 	ret
-.LBB0_12:
+.LBB0_11:
 	mov rax, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 32]
 	mov rcx, qword ptr [rcx]
@@ -111,7 +113,7 @@ inspect_asm::alloc_iter_u32::try_down:
 	lea rax, [rax + 4*rdx]
 	mov qword ptr [rcx], rax
 	jmp .LBB0_0
-.LBB0_13:
+.LBB0_12:
 	mov rbx, rdi
 	mov rsi, rdx
 	mov r15, rdx
@@ -119,16 +121,16 @@ inspect_asm::alloc_iter_u32::try_down:
 	mov rdx, r15
 	mov rdi, rbx
 	test rax, rax
-	jne .LBB0_4
+	jne .LBB0_3
 	jmp .LBB0_0
 	mov rcx, qword ptr [rsp + 8]
 	mov rdx, qword ptr [rsp + 32]
 	mov rdx, qword ptr [rdx]
 	cmp qword ptr [rdx], rcx
-	jne .LBB0_14
+	jne .LBB0_13
 	mov rsi, qword ptr [rsp + 24]
 	lea rcx, [rcx + 4*rsi]
 	mov qword ptr [rdx], rcx
-.LBB0_14:
+.LBB0_13:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down.asm
@@ -58,7 +58,7 @@ inspect_asm::alloc_iter_u32::try_down:
 	cmp qword ptr [rsp + 24], rbx
 	jne .LBB0_5
 	mov rdi, r15
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_12
 	mov rax, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
@@ -57,7 +57,7 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	cmp qword ptr [rsp + 24], rbx
 	jne .LBB0_5
 	mov rdi, r15
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_12
 	mov rax, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_down_a.asm
@@ -10,21 +10,19 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	je .LBB0_1
 	mov rax, rdx
 	shr rax, 61
-	je .LBB0_3
+	je .LBB0_2
 .LBB0_0:
 	xor eax, eax
-	jmp .LBB0_11
+	jmp .LBB0_10
 .LBB0_1:
 	mov qword ptr [rsp + 24], rdx
-	mov esi, 4
+	mov eax, 4
 	xor ebx, ebx
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	je .LBB0_8
+	mov rcx, qword ptr [rdi]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_10
+	jmp .LBB0_7
 .LBB0_2:
-	mov rax, rsi
-	jmp .LBB0_11
-.LBB0_3:
 	mov r14, rsi
 	lea r12, [4*rdx]
 	mov rcx, qword ptr [rdi]
@@ -32,11 +30,11 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	mov rsi, rax
 	sub rsi, qword ptr [rcx + 8]
 	cmp r12, rsi
-	ja .LBB0_13
+	ja .LBB0_12
 	sub rax, r12
 	mov qword ptr [rcx], rax
-	je .LBB0_13
-.LBB0_4:
+	je .LBB0_12
+.LBB0_3:
 	mov qword ptr [rsp + 8], rax
 	mov qword ptr [rsp + 16], 0
 	mov qword ptr [rsp + 24], rdx
@@ -44,53 +42,57 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	xor r13d, r13d
 	lea r15, [rsp + 8]
 	xor ebx, ebx
-	jmp .LBB0_6
-.LBB0_5:
+	jmp .LBB0_5
+.LBB0_4:
 	mov dword ptr [rax + 4*rbx], ebp
 	inc rbx
 	mov qword ptr [rsp + 16], rbx
 	add r13, 4
 	cmp r12, r13
-	je .LBB0_7
-.LBB0_6:
+	je .LBB0_6
+.LBB0_5:
 	mov ebp, dword ptr [r14 + r13]
 	cmp qword ptr [rsp + 24], rbx
-	jne .LBB0_5
+	jne .LBB0_4
 	mov rdi, r15
 	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	test al, al
-	jne .LBB0_12
+	jne .LBB0_11
 	mov rax, qword ptr [rsp + 8]
 	mov rbx, qword ptr [rsp + 16]
-	jmp .LBB0_5
-.LBB0_7:
-	mov rsi, qword ptr [rsp + 8]
+	jmp .LBB0_4
+.LBB0_6:
+	mov rax, qword ptr [rsp + 8]
 	mov rdi, qword ptr [rsp + 32]
-	mov rax, qword ptr [rdi]
-	cmp rsi, qword ptr [rax]
-	jne .LBB0_2
-.LBB0_8:
-	mov r14, rdi
-	lea rdx, [4*rbx]
-	mov rax, qword ptr [rsp + 24]
-	lea rax, [rsi + 4*rax]
-	xor edi, edi
-	sub rax, rdx
-	cmovae rdi, rax
-	and rdi, -4
-	lea rax, [rdx + rsi]
+	mov rcx, qword ptr [rdi]
+	cmp qword ptr [rcx], rax
+	jne .LBB0_10
+.LBB0_7:
 	mov r15, rdi
-	cmp rax, rdi
-	jbe .LBB0_9
+	lea rdx, [4*rbx]
+	mov rcx, qword ptr [rsp + 24]
+	lea rcx, [rax + 4*rcx]
+	xor r14d, r14d
+	sub rcx, rdx
+	cmovae r14, rcx
+	and r14, -4
+	lea rcx, [rdx + rax]
+	mov rdi, r14
+	mov r12, rax
+	mov rsi, rax
+	cmp rcx, r14
+	jbe .LBB0_8
 	call qword ptr [rip + memmove@GOTPCREL]
-	jmp .LBB0_10
-.LBB0_9:
+	jmp .LBB0_9
+.LBB0_8:
 	call qword ptr [rip + memcpy@GOTPCREL]
+.LBB0_9:
+	mov rax, qword ptr [r15]
+	mov qword ptr [rax], r14
+	test r14, r14
+	mov rax, r12
+	cmovne rax, r14
 .LBB0_10:
-	mov rcx, qword ptr [r14]
-	mov rax, r15
-	mov qword ptr [rcx], r15
-.LBB0_11:
 	mov rdx, rbx
 	add rsp, 40
 	pop rbx
@@ -100,7 +102,7 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	pop r15
 	pop rbp
 	ret
-.LBB0_12:
+.LBB0_11:
 	mov rcx, qword ptr [rsp + 8]
 	mov rax, qword ptr [rsp + 32]
 	mov rax, qword ptr [rax]
@@ -112,7 +114,7 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	and rcx, -4
 	mov qword ptr [rax], rcx
 	jmp .LBB0_0
-.LBB0_13:
+.LBB0_12:
 	mov rbx, rdi
 	mov rsi, rdx
 	mov r15, rdx
@@ -120,18 +122,18 @@ inspect_asm::alloc_iter_u32::try_down_a:
 	mov rdx, r15
 	mov rdi, rbx
 	test rax, rax
-	jne .LBB0_4
+	jne .LBB0_3
 	jmp .LBB0_0
 	mov rdx, qword ptr [rsp + 8]
 	mov rcx, qword ptr [rsp + 32]
 	mov rcx, qword ptr [rcx]
 	cmp qword ptr [rcx], rdx
-	jne .LBB0_14
+	jne .LBB0_13
 	mov rsi, qword ptr [rsp + 24]
 	lea rdx, [rdx + 4*rsi]
 	add rdx, 3
 	and rdx, -4
 	mov qword ptr [rcx], rdx
-.LBB0_14:
+.LBB0_13:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_down.asm
@@ -2,30 +2,28 @@ inspect_asm::alloc_iter_u32::try_mut_down:
 	push rbp
 	push r15
 	push r14
-	push r13
 	push r12
 	push rbx
-	sub rsp, 40
-	mov ebx, 4
+	sub rsp, 32
 	test rdx, rdx
 	je .LBB0_6
-	mov r14, rdx
+	mov rbx, rdx
 	mov rax, rdx
 	shr rax, 61
 	je .LBB0_1
 .LBB0_0:
-	xor ebx, ebx
+	xor eax, eax
 	jmp .LBB0_7
 .LBB0_1:
-	mov r15, rsi
-	shl r14, 2
+	mov r14, rsi
+	shl rbx, 2
 	mov rax, qword ptr [rdi]
 	mov rdx, qword ptr [rax]
 	mov rax, qword ptr [rax + 8]
 	and rdx, -4
 	mov rcx, rdx
 	sub rcx, rax
-	cmp r14, rcx
+	cmp rbx, rcx
 	ja .LBB0_8
 	add rax, 3
 	and rax, -4
@@ -33,39 +31,39 @@ inspect_asm::alloc_iter_u32::try_mut_down:
 .LBB0_2:
 	sub rdx, rax
 	shr rdx, 2
-	mov qword ptr [rsp + 8], rax
-	mov qword ptr [rsp + 16], 0
-	mov qword ptr [rsp + 24], rdx
-	mov qword ptr [rsp + 32], rdi
-	xor r13d, r13d
-	lea r12, [rsp + 8]
+	mov qword ptr [rsp], rax
+	mov qword ptr [rsp + 8], 0
+	mov qword ptr [rsp + 16], rdx
+	mov qword ptr [rsp + 24], rdi
+	xor r12d, r12d
+	mov r15, rsp
 	xor ecx, ecx
 	jmp .LBB0_4
 .LBB0_3:
 	mov dword ptr [rax + 4*rdx], ebp
 	lea rcx, [rdx + 1]
-	mov qword ptr [rsp + 16], rcx
-	add r13, 4
-	cmp r14, r13
+	mov qword ptr [rsp + 8], rcx
+	add r12, 4
+	cmp rbx, r12
 	je .LBB0_5
 .LBB0_4:
-	mov ebp, dword ptr [r15 + r13]
+	mov ebp, dword ptr [r14 + r12]
 	mov rdx, rcx
-	cmp qword ptr [rsp + 24], rcx
+	cmp qword ptr [rsp + 16], rcx
 	jne .LBB0_3
-	mov rdi, r12
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	mov rdi, r15
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
-	mov rax, qword ptr [rsp + 8]
-	mov rdx, qword ptr [rsp + 16]
+	mov rax, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_3
 .LBB0_5:
-	mov rax, qword ptr [rsp + 24]
+	mov rax, qword ptr [rsp + 16]
 	test rax, rax
 	je .LBB0_6
-	mov rsi, qword ptr [rsp + 8]
-	mov r15, qword ptr [rsp + 32]
+	mov rsi, qword ptr [rsp]
+	mov r15, qword ptr [rsp + 24]
 	lea rax, [rsi + 4*rax]
 	not rdx
 	lea rbx, [rax + 4*rdx]
@@ -73,28 +71,28 @@ inspect_asm::alloc_iter_u32::try_mut_down:
 	mov rdi, rbx
 	mov r14, rcx
 	call qword ptr [rip + memmove@GOTPCREL]
+	mov rax, rbx
 	mov rdx, r14
-	mov rax, qword ptr [r15]
-	mov qword ptr [rax], rbx
+	mov rcx, qword ptr [r15]
+	mov qword ptr [rcx], rbx
 	jmp .LBB0_7
 .LBB0_6:
+	mov eax, 4
 	xor edx, edx
 .LBB0_7:
-	mov rax, rbx
-	add rsp, 40
+	add rsp, 32
 	pop rbx
 	pop r12
-	pop r13
 	pop r14
 	pop r15
 	pop rbp
 	ret
 .LBB0_8:
 	mov esi, 4
-	mov r12, rdi
-	mov rdx, r14
+	mov r15, rdi
+	mov rdx, rbx
 	call bump_scope::bump_scope::BumpScope<A,_,_,_>::alloc_greedy_in_another_chunk
 	test rax, rax
 	je .LBB0_0
-	mov rdi, r12
+	mov rdi, r15
 	jmp .LBB0_2

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_down_a.asm
@@ -2,29 +2,27 @@ inspect_asm::alloc_iter_u32::try_mut_down_a:
 	push rbp
 	push r15
 	push r14
-	push r13
 	push r12
 	push rbx
-	sub rsp, 40
-	mov ebx, 4
+	sub rsp, 32
 	test rdx, rdx
 	je .LBB0_6
-	mov r14, rdx
+	mov rbx, rdx
 	mov rax, rdx
 	shr rax, 61
 	je .LBB0_1
 .LBB0_0:
-	xor ebx, ebx
+	xor eax, eax
 	jmp .LBB0_7
 .LBB0_1:
-	mov r15, rsi
-	shl r14, 2
+	mov r14, rsi
+	shl rbx, 2
 	mov rax, qword ptr [rdi]
 	mov rdx, qword ptr [rax]
 	mov rax, qword ptr [rax + 8]
 	mov rcx, rdx
 	sub rcx, rax
-	cmp r14, rcx
+	cmp rbx, rcx
 	ja .LBB0_8
 	add rax, 3
 	and rax, -4
@@ -32,39 +30,39 @@ inspect_asm::alloc_iter_u32::try_mut_down_a:
 .LBB0_2:
 	sub rdx, rax
 	shr rdx, 2
-	mov qword ptr [rsp + 8], rax
-	mov qword ptr [rsp + 16], 0
-	mov qword ptr [rsp + 24], rdx
-	mov qword ptr [rsp + 32], rdi
-	xor r13d, r13d
-	lea r12, [rsp + 8]
+	mov qword ptr [rsp], rax
+	mov qword ptr [rsp + 8], 0
+	mov qword ptr [rsp + 16], rdx
+	mov qword ptr [rsp + 24], rdi
+	xor r12d, r12d
+	mov r15, rsp
 	xor ecx, ecx
 	jmp .LBB0_4
 .LBB0_3:
 	mov dword ptr [rax + 4*rdx], ebp
 	lea rcx, [rdx + 1]
-	mov qword ptr [rsp + 16], rcx
-	add r13, 4
-	cmp r14, r13
+	mov qword ptr [rsp + 8], rcx
+	add r12, 4
+	cmp rbx, r12
 	je .LBB0_5
 .LBB0_4:
-	mov ebp, dword ptr [r15 + r13]
+	mov ebp, dword ptr [r14 + r12]
 	mov rdx, rcx
-	cmp qword ptr [rsp + 24], rcx
+	cmp qword ptr [rsp + 16], rcx
 	jne .LBB0_3
-	mov rdi, r12
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	mov rdi, r15
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
-	mov rax, qword ptr [rsp + 8]
-	mov rdx, qword ptr [rsp + 16]
+	mov rax, qword ptr [rsp]
+	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_3
 .LBB0_5:
-	mov rax, qword ptr [rsp + 24]
+	mov rax, qword ptr [rsp + 16]
 	test rax, rax
 	je .LBB0_6
-	mov rsi, qword ptr [rsp + 8]
-	mov r15, qword ptr [rsp + 32]
+	mov rsi, qword ptr [rsp]
+	mov r15, qword ptr [rsp + 24]
 	lea rax, [rsi + 4*rax]
 	not rdx
 	lea rbx, [rax + 4*rdx]
@@ -72,28 +70,28 @@ inspect_asm::alloc_iter_u32::try_mut_down_a:
 	mov rdi, rbx
 	mov r14, rcx
 	call qword ptr [rip + memmove@GOTPCREL]
+	mov rax, rbx
 	mov rdx, r14
-	mov rax, qword ptr [r15]
-	mov qword ptr [rax], rbx
+	mov rcx, qword ptr [r15]
+	mov qword ptr [rcx], rbx
 	jmp .LBB0_7
 .LBB0_6:
+	mov eax, 4
 	xor edx, edx
 .LBB0_7:
-	mov rax, rbx
-	add rsp, 40
+	add rsp, 32
 	pop rbx
 	pop r12
-	pop r13
 	pop r14
 	pop r15
 	pop rbp
 	ret
 .LBB0_8:
 	mov esi, 4
-	mov r12, rdi
-	mov rdx, r14
+	mov r15, rdi
+	mov rdx, rbx
 	call bump_scope::bump_scope::BumpScope<A,_,_,_>::alloc_greedy_in_another_chunk
 	test rax, rax
 	je .LBB0_0
-	mov rdi, r12
+	mov rdi, r15
 	jmp .LBB0_2

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_down.asm
@@ -56,7 +56,7 @@ inspect_asm::alloc_iter_u32::try_mut_rev_down:
 	cmp qword ptr [rsp + 32], rcx
 	jne .LBB0_3
 	mov rdi, r12
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_down_a.asm
@@ -55,7 +55,7 @@ inspect_asm::alloc_iter_u32::try_mut_rev_down_a:
 	cmp qword ptr [rsp + 32], rcx
 	jne .LBB0_3
 	mov rdi, r12
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_up.asm
@@ -56,7 +56,7 @@ inspect_asm::alloc_iter_u32::try_mut_rev_up:
 	cmp qword ptr [rsp + 32], r12
 	jne .LBB0_3
 	lea rdi, [rsp + 8]
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_rev_up_a.asm
@@ -53,7 +53,7 @@ inspect_asm::alloc_iter_u32::try_mut_rev_up_a:
 	cmp qword ptr [rsp + 32], rax
 	jne .LBB0_3
 	mov rdi, r12
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_up.asm
@@ -54,7 +54,7 @@ inspect_asm::alloc_iter_u32::try_mut_up:
 	cmp qword ptr [rsp + 24], rdx
 	jne .LBB0_3
 	mov rdi, r12
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
 	mov rax, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_mut_up_a.asm
@@ -50,7 +50,7 @@ inspect_asm::alloc_iter_u32::try_mut_up_a:
 	cmp qword ptr [rsp + 24], rdx
 	jne .LBB0_3
 	mov rdi, r12
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_0
 	mov rax, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
@@ -17,8 +17,8 @@ inspect_asm::alloc_iter_u32::try_up:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 .LBB0_2:
@@ -68,7 +68,7 @@ inspect_asm::alloc_iter_u32::try_up:
 	cmp qword ptr [rsp + 16], rdx
 	jne .LBB0_6
 	mov rdi, r14
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_9
 	mov rax, qword ptr [rsp]
@@ -79,8 +79,8 @@ inspect_asm::alloc_iter_u32::try_up:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 	jmp .LBB0_2

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up.asm
@@ -17,8 +17,8 @@ inspect_asm::alloc_iter_u32::try_up:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 .LBB0_2:
@@ -79,8 +79,8 @@ inspect_asm::alloc_iter_u32::try_up:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 	jmp .LBB0_2

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
@@ -17,8 +17,8 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 .LBB0_2:
@@ -66,7 +66,7 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	cmp qword ptr [rsp + 16], rdx
 	jne .LBB0_6
 	mov rdi, r14
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	test al, al
 	jne .LBB0_9
 	mov rax, qword ptr [rsp]
@@ -77,8 +77,8 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 	jmp .LBB0_2

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/try_up_a.asm
@@ -17,8 +17,8 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 .LBB0_2:
@@ -77,8 +77,8 @@ inspect_asm::alloc_iter_u32::try_up_a:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_3
 	jmp .LBB0_2

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
@@ -52,8 +52,8 @@ inspect_asm::alloc_iter_u32::up:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 .LBB0_4:
@@ -71,8 +71,8 @@ inspect_asm::alloc_iter_u32::up:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 	jmp .LBB0_4

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up.asm
@@ -43,7 +43,7 @@ inspect_asm::alloc_iter_u32::up:
 	cmp qword ptr [rsp + 16], rdx
 	jne .LBB0_1
 	mov rdi, r14
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_1
@@ -52,8 +52,8 @@ inspect_asm::alloc_iter_u32::up:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 .LBB0_4:
@@ -71,8 +71,8 @@ inspect_asm::alloc_iter_u32::up:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 	jmp .LBB0_4

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
@@ -50,8 +50,8 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 .LBB0_4:
@@ -71,8 +71,8 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	mov rsi, qword ptr [rdi]
 	add rcx, rax
+	mov rsi, qword ptr [rdi]
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 	jmp .LBB0_4

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32/up_a.asm
@@ -41,7 +41,7 @@ inspect_asm::alloc_iter_u32::up_a:
 	cmp qword ptr [rsp + 16], rdx
 	jne .LBB0_1
 	mov rdi, r14
-	call bump_scope::bump_vec::BumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::bump_vec::BumpVec<T,A>::generic_grow_amortized
 	mov rax, qword ptr [rsp]
 	mov rdx, qword ptr [rsp + 8]
 	jmp .LBB0_1
@@ -50,8 +50,8 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov rcx, qword ptr [rsp + 16]
 	mov rdi, qword ptr [rsp + 24]
 	shl rcx, 2
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 .LBB0_4:
@@ -71,8 +71,8 @@ inspect_asm::alloc_iter_u32::up_a:
 	mov eax, 4
 	xor ecx, ecx
 	xor edx, edx
-	add rcx, rax
 	mov rsi, qword ptr [rdi]
+	add rcx, rax
 	cmp rcx, qword ptr [rsi]
 	jne .LBB0_5
 	jmp .LBB0_4

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/down.asm
@@ -45,7 +45,7 @@ inspect_asm::alloc_iter_u32_bump_vec::down:
 	mov r14, rsi
 	mov rsi, rdx
 	mov r15, rdx
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r15
 	mov rdx, qword ptr [rsp + 8]
@@ -67,7 +67,7 @@ inspect_asm::alloc_iter_u32_bump_vec::down:
 	mov esi, 1
 	mov rdi, rbx
 	mov r12, rax
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r12
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/down_a.asm
@@ -45,7 +45,7 @@ inspect_asm::alloc_iter_u32_bump_vec::down_a:
 	mov r14, rsi
 	mov rsi, rdx
 	mov r15, rdx
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r15
 	mov rdx, qword ptr [rsp + 8]
@@ -67,7 +67,7 @@ inspect_asm::alloc_iter_u32_bump_vec::down_a:
 	mov esi, 1
 	mov rdi, rbx
 	mov r12, rax
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r12
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_down.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_down.asm
@@ -27,7 +27,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_down:
 	mov r14, rsi
 	mov rsi, rdx
 	mov r15, rdx
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r15
 	mov rdx, qword ptr [rsp + 16]
@@ -51,7 +51,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_down:
 	mov esi, 1
 	mov rdi, rbx
 	mov r12, rax
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r12
 	mov rdx, qword ptr [rsp + 16]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_down_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_down_a.asm
@@ -27,7 +27,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_down_a:
 	mov r14, rsi
 	mov rsi, rdx
 	mov r15, rdx
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r15
 	mov rdx, qword ptr [rsp + 16]
@@ -51,7 +51,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_down_a:
 	mov esi, 1
 	mov rdi, rbx
 	mov r12, rax
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r12
 	mov rdx, qword ptr [rsp + 16]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_up.asm
@@ -27,7 +27,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_up:
 	mov r15, rsi
 	mov rsi, rdx
 	mov r14, rdx
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, r15
 	mov rcx, r14
 	mov rax, qword ptr [rsp + 16]
@@ -51,7 +51,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_up:
 	mov esi, 1
 	mov rdi, rbx
 	mov r14, rcx
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, r15
 	mov rcx, r14
 	mov rax, qword ptr [rsp + 16]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/rev_up_a.asm
@@ -27,7 +27,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_up_a:
 	mov r15, rsi
 	mov rsi, rdx
 	mov r14, rdx
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, r15
 	mov rcx, r14
 	mov rax, qword ptr [rsp + 16]
@@ -51,7 +51,7 @@ inspect_asm::alloc_iter_u32_bump_vec::rev_up_a:
 	mov esi, 1
 	mov rdi, rbx
 	mov r14, rcx
-	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec_rev::MutBumpVecRev<T,A>::generic_grow_amortized
 	mov rdx, r15
 	mov rcx, r14
 	mov rax, qword ptr [rsp + 16]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/up.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/up.asm
@@ -38,7 +38,7 @@ inspect_asm::alloc_iter_u32_bump_vec::up:
 	mov r14, rsi
 	mov rsi, rdx
 	mov r15, rdx
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r15
 	mov rdx, qword ptr [rsp + 8]
@@ -60,7 +60,7 @@ inspect_asm::alloc_iter_u32_bump_vec::up:
 	mov esi, 1
 	mov rdi, rbx
 	mov r12, rax
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r12
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/up_a.asm
+++ b/crates/inspect-asm/out/x86-64/alloc_iter_u32_bump_vec/up_a.asm
@@ -38,7 +38,7 @@ inspect_asm::alloc_iter_u32_bump_vec::up_a:
 	mov r14, rsi
 	mov rsi, rdx
 	mov r15, rdx
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r15
 	mov rdx, qword ptr [rsp + 8]
@@ -60,7 +60,7 @@ inspect_asm::alloc_iter_u32_bump_vec::up_a:
 	mov esi, 1
 	mov rdi, rbx
 	mov r12, rax
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov rcx, r14
 	mov rax, r12
 	mov rdx, qword ptr [rsp + 8]

--- a/crates/inspect-asm/out/x86-64/bump_vec_u32/down/push.asm
+++ b/crates/inspect-asm/out/x86-64/bump_vec_u32/down/push.asm
@@ -18,7 +18,7 @@ inspect_asm::bump_vec_u32::down::push:
 	mov ebp, esi
 	mov esi, 1
 	mov rbx, rdi
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov esi, ebp
 	mov rdi, rbx
 	mov rax, qword ptr [rbx + 8]

--- a/crates/inspect-asm/out/x86-64/bump_vec_u32/down/try_push.asm
+++ b/crates/inspect-asm/out/x86-64/bump_vec_u32/down/try_push.asm
@@ -19,7 +19,7 @@ inspect_asm::bump_vec_u32::down::try_push:
 .LBB0_2:
 	mov ebx, esi
 	mov r14, rdi
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov ecx, eax
 	mov al, 1
 	test cl, cl

--- a/crates/inspect-asm/out/x86-64/bump_vec_u32/up/push.asm
+++ b/crates/inspect-asm/out/x86-64/bump_vec_u32/up/push.asm
@@ -18,7 +18,7 @@ inspect_asm::bump_vec_u32::up::push:
 	mov ebp, esi
 	mov esi, 1
 	mov rbx, rdi
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov esi, ebp
 	mov rdi, rbx
 	mov rax, qword ptr [rbx + 8]

--- a/crates/inspect-asm/out/x86-64/bump_vec_u32/up/try_push.asm
+++ b/crates/inspect-asm/out/x86-64/bump_vec_u32/up/try_push.asm
@@ -19,7 +19,7 @@ inspect_asm::bump_vec_u32::up::try_push:
 .LBB0_2:
 	mov ebx, esi
 	mov r14, rdi
-	call bump_scope::mut_bump_vec::MutBumpVec<T,A,_,_,_>::generic_grow_amortized
+	call bump_scope::mut_bump_vec::MutBumpVec<T,A>::generic_grow_amortized
 	mov ecx, eax
 	mov al, 1
 	test cl, cl

--- a/crates/inspect-asm/out/x86-64/vec_map/grow.asm
+++ b/crates/inspect-asm/out/x86-64/vec_map/grow.asm
@@ -1,110 +1,84 @@
 inspect_asm::vec_map::grow:
-	push rbp
 	push r15
 	push r14
 	push r13
 	push r12
 	push rbx
-	push rax
 	mov r14, rdi
 	mov rbx, qword ptr [rsi + 24]
 	mov r12, qword ptr [rsi]
-	mov rbp, qword ptr [rsi + 8]
+	mov r15, qword ptr [rsi + 8]
 	mov r13, qword ptr [rsi + 16]
-	test rbp, rbp
-	je .LBB0_5
-	mov rax, rbp
+	test r15, r15
+	je .LBB0_0
+	mov rax, r15
 	shr rax, 60
 	jne .LBB0_10
-	lea r15, [8*rbp]
-	mov rcx, qword ptr [rbx]
-	mov rax, qword ptr [rcx]
-	dec rax
+	lea rcx, [8*r15]
+	mov rdx, qword ptr [rbx]
+	mov rax, qword ptr [rdx]
+	mov rsi, qword ptr [rdx + 8]
+	add rax, 7
 	and rax, -8
-	lea rsi, [r15 + 8]
-	add rsi, rax
-	mov rdx, -1
-	cmovae rdx, rsi
-	cmp rdx, qword ptr [rcx + 8]
-	ja .LBB0_0
-	mov qword ptr [rcx], rdx
-	add rax, 8
-	jne .LBB0_1
-.LBB0_0:
-	mov esi, 8
+	sub rsi, rax
+	cmp rcx, rsi
+	jbe .LBB0_1
 	mov rdi, rbx
-	mov rdx, r15
-	call bump_scope::bump_scope::BumpScope<A,_,_,_>::alloc_in_another_chunk
-	test rax, rax
-	je .LBB0_11
+	mov rsi, r15
+	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
+	jmp .LBB0_2
+.LBB0_0:
+	mov eax, 8
+	xor edx, edx
+	jmp .LBB0_8
 .LBB0_1:
+	add rcx, rax
+	mov qword ptr [rdx], rcx
+.LBB0_2:
 	movabs rdx, 4611686018427387903
-	lea rcx, [rbp - 1]
+	lea rcx, [r15 - 1]
 	mov rdi, rcx
 	and rdi, rdx
 	cmp rdi, rcx
 	cmovae rdi, rcx
 	cmp rdi, 18
-	jbe .LBB0_2
-	lea rsi, [rdx + rbp]
+	jbe .LBB0_3
+	lea rsi, [r15 + rdx]
 	and rsi, rdx
 	cmp rsi, rcx
 	cmovae rsi, rcx
 	lea rdx, [r12 + 4*rsi]
 	add rdx, 4
 	cmp rax, rdx
-	jae .LBB0_8
+	jae .LBB0_6
 	lea rdx, [rax + 8*rsi]
 	add rdx, 8
 	cmp r12, rdx
-	jae .LBB0_8
-.LBB0_2:
+	jae .LBB0_6
+.LBB0_3:
 	xor edx, edx
 	mov rsi, r12
-.LBB0_3:
-	lea rdi, [r12 + 4*rbp]
 .LBB0_4:
+	lea rdi, [r12 + 4*r15]
+.LBB0_5:
 	mov r8, rdx
 	mov edx, dword ptr [rsi]
 	mov qword ptr [rax + 8*r8], rdx
 	lea rdx, [r8 + 1]
 	cmp rcx, r8
-	je .LBB0_6
+	je .LBB0_8
 	add rsi, 4
 	cmp rsi, rdi
-	jne .LBB0_4
-	jmp .LBB0_6
-.LBB0_5:
-	mov eax, 8
-	xor edx, edx
+	jne .LBB0_5
+	jmp .LBB0_8
 .LBB0_6:
-	lea rsi, [r12 + 4*r13]
-	mov rcx, qword ptr [rbx]
-	cmp rsi, qword ptr [rcx]
-	jne .LBB0_7
-	mov qword ptr [rcx], r12
-.LBB0_7:
-	mov qword ptr [r14], rax
-	mov qword ptr [r14 + 8], rdx
-	mov qword ptr [r14 + 16], rbp
-	mov qword ptr [r14 + 24], rbx
-	mov rax, r14
-	add rsp, 8
-	pop rbx
-	pop r12
-	pop r13
-	pop r14
-	pop r15
-	pop rbp
-	ret
-.LBB0_8:
 	inc rdi
 	movabs rdx, 9223372036854775804
 	and rdx, rdi
 	lea rsi, [r12 + 4*rdx]
 	xor r8d, r8d
 	xorps xmm0, xmm0
-.LBB0_9:
+.LBB0_7:
 	movsd xmm1, qword ptr [r12 + 4*r8]
 	movsd xmm2, qword ptr [r12 + 4*r8 + 8]
 	unpcklps xmm1, xmm0
@@ -113,24 +87,35 @@ inspect_asm::vec_map::grow:
 	movups xmmword ptr [rax + 8*r8 + 16], xmm2
 	add r8, 4
 	cmp rdx, r8
-	jne .LBB0_9
+	jne .LBB0_7
 	cmp rdi, rdx
-	jne .LBB0_3
-	jmp .LBB0_6
+	jne .LBB0_4
+.LBB0_8:
+	lea rsi, [r12 + 4*r13]
+	mov rcx, qword ptr [rbx]
+	cmp rsi, qword ptr [rcx]
+	jne .LBB0_9
+	mov qword ptr [rcx], r12
+.LBB0_9:
+	mov qword ptr [r14], rax
+	mov qword ptr [r14 + 8], rdx
+	mov qword ptr [r14 + 16], r15
+	mov qword ptr [r14 + 24], rbx
+	mov rax, r14
+	pop rbx
+	pop r12
+	pop r13
+	pop r14
+	pop r15
+	ret
 .LBB0_10:
-	call qword ptr [rip + bump_scope::bump_allocator::invalid_slice_layout@GOTPCREL]
-	jmp .LBB0_12
-.LBB0_11:
-	mov edi, 8
-	mov rsi, r15
-	call qword ptr [rip + alloc::alloc::handle_alloc_error@GOTPCREL]
-.LBB0_12:
+	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
 	ud2
 	lea rdx, [r12 + 4*r13]
 	mov rcx, qword ptr [rbx]
 	cmp rdx, qword ptr [rcx]
-	jne .LBB0_13
+	jne .LBB0_11
 	mov qword ptr [rcx], r12
-.LBB0_13:
+.LBB0_11:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/vec_map/grow.asm
+++ b/crates/inspect-asm/out/x86-64/vec_map/grow.asm
@@ -1,84 +1,110 @@
 inspect_asm::vec_map::grow:
+	push rbp
 	push r15
 	push r14
 	push r13
 	push r12
 	push rbx
+	push rax
 	mov r14, rdi
 	mov rbx, qword ptr [rsi + 24]
 	mov r12, qword ptr [rsi]
-	mov r15, qword ptr [rsi + 8]
+	mov rbp, qword ptr [rsi + 8]
 	mov r13, qword ptr [rsi + 16]
-	test r15, r15
-	je .LBB0_0
-	mov rax, r15
+	test rbp, rbp
+	je .LBB0_5
+	mov rax, rbp
 	shr rax, 60
 	jne .LBB0_10
-	lea rcx, [8*r15]
-	mov rdx, qword ptr [rbx]
-	mov rax, qword ptr [rdx]
-	mov rsi, qword ptr [rdx + 8]
-	add rax, 7
+	lea r15, [8*rbp]
+	mov rcx, qword ptr [rbx]
+	mov rax, qword ptr [rcx]
+	dec rax
 	and rax, -8
-	sub rsi, rax
-	cmp rcx, rsi
-	jbe .LBB0_1
-	mov rdi, rbx
-	mov rsi, r15
-	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
-	jmp .LBB0_2
+	lea rsi, [r15 + 8]
+	add rsi, rax
+	mov rdx, -1
+	cmovae rdx, rsi
+	cmp rdx, qword ptr [rcx + 8]
+	ja .LBB0_0
+	mov qword ptr [rcx], rdx
+	add rax, 8
+	jne .LBB0_1
 .LBB0_0:
-	mov eax, 8
-	xor edx, edx
-	jmp .LBB0_8
+	mov esi, 8
+	mov rdi, rbx
+	mov rdx, r15
+	call bump_scope::bump_scope::BumpScope<A,_,_,_>::alloc_in_another_chunk
+	test rax, rax
+	je .LBB0_11
 .LBB0_1:
-	add rcx, rax
-	mov qword ptr [rdx], rcx
-.LBB0_2:
 	movabs rdx, 4611686018427387903
-	lea rcx, [r15 - 1]
+	lea rcx, [rbp - 1]
 	mov rdi, rcx
 	and rdi, rdx
 	cmp rdi, rcx
 	cmovae rdi, rcx
 	cmp rdi, 18
-	jbe .LBB0_3
-	lea rsi, [r15 + rdx]
+	jbe .LBB0_2
+	lea rsi, [rdx + rbp]
 	and rsi, rdx
 	cmp rsi, rcx
 	cmovae rsi, rcx
 	lea rdx, [r12 + 4*rsi]
 	add rdx, 4
 	cmp rax, rdx
-	jae .LBB0_6
+	jae .LBB0_8
 	lea rdx, [rax + 8*rsi]
 	add rdx, 8
 	cmp r12, rdx
-	jae .LBB0_6
-.LBB0_3:
+	jae .LBB0_8
+.LBB0_2:
 	xor edx, edx
 	mov rsi, r12
+.LBB0_3:
+	lea rdi, [r12 + 4*rbp]
 .LBB0_4:
-	lea rdi, [r12 + 4*r15]
-.LBB0_5:
 	mov r8, rdx
 	mov edx, dword ptr [rsi]
 	mov qword ptr [rax + 8*r8], rdx
 	lea rdx, [r8 + 1]
 	cmp rcx, r8
-	je .LBB0_8
+	je .LBB0_6
 	add rsi, 4
 	cmp rsi, rdi
-	jne .LBB0_5
-	jmp .LBB0_8
+	jne .LBB0_4
+	jmp .LBB0_6
+.LBB0_5:
+	mov eax, 8
+	xor edx, edx
 .LBB0_6:
+	lea rsi, [r12 + 4*r13]
+	mov rcx, qword ptr [rbx]
+	cmp rsi, qword ptr [rcx]
+	jne .LBB0_7
+	mov qword ptr [rcx], r12
+.LBB0_7:
+	mov qword ptr [r14], rax
+	mov qword ptr [r14 + 8], rdx
+	mov qword ptr [r14 + 16], rbp
+	mov qword ptr [r14 + 24], rbx
+	mov rax, r14
+	add rsp, 8
+	pop rbx
+	pop r12
+	pop r13
+	pop r14
+	pop r15
+	pop rbp
+	ret
+.LBB0_8:
 	inc rdi
 	movabs rdx, 9223372036854775804
 	and rdx, rdi
 	lea rsi, [r12 + 4*rdx]
 	xor r8d, r8d
 	xorps xmm0, xmm0
-.LBB0_7:
+.LBB0_9:
 	movsd xmm1, qword ptr [r12 + 4*r8]
 	movsd xmm2, qword ptr [r12 + 4*r8 + 8]
 	unpcklps xmm1, xmm0
@@ -87,35 +113,24 @@ inspect_asm::vec_map::grow:
 	movups xmmword ptr [rax + 8*r8 + 16], xmm2
 	add r8, 4
 	cmp rdx, r8
-	jne .LBB0_7
-	cmp rdi, rdx
-	jne .LBB0_4
-.LBB0_8:
-	lea rsi, [r12 + 4*r13]
-	mov rcx, qword ptr [rbx]
-	cmp rsi, qword ptr [rcx]
 	jne .LBB0_9
-	mov qword ptr [rcx], r12
-.LBB0_9:
-	mov qword ptr [r14], rax
-	mov qword ptr [r14 + 8], rdx
-	mov qword ptr [r14 + 16], rdx
-	mov qword ptr [r14 + 24], rbx
-	mov rax, r14
-	pop rbx
-	pop r12
-	pop r13
-	pop r14
-	pop r15
-	ret
+	cmp rdi, rdx
+	jne .LBB0_3
+	jmp .LBB0_6
 .LBB0_10:
-	call qword ptr [rip + bump_scope::private::capacity_overflow@GOTPCREL]
+	call qword ptr [rip + bump_scope::bump_allocator::invalid_slice_layout@GOTPCREL]
+	jmp .LBB0_12
+.LBB0_11:
+	mov edi, 8
+	mov rsi, r15
+	call qword ptr [rip + alloc::alloc::handle_alloc_error@GOTPCREL]
+.LBB0_12:
 	ud2
 	lea rdx, [r12 + 4*r13]
 	mov rcx, qword ptr [rbx]
 	cmp rdx, qword ptr [rcx]
-	jne .LBB0_11
+	jne .LBB0_13
 	mov qword ptr [rcx], r12
-.LBB0_11:
+.LBB0_13:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/vec_map/try_grow.asm
+++ b/crates/inspect-asm/out/x86-64/vec_map/try_grow.asm
@@ -6,59 +6,60 @@ inspect_asm::vec_map::try_grow:
 	push rbx
 	mov rbx, rdi
 	mov r14, qword ptr [rsi + 24]
-	mov r12, qword ptr [rsi]
-	mov r15, qword ptr [rsi + 8]
+	mov r15, qword ptr [rsi]
+	mov r12, qword ptr [rsi + 8]
 	mov r13, qword ptr [rsi + 16]
-	test r15, r15
+	test r12, r12
 	je .LBB0_7
-	mov rax, r15
+	mov rax, r12
 	shr rax, 60
 	jne .LBB0_5
-	lea rcx, [8*r15]
-	mov rdx, qword ptr [r14]
-	mov rax, qword ptr [rdx]
-	mov rsi, qword ptr [rdx + 8]
-	add rax, 7
+	lea rdx, [8*r12]
+	mov rcx, qword ptr [r14]
+	mov rax, qword ptr [rcx]
+	dec rax
 	and rax, -8
-	sub rsi, rax
-	cmp rcx, rsi
+	lea rdi, [rdx + 8]
+	add rdi, rax
+	mov rsi, -1
+	cmovae rsi, rdi
+	cmp rsi, qword ptr [rcx + 8]
 	ja .LBB0_0
-	add rcx, rax
-	mov qword ptr [rdx], rcx
-	test rax, rax
+	mov qword ptr [rcx], rsi
+	add rax, 8
 	jne .LBB0_1
 .LBB0_0:
+	mov esi, 8
 	mov rdi, r14
-	mov rsi, r15
-	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
+	call bump_scope::bump_scope::BumpScope<A,_,_,_>::alloc_in_another_chunk
 	test rax, rax
 	je .LBB0_5
 .LBB0_1:
 	movabs rdx, 4611686018427387903
-	lea rcx, [r15 - 1]
+	lea rcx, [r12 - 1]
 	mov rdi, rcx
 	and rdi, rdx
 	cmp rdi, rcx
 	cmovae rdi, rcx
 	cmp rdi, 18
 	jbe .LBB0_2
-	lea rsi, [r15 + rdx]
+	lea rsi, [r12 + rdx]
 	and rsi, rdx
 	cmp rsi, rcx
 	cmovae rsi, rcx
-	lea rdx, [r12 + 4*rsi]
+	lea rdx, [r15 + 4*rsi]
 	add rdx, 4
 	cmp rax, rdx
 	jae .LBB0_11
 	lea rdx, [rax + 8*rsi]
 	add rdx, 8
-	cmp r12, rdx
+	cmp r15, rdx
 	jae .LBB0_11
 .LBB0_2:
 	xor edx, edx
-	mov rsi, r12
+	mov rsi, r15
 .LBB0_3:
-	lea rdi, [r12 + 4*r15]
+	lea rdi, [r15 + 4*r12]
 .LBB0_4:
 	mov r8, rdx
 	mov edx, dword ptr [rsi]
@@ -71,11 +72,11 @@ inspect_asm::vec_map::try_grow:
 	jne .LBB0_4
 	jmp .LBB0_8
 .LBB0_5:
-	lea rcx, [r12 + 4*r13]
+	lea rcx, [r15 + 4*r13]
 	mov rax, qword ptr [r14]
 	cmp rcx, qword ptr [rax]
 	jne .LBB0_6
-	mov qword ptr [rax], r12
+	mov qword ptr [rax], r15
 .LBB0_6:
 	mov qword ptr [rbx], 0
 	jmp .LBB0_10
@@ -83,15 +84,15 @@ inspect_asm::vec_map::try_grow:
 	mov eax, 8
 	xor edx, edx
 .LBB0_8:
-	lea rsi, [r12 + 4*r13]
+	lea rsi, [r15 + 4*r13]
 	mov rcx, qword ptr [r14]
 	cmp rsi, qword ptr [rcx]
 	jne .LBB0_9
-	mov qword ptr [rcx], r12
+	mov qword ptr [rcx], r15
 .LBB0_9:
 	mov qword ptr [rbx], rax
 	mov qword ptr [rbx + 8], rdx
-	mov qword ptr [rbx + 16], rdx
+	mov qword ptr [rbx + 16], r12
 	mov qword ptr [rbx + 24], r14
 .LBB0_10:
 	mov rax, rbx
@@ -105,12 +106,12 @@ inspect_asm::vec_map::try_grow:
 	inc rdi
 	movabs rdx, 9223372036854775804
 	and rdx, rdi
-	lea rsi, [r12 + 4*rdx]
+	lea rsi, [r15 + 4*rdx]
 	xor r8d, r8d
 	xorps xmm0, xmm0
 .LBB0_12:
-	movsd xmm1, qword ptr [r12 + 4*r8]
-	movsd xmm2, qword ptr [r12 + 4*r8 + 8]
+	movsd xmm1, qword ptr [r15 + 4*r8]
+	movsd xmm2, qword ptr [r15 + 4*r8 + 8]
 	unpcklps xmm1, xmm0
 	unpcklps xmm2, xmm0
 	movups xmmword ptr [rax + 8*r8], xmm1
@@ -121,11 +122,11 @@ inspect_asm::vec_map::try_grow:
 	cmp rdi, rdx
 	jne .LBB0_3
 	jmp .LBB0_8
-	lea rdx, [r12 + 4*r13]
+	lea rdx, [r15 + 4*r13]
 	mov rcx, qword ptr [r14]
 	cmp rdx, qword ptr [rcx]
 	jne .LBB0_13
-	mov qword ptr [rcx], r12
+	mov qword ptr [rcx], r15
 .LBB0_13:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/out/x86-64/vec_map/try_grow.asm
+++ b/crates/inspect-asm/out/x86-64/vec_map/try_grow.asm
@@ -6,60 +6,59 @@ inspect_asm::vec_map::try_grow:
 	push rbx
 	mov rbx, rdi
 	mov r14, qword ptr [rsi + 24]
-	mov r15, qword ptr [rsi]
-	mov r12, qword ptr [rsi + 8]
+	mov r12, qword ptr [rsi]
+	mov r15, qword ptr [rsi + 8]
 	mov r13, qword ptr [rsi + 16]
-	test r12, r12
+	test r15, r15
 	je .LBB0_7
-	mov rax, r12
+	mov rax, r15
 	shr rax, 60
 	jne .LBB0_5
-	lea rdx, [8*r12]
-	mov rcx, qword ptr [r14]
-	mov rax, qword ptr [rcx]
-	dec rax
+	lea rcx, [8*r15]
+	mov rdx, qword ptr [r14]
+	mov rax, qword ptr [rdx]
+	mov rsi, qword ptr [rdx + 8]
+	add rax, 7
 	and rax, -8
-	lea rdi, [rdx + 8]
-	add rdi, rax
-	mov rsi, -1
-	cmovae rsi, rdi
-	cmp rsi, qword ptr [rcx + 8]
+	sub rsi, rax
+	cmp rcx, rsi
 	ja .LBB0_0
-	mov qword ptr [rcx], rsi
-	add rax, 8
+	add rcx, rax
+	mov qword ptr [rdx], rcx
+	test rax, rax
 	jne .LBB0_1
 .LBB0_0:
-	mov esi, 8
 	mov rdi, r14
-	call bump_scope::bump_scope::BumpScope<A,_,_,_>::alloc_in_another_chunk
+	mov rsi, r15
+	call bump_scope::bump_scope::BumpScope<A,_,_,_>::do_alloc_slice_in_another_chunk
 	test rax, rax
 	je .LBB0_5
 .LBB0_1:
 	movabs rdx, 4611686018427387903
-	lea rcx, [r12 - 1]
+	lea rcx, [r15 - 1]
 	mov rdi, rcx
 	and rdi, rdx
 	cmp rdi, rcx
 	cmovae rdi, rcx
 	cmp rdi, 18
 	jbe .LBB0_2
-	lea rsi, [r12 + rdx]
+	lea rsi, [r15 + rdx]
 	and rsi, rdx
 	cmp rsi, rcx
 	cmovae rsi, rcx
-	lea rdx, [r15 + 4*rsi]
+	lea rdx, [r12 + 4*rsi]
 	add rdx, 4
 	cmp rax, rdx
 	jae .LBB0_11
 	lea rdx, [rax + 8*rsi]
 	add rdx, 8
-	cmp r15, rdx
+	cmp r12, rdx
 	jae .LBB0_11
 .LBB0_2:
 	xor edx, edx
-	mov rsi, r15
+	mov rsi, r12
 .LBB0_3:
-	lea rdi, [r15 + 4*r12]
+	lea rdi, [r12 + 4*r15]
 .LBB0_4:
 	mov r8, rdx
 	mov edx, dword ptr [rsi]
@@ -72,11 +71,11 @@ inspect_asm::vec_map::try_grow:
 	jne .LBB0_4
 	jmp .LBB0_8
 .LBB0_5:
-	lea rcx, [r15 + 4*r13]
+	lea rcx, [r12 + 4*r13]
 	mov rax, qword ptr [r14]
 	cmp rcx, qword ptr [rax]
 	jne .LBB0_6
-	mov qword ptr [rax], r15
+	mov qword ptr [rax], r12
 .LBB0_6:
 	mov qword ptr [rbx], 0
 	jmp .LBB0_10
@@ -84,15 +83,15 @@ inspect_asm::vec_map::try_grow:
 	mov eax, 8
 	xor edx, edx
 .LBB0_8:
-	lea rsi, [r15 + 4*r13]
+	lea rsi, [r12 + 4*r13]
 	mov rcx, qword ptr [r14]
 	cmp rsi, qword ptr [rcx]
 	jne .LBB0_9
-	mov qword ptr [rcx], r15
+	mov qword ptr [rcx], r12
 .LBB0_9:
 	mov qword ptr [rbx], rax
 	mov qword ptr [rbx + 8], rdx
-	mov qword ptr [rbx + 16], r12
+	mov qword ptr [rbx + 16], r15
 	mov qword ptr [rbx + 24], r14
 .LBB0_10:
 	mov rax, rbx
@@ -106,12 +105,12 @@ inspect_asm::vec_map::try_grow:
 	inc rdi
 	movabs rdx, 9223372036854775804
 	and rdx, rdi
-	lea rsi, [r15 + 4*rdx]
+	lea rsi, [r12 + 4*rdx]
 	xor r8d, r8d
 	xorps xmm0, xmm0
 .LBB0_12:
-	movsd xmm1, qword ptr [r15 + 4*r8]
-	movsd xmm2, qword ptr [r15 + 4*r8 + 8]
+	movsd xmm1, qword ptr [r12 + 4*r8]
+	movsd xmm2, qword ptr [r12 + 4*r8 + 8]
 	unpcklps xmm1, xmm0
 	unpcklps xmm2, xmm0
 	movups xmmword ptr [rax + 8*r8], xmm1
@@ -122,11 +121,11 @@ inspect_asm::vec_map::try_grow:
 	cmp rdi, rdx
 	jne .LBB0_3
 	jmp .LBB0_8
-	lea rdx, [r15 + 4*r13]
+	lea rdx, [r12 + 4*r13]
 	mov rcx, qword ptr [r14]
 	cmp rdx, qword ptr [rcx]
 	jne .LBB0_13
-	mov qword ptr [rcx], r15
+	mov qword ptr [rcx], r12
 .LBB0_13:
 	mov rdi, rax
 	call _Unwind_Resume@PLT

--- a/crates/inspect-asm/src/lib.rs
+++ b/crates/inspect-asm/src/lib.rs
@@ -713,30 +713,32 @@ pub mod alloc_fmt {
 }
 
 pub mod vec_map {
-    use bump_scope::{allocator_api2::alloc::AllocError, BumpVec};
+    use bump_scope::{allocator_api2::alloc::AllocError, Bump};
     use std::num::NonZeroU32;
 
-    pub fn same<'b, 'a>(vec: BumpVec<'b, 'a, u32>) -> BumpVec<'b, 'a, Option<NonZeroU32>> {
+    type BumpVec<'a, T> = bump_scope::BumpVec<T, &'a Bump>;
+
+    pub fn same(vec: BumpVec<u32>) -> BumpVec<Option<NonZeroU32>> {
         vec.map(NonZeroU32::new)
     }
 
-    pub fn try_same<'b, 'a>(vec: BumpVec<'b, 'a, u32>) -> Result<BumpVec<'b, 'a, Option<NonZeroU32>>, AllocError> {
+    pub fn try_same(vec: BumpVec<u32>) -> Result<BumpVec<Option<NonZeroU32>>, AllocError> {
         vec.try_map(NonZeroU32::new)
     }
 
-    pub fn grow<'b, 'a>(vec: BumpVec<'b, 'a, u32>) -> BumpVec<'b, 'a, u64> {
+    pub fn grow(vec: BumpVec<u32>) -> BumpVec<u64> {
         vec.map(|i| i as _)
     }
 
-    pub fn try_grow<'b, 'a>(vec: BumpVec<'b, 'a, u32>) -> Result<BumpVec<'b, 'a, u64>, AllocError> {
+    pub fn try_grow(vec: BumpVec<u32>) -> Result<BumpVec<u64>, AllocError> {
         vec.try_map(|i| i as _)
     }
 
-    pub fn shrink<'b, 'a>(vec: BumpVec<'b, 'a, u64>) -> BumpVec<'b, 'a, u32> {
+    pub fn shrink(vec: BumpVec<u64>) -> BumpVec<u32> {
         vec.map(|i| i as _)
     }
 
-    pub fn try_shrink<'b, 'a>(vec: BumpVec<'b, 'a, u64>) -> Result<BumpVec<'b, 'a, u32>, AllocError> {
+    pub fn try_shrink(vec: BumpVec<u64>) -> Result<BumpVec<u32>, AllocError> {
         vec.try_map(|i| i as _)
     }
 }

--- a/crates/inspect-asm/src/lib.rs
+++ b/crates/inspect-asm/src/lib.rs
@@ -25,7 +25,7 @@ trait BumpaloExt {
 }
 
 type Bump<const MIN_ALIGN: usize, const UP: bool> = bump_scope::Bump<Global, MIN_ALIGN, UP>;
-type MutBumpVec<'a, T, const MIN_ALIGN: usize, const UP: bool> = bump_scope::MutBumpVec<T, &'a Bump<MIN_ALIGN, UP>>;
+type MutBumpVec<'a, T, const MIN_ALIGN: usize, const UP: bool> = bump_scope::MutBumpVec<T, &'a mut Bump<MIN_ALIGN, UP>>;
 type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize, const UP: bool> =
     bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, UP>;
 

--- a/crates/inspect-asm/src/lib.rs
+++ b/crates/inspect-asm/src/lib.rs
@@ -26,8 +26,8 @@ trait BumpaloExt {
 
 type Bump<const MIN_ALIGN: usize, const UP: bool> = bump_scope::Bump<Global, MIN_ALIGN, UP>;
 type MutBumpVec<'a, T, const MIN_ALIGN: usize, const UP: bool> = bump_scope::MutBumpVec<T, &'a mut Bump<MIN_ALIGN, UP>>;
-type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize, const UP: bool> =
-    bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, UP>;
+type MutBumpVecRev<'a, T, const MIN_ALIGN: usize, const UP: bool> =
+    bump_scope::MutBumpVecRev<T, &'a mut Bump<MIN_ALIGN, UP>>;
 
 impl BumpaloExt for bumpalo::Bump {
     fn try_alloc_str(&self, value: &str) -> Result<&mut str, bumpalo::AllocErr> {

--- a/crates/inspect-asm/src/lib.rs
+++ b/crates/inspect-asm/src/lib.rs
@@ -25,8 +25,7 @@ trait BumpaloExt {
 }
 
 type Bump<const MIN_ALIGN: usize, const UP: bool> = bump_scope::Bump<Global, MIN_ALIGN, UP>;
-type MutBumpVec<'b, 'a, T, const MIN_ALIGN: usize, const UP: bool> =
-    bump_scope::MutBumpVec<'b, 'a, T, Global, MIN_ALIGN, UP>;
+type MutBumpVec<'a, T, const MIN_ALIGN: usize, const UP: bool> = bump_scope::MutBumpVec<T, &'a Bump<MIN_ALIGN, UP>>;
 type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize, const UP: bool> =
     bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, UP>;
 

--- a/crates/test-fallibility/Cargo.lock
+++ b/crates/test-fallibility/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "bump-scope"
-version = "0.10.11"
+version = "0.11.0-dev"
 dependencies = [
  "allocator-api2",
  "sptr",

--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -18,8 +18,8 @@ macro_rules! type_definitions {
         type BumpScope<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScope<'a, Global, MIN_ALIGN, $up>;
         type BumpScopeGuard<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuard<'a, Global, MIN_ALIGN, $up>;
         type BumpScopeGuardRoot<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuardRoot<'a, Global, MIN_ALIGN, $up>;
-        type BumpVec<'b, 'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<'b, 'a, T, Global, MIN_ALIGN, $up>;
-        type BumpString<'b, 'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpString<'b, 'a, Global, MIN_ALIGN, $up>;
+        type BumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<T, &'a Bump>;
+        type BumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpString<&'a Bump>;
         type MutBumpVec<'b, 'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<'b, 'a, T, Global, MIN_ALIGN, $up>;
         type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize = 1> =
             bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, $up>;
@@ -342,11 +342,11 @@ up_and_down! {
         vec.try_extend_zeroed(additional)
     }
 
-    pub fn BumpVec_try_from_iter_in<'a>(iter: core::slice::Iter<u32>, bump: &'a Bump) -> Result<BumpVec<'a, 'a, u32>> {
+    pub fn BumpVec_try_from_iter_in<'a>(iter: core::slice::Iter<u32>, bump: &'a Bump) -> Result<BumpVec<'a, u32>> {
         BumpVec::try_from_iter_in(iter.copied(), bump)
     }
 
-    pub fn BumpVec_try_from_iter_exact_in<'a>(iter: core::slice::Iter<u32>, bump: &'a Bump) -> Result<BumpVec<'a, 'a, u32>> {
+    pub fn BumpVec_try_from_iter_exact_in<'a>(iter: core::slice::Iter<u32>, bump: &'a Bump) -> Result<BumpVec<'a, u32>> {
         BumpVec::try_from_iter_exact_in(iter.copied(), bump)
     }
 
@@ -382,11 +382,11 @@ up_and_down! {
         BumpVec::try_with_capacity_in(capacity, bump)
     }
 
-    pub fn BumpVec_try_map<'b, 'a>(bump: BumpVec<'b, 'a, u32>, f: fn(u32) -> i16) -> Result<BumpVec<'b, 'a, i16>> {
+    pub fn BumpVec_try_map(bump: BumpVec<u32>, f: fn(u32) -> i16) -> Result<BumpVec<i16>> {
         bump.try_map(f)
     }
 
-    pub fn BumpString__try_from_str_in<'b>(string: &str, bump: &'b Bump) -> Result<BumpString<'b, 'b>> {
+    pub fn BumpString__try_from_str_in<'a>(string: &str, bump: &'a Bump) -> Result<BumpString<'a>> {
         BumpString::try_from_str_in(string, bump)
     }
 

--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -20,10 +20,9 @@ macro_rules! type_definitions {
         type BumpScopeGuardRoot<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuardRoot<'a, Global, MIN_ALIGN, $up>;
         type BumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<T, &'a Bump>;
         type BumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpString<&'a Bump>;
-        type MutBumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<T, &'a mut Bump>;
-        type MutBumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpString<&'a mut Bump>;
-        type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize = 1> =
-            bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, $up>;
+        type MutBumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<T, &'a mut Bump<MIN_ALIGN>>;
+        type MutBumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpString<&'a mut Bump<MIN_ALIGN>>;
+        type MutBumpVecRev<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVecRev<T, &'a mut Bump<MIN_ALIGN>>;
     };
 }
 
@@ -266,7 +265,7 @@ up_and_down! {
         vec.try_extend_from_slice_copy(slice)
     }
 
-    pub fn MutBumpVecRev_try_from_iter_in<'a>(iter: core::slice::Iter<u32>, bump: &'a mut Bump) -> Result<MutBumpVecRev<'a, 'a, u32>> {
+    pub fn MutBumpVecRev_try_from_iter_in<'a>(iter: core::slice::Iter<u32>, bump: &'a mut Bump) -> Result<MutBumpVecRev<'a, u32>> {
         MutBumpVecRev::try_from_iter_in(iter.copied(), bump)
     }
 

--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -20,8 +20,8 @@ macro_rules! type_definitions {
         type BumpScopeGuardRoot<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuardRoot<'a, Global, MIN_ALIGN, $up>;
         type BumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<T, &'a Bump>;
         type BumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpString<&'a Bump>;
-        type MutBumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<T, &'a Bump>;
-        type MutBumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpString<&'a Bump>;
+        type MutBumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<T, &'a mut Bump>;
+        type MutBumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpString<&'a mut Bump>;
         type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize = 1> =
             bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, $up>;
     };

--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -20,10 +20,10 @@ macro_rules! type_definitions {
         type BumpScopeGuardRoot<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuardRoot<'a, Global, MIN_ALIGN, $up>;
         type BumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<T, &'a Bump>;
         type BumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpString<&'a Bump>;
-        type MutBumpVec<'b, 'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<'b, 'a, T, Global, MIN_ALIGN, $up>;
+        type MutBumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<T, &'a Bump>;
+        type MutBumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpString<&'a Bump>;
         type MutBumpVecRev<'b, 'a, T, const MIN_ALIGN: usize = 1> =
             bump_scope::MutBumpVecRev<'b, 'a, T, Global, MIN_ALIGN, $up>;
-        type MutBumpString<'b, 'a, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpString<'b, 'a, Global, MIN_ALIGN, $up>;
     };
 }
 
@@ -218,7 +218,7 @@ up_and_down! {
         vec.try_extend_zeroed(additional)
     }
 
-    pub fn MutBumpVec_try_from_iter_in<'a>(iter: core::slice::Iter<u32>, bump: &'a mut Bump) -> Result<MutBumpVec<'a, 'a, u32>> {
+    pub fn MutBumpVec_try_from_iter_in<'a>(iter: core::slice::Iter<u32>, bump: &'a mut Bump) -> Result<MutBumpVec<'a, u32>> {
         MutBumpVec::try_from_iter_in(iter.copied(), bump)
     }
 
@@ -302,7 +302,7 @@ up_and_down! {
         MutBumpVecRev::try_with_capacity_in(capacity, bump)
     }
 
-    pub fn MutBumpString__try_from_str_in<'b>(string: &str, bump: &'b mut Bump) -> Result<MutBumpString<'b, 'b>> {
+    pub fn MutBumpString__try_from_str_in<'b>(string: &str, bump: &'b mut Bump) -> Result<MutBumpString<'b>> {
         MutBumpString::try_from_str_in(string, bump)
     }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "bump-scope"
-version = "0.10.11"
+version = "0.11.0-dev"
 dependencies = [
  "allocator-api2",
  "sptr",

--- a/justfile
+++ b/justfile
@@ -76,4 +76,4 @@ test-fallibility:
   @ just crates/test-fallibility/test
 
 inspect-asm *args:
-  just crates/inspect-asm/inspect {{args}}
+  just crates/inspect-asm/inspect-asm {{args}}

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ check-fmt:
   cd fuzz; cargo fmt --check
 
 check-clippy:
-  cargo clippy --tests
+  cargo clippy --tests --all-features
   cargo clippy --tests --no-default-features
   cargo clippy --tests --no-default-features --features alloc
   cd crates/fuzzing-support; cargo clippy --tests

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ export RUST_BACKTRACE := "1"
 export MIRIFLAGS := "-Zmiri-strict-provenance"
 
 default:
-  just --list
+  @just --list
 
 pre-release:
   # TODO: fix issues

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -46,6 +46,43 @@ where
 }
 
 unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Allocator
+    for &mut BumpScope<'_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    #[inline(always)]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        BumpScope::allocate(self, layout)
+    }
+
+    #[inline(always)]
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        BumpScope::deallocate(self, ptr, layout);
+    }
+
+    #[inline(always)]
+    unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        BumpScope::grow(self, ptr, old_layout, new_layout)
+    }
+
+    #[inline(always)]
+    unsafe fn grow_zeroed(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        BumpScope::grow_zeroed(self, ptr, old_layout, new_layout)
+    }
+
+    #[inline(always)]
+    unsafe fn shrink(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        BumpScope::shrink(self, ptr, old_layout, new_layout)
+    }
+}
+
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Allocator
     for Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
@@ -79,6 +116,43 @@ where
     #[inline(always)]
     unsafe fn shrink(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.as_scope().shrink(ptr, old_layout, new_layout)
+    }
+}
+
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Allocator
+    for &mut Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    #[inline(always)]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Bump::allocate(self, layout)
+    }
+
+    #[inline(always)]
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        Bump::deallocate(self, ptr, layout);
+    }
+
+    #[inline(always)]
+    unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Bump::grow(self, ptr, old_layout, new_layout)
+    }
+
+    #[inline(always)]
+    unsafe fn grow_zeroed(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        Bump::grow_zeroed(self, ptr, old_layout, new_layout)
+    }
+
+    #[inline(always)]
+    unsafe fn shrink(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Bump::shrink(self, ptr, old_layout, new_layout)
     }
 }
 

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -35,7 +35,7 @@ pub unsafe trait BumpAllocator: Allocator {
     }
 
     /// A specialized version of `allocate`.
-    fn allocate_sized<T>(&self) -> NonNull<u8>
+    fn allocate_sized<T>(&self) -> NonNull<T>
     where
         Self: Sized,
     {
@@ -48,7 +48,7 @@ pub unsafe trait BumpAllocator: Allocator {
     }
 
     /// A specialized version of `allocate`.
-    fn try_allocate_sized<T>(&self) -> Result<NonNull<u8>, AllocError>
+    fn try_allocate_sized<T>(&self) -> Result<NonNull<T>, AllocError>
     where
         Self: Sized,
     {
@@ -59,7 +59,7 @@ pub unsafe trait BumpAllocator: Allocator {
     }
 
     /// A specialized version of `allocate`.
-    fn allocate_slice<T>(&self, len: usize) -> NonNull<u8>
+    fn allocate_slice<T>(&self, len: usize) -> NonNull<T>
     where
         Self: Sized,
     {
@@ -75,7 +75,7 @@ pub unsafe trait BumpAllocator: Allocator {
     }
 
     /// A specialized version of `allocate`.
-    fn try_allocate_slice<T>(&self, len: usize) -> Result<NonNull<u8>, AllocError>
+    fn try_allocate_slice<T>(&self, len: usize) -> Result<NonNull<T>, AllocError>
     where
         Self: Sized,
     {

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -1,5 +1,5 @@
+use alloc::alloc::handle_alloc_error;
 use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
-use std::alloc::handle_alloc_error;
 
 use allocator_api2::alloc::{AllocError, Allocator};
 

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -7,7 +7,10 @@ use crate::{BaseAllocator, Bump, BumpScope, MinimumAlignment, SupportedMinimumAl
 /// This trait is used for [`BumpBox::into_box`][into_box] to allow safely converting a `BumpBox` into a `Box`.
 ///
 /// # Safety
-/// - `grow(_zeroed)`, `shrink` and `deallocate` must be ok to be called with a pointer that was not allocated by this Allocator
+///
+/// This trait must only be implemented when
+/// - `grow(_zeroed)`, `shrink` and `deallocate` can be called with a pointer that was not allocated by this Allocator
+/// - `deallocate` can be called with any pointer or alignment when the size is `0`
 ///
 /// [into_box]: crate::BumpBox::into_box
 pub unsafe trait BumpAllocator: Allocator {}
@@ -24,6 +27,45 @@ where
 
 unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocator
     for Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+/// An allocator that makes allocations with a lifetime of `'a`.
+///
+/// # Safety
+///
+/// This trait must only be implemented when allocations live for `'a`.
+/// In other words this function must be sound:
+///
+/// ```
+/// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
+/// # #![allow(dead_code)]
+/// use bump_scope::BumpAllocatorScope;
+/// use core::alloc::Layout;
+///
+/// fn allocate_zeroed_bytes<'a>(allocator: impl BumpAllocatorScope<'a>, len: usize) -> &'a [u8] {
+///     let layout = Layout::array::<u8>(len).unwrap();
+///     let ptr = allocator.allocate_zeroed(layout).unwrap();
+///     unsafe { ptr.as_ref() }
+/// }
+/// ```
+pub unsafe trait BumpAllocatorScope<'a>: BumpAllocator {}
+
+unsafe impl<'a, A: BumpAllocatorScope<'a>> BumpAllocatorScope<'a> for &A {}
+
+unsafe impl<'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorScope<'a>
+    for BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+unsafe impl<'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorScope<'a>
+    for &'a Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator<GUARANTEED_ALLOCATED>,

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -141,15 +141,11 @@ pub unsafe trait BumpAllocator: Allocator {
         None
     }
 
-    /// Returns `true` if this allocator has an optimized `allocate` version in
-    /// <code>([try_][try_allocate_slice_greedy])[mut_allocate_slice][allocate_slice_greedy])</code>.
+    /// Returns `true` if this allocator is exclusive.
     ///
-    /// If `false`, then <code>([try_][try_allocate_slice_greedy])[mut_allocate_slice][allocate_slice_greedy])</code>
-    /// must not be manually implemented.
-    ///
-    /// [allocate_slice_greedy]: Self::allocate_slice_greedy
-    /// [try_allocate_slice_greedy]: Self::try_allocate_slice_greedy
-    fn supports_greedy_allocations(&self) -> bool {
+    /// In practice this means that this is a `Bump(Scope)` or a `&mut Bump(Scope)`. A `&Bump(Scope)` or a `Rc<Bump>`
+    /// will not be an exclusive allocator.
+    fn is_exclusive_allocator(&self) -> bool {
         false
     }
 
@@ -368,7 +364,7 @@ where
     }
 
     #[inline(always)]
-    fn supports_greedy_allocations(&self) -> bool {
+    fn is_exclusive_allocator(&self) -> bool {
         true
     }
 
@@ -457,8 +453,8 @@ where
     }
 
     #[inline(always)]
-    fn supports_greedy_allocations(&self) -> bool {
-        self.as_scope().supports_greedy_allocations()
+    fn is_exclusive_allocator(&self) -> bool {
+        self.as_scope().is_exclusive_allocator()
     }
 
     #[inline(always)]
@@ -533,8 +529,8 @@ where
     }
 
     #[inline(always)]
-    fn supports_greedy_allocations(&self) -> bool {
-        BumpScope::supports_greedy_allocations(self)
+    fn is_exclusive_allocator(&self) -> bool {
+        BumpScope::is_exclusive_allocator(self)
     }
 
     #[inline(always)]
@@ -609,8 +605,8 @@ where
     }
 
     #[inline(always)]
-    fn supports_greedy_allocations(&self) -> bool {
-        Bump::supports_greedy_allocations(self)
+    fn is_exclusive_allocator(&self) -> bool {
+        Bump::is_exclusive_allocator(self)
     }
 
     #[inline(always)]

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -478,6 +478,158 @@ where
     }
 }
 
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocator
+    for &mut BumpScope<'_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    #[inline(always)]
+    fn allocate_layout(&self, layout: Layout) -> NonNull<u8> {
+        BumpScope::allocate_layout(self, layout)
+    }
+
+    #[inline(always)]
+    fn try_allocate_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        BumpScope::try_allocate_layout(self, layout)
+    }
+
+    #[inline(always)]
+    fn allocate_sized<T>(&self) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        BumpScope::allocate_sized(self)
+    }
+
+    #[inline(always)]
+    fn try_allocate_sized<T>(&self) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        BumpScope::try_allocate_sized(self)
+    }
+
+    #[inline(always)]
+    #[cfg(not(no_global_oom_handling))]
+    fn allocate_slice<T>(&self, len: usize) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        BumpScope::allocate_slice(self, len)
+    }
+
+    #[inline(always)]
+    fn try_allocate_slice<T>(&self, len: usize) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        BumpScope::try_allocate_slice(self, len)
+    }
+
+    #[inline(always)]
+    unsafe fn allocate_slice_greedy<T>(&mut self, len: usize) -> NonNull<[T]>
+    where
+        Self: Sized,
+    {
+        BumpScope::allocate_slice_greedy(self, len)
+    }
+
+    #[inline(always)]
+    unsafe fn try_allocate_slice_greedy<T>(&mut self, len: usize) -> Result<NonNull<[T]>, AllocError>
+    where
+        Self: Sized,
+    {
+        BumpScope::try_allocate_slice_greedy(self, len)
+    }
+
+    #[inline(always)]
+    unsafe fn shrink_slice<T>(&self, ptr: NonNull<T>, old_len: usize, new_len: usize) -> Option<NonNull<T>> {
+        BumpScope::shrink_slice(self, ptr, old_len, new_len)
+    }
+
+    #[inline(always)]
+    fn supports_greedy_allocations(&self) -> bool {
+        BumpScope::supports_greedy_allocations(self)
+    }
+}
+
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocator
+    for &mut Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+    #[inline(always)]
+    fn allocate_layout(&self, layout: Layout) -> NonNull<u8> {
+        Bump::allocate_layout(self, layout)
+    }
+
+    #[inline(always)]
+    fn try_allocate_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Bump::try_allocate_layout(self, layout)
+    }
+
+    #[inline(always)]
+    fn allocate_sized<T>(&self) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        Bump::allocate_sized(self)
+    }
+
+    #[inline(always)]
+    fn try_allocate_sized<T>(&self) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        Bump::try_allocate_sized(self)
+    }
+
+    #[inline(always)]
+    #[cfg(not(no_global_oom_handling))]
+    fn allocate_slice<T>(&self, len: usize) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        Bump::allocate_slice(self, len)
+    }
+
+    #[inline(always)]
+    fn try_allocate_slice<T>(&self, len: usize) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        Bump::try_allocate_slice(self, len)
+    }
+
+    #[inline(always)]
+    unsafe fn allocate_slice_greedy<T>(&mut self, len: usize) -> NonNull<[T]>
+    where
+        Self: Sized,
+    {
+        Bump::allocate_slice_greedy(self, len)
+    }
+
+    #[inline(always)]
+    unsafe fn try_allocate_slice_greedy<T>(&mut self, len: usize) -> Result<NonNull<[T]>, AllocError>
+    where
+        Self: Sized,
+    {
+        Bump::try_allocate_slice_greedy(self, len)
+    }
+
+    #[inline(always)]
+    unsafe fn shrink_slice<T>(&self, ptr: NonNull<T>, old_len: usize, new_len: usize) -> Option<NonNull<T>> {
+        Bump::shrink_slice(self, ptr, old_len, new_len)
+    }
+
+    #[inline(always)]
+    fn supports_greedy_allocations(&self) -> bool {
+        Bump::supports_greedy_allocations(self)
+    }
+}
+
 /// An allocator that makes allocations with a lifetime of `'a`.
 ///
 /// # Safety
@@ -511,6 +663,22 @@ where
 
 unsafe impl<'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorScope<'a>
     for &'a Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+unsafe impl<'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorScope<'a>
+    for &mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+where
+    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
+{
+}
+
+unsafe impl<'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorScope<'a>
+    for &'a mut Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator<GUARANTEED_ALLOCATED>,

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -329,7 +329,7 @@ where
 
     #[inline(always)]
     fn has_mut_optimizations(&self) -> bool {
-        false
+        true
     }
 }
 
@@ -339,11 +339,75 @@ where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
+    #[inline(always)]
+    fn allocate_layout(&self, layout: Layout) -> NonNull<u8> {
+        self.as_scope().allocate_layout(layout)
+    }
+
+    #[inline(always)]
+    fn try_allocate_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        self.as_scope().try_allocate_layout(layout)
+    }
+
+    #[inline(always)]
+    fn allocate_sized<T>(&self) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        self.as_scope().allocate_sized()
+    }
+
+    #[inline(always)]
+    fn try_allocate_sized<T>(&self) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        self.as_scope().try_allocate_sized()
+    }
+
+    #[inline(always)]
+    fn allocate_slice<T>(&self, len: usize) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        self.as_scope().allocate_slice(len)
+    }
+
+    #[inline(always)]
+    fn try_allocate_slice<T>(&self, len: usize) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        self.as_scope().try_allocate_slice(len)
+    }
+
+    #[inline(always)]
+    unsafe fn mut_allocate_slice<T>(&mut self, len: usize) -> NonNull<[T]>
+    where
+        Self: Sized,
+    {
+        self.as_mut_scope().mut_allocate_slice(len)
+    }
+
+    #[inline(always)]
+    unsafe fn try_mut_allocate_slice<T>(&mut self, len: usize) -> Result<NonNull<[T]>, AllocError>
+    where
+        Self: Sized,
+    {
+        self.as_mut_scope().try_mut_allocate_slice(len)
+    }
+
+    #[inline(always)]
     unsafe fn shrink_slice<T>(&self, ptr: NonNull<T>, old_len: usize, new_len: usize) -> Option<NonNull<T>>
     where
         Self: Sized,
     {
         self.as_scope().shrink_slice(ptr, old_len, new_len)
+    }
+
+    #[inline(always)]
+    fn has_mut_optimizations(&self) -> bool {
+        self.as_scope().has_mut_optimizations()
     }
 }
 

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -1,9 +1,12 @@
-use core::{alloc::Layout, ptr::NonNull};
+use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
 use std::alloc::handle_alloc_error;
 
 use allocator_api2::alloc::{AllocError, Allocator};
 
-use crate::{BaseAllocator, Bump, BumpScope, MinimumAlignment, SupportedMinimumAlignment};
+use crate::{
+    bump_down, polyfill::nonnull, raw_fixed_bump_vec::RawFixedBumpVec, up_align_usize_unchecked, BaseAllocator, Bump,
+    BumpScope, MinimumAlignment, SizedTypeProperties, SupportedMinimumAlignment,
+};
 
 /// An allocator that allows `grow(_zeroed)`, `shrink` and `deallocate` calls with pointers that were not allocated by this allocator.
 ///
@@ -14,6 +17,7 @@ use crate::{BaseAllocator, Bump, BumpScope, MinimumAlignment, SupportedMinimumAl
 /// This trait must only be implemented when
 /// - `grow(_zeroed)`, `shrink` and `deallocate` can be called with a pointer that was not allocated by this Allocator
 /// - `deallocate` can be called with any pointer or alignment when the size is `0`
+/// - `shrink` does not error
 ///
 /// [into_box]: crate::BumpBox::into_box
 #[allow(clippy::missing_errors_doc)]
@@ -89,9 +93,73 @@ pub unsafe trait BumpAllocator: Allocator {
             Err(err) => Err(err),
         }
     }
+
+    /// Returns whether this memory block is the last allocation.
+    fn is_last_allocation(&self, allocation: NonNull<[u8]>) -> bool {
+        _ = allocation;
+        false
+    }
+
+    /// TODO
+    fn shrink_to_fit<T>(&self, vec: &mut RawFixedBumpVec<T>) {
+        _ = vec;
+        todo!()
+    }
 }
 
-unsafe impl<A: BumpAllocator> BumpAllocator for &A {}
+unsafe impl<A: BumpAllocator> BumpAllocator for &A {
+    #[inline(always)]
+    fn allocate_layout(&self, layout: Layout) -> NonNull<u8> {
+        A::allocate_layout(self, layout)
+    }
+
+    #[inline(always)]
+    fn try_allocate_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        A::try_allocate_layout(self, layout)
+    }
+
+    #[inline(always)]
+    fn allocate_sized<T>(&self) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        A::allocate_sized(self)
+    }
+
+    #[inline(always)]
+    fn try_allocate_sized<T>(&self) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        A::try_allocate_sized(self)
+    }
+
+    #[inline(always)]
+    fn allocate_slice<T>(&self, len: usize) -> NonNull<T>
+    where
+        Self: Sized,
+    {
+        A::allocate_slice(self, len)
+    }
+
+    #[inline(always)]
+    fn try_allocate_slice<T>(&self, len: usize) -> Result<NonNull<T>, AllocError>
+    where
+        Self: Sized,
+    {
+        A::try_allocate_slice(self, len)
+    }
+
+    #[inline(always)]
+    fn is_last_allocation(&self, allocation: NonNull<[u8]>) -> bool {
+        A::is_last_allocation(self, allocation)
+    }
+
+    #[inline(always)]
+    fn shrink_to_fit<T>(&self, vec: &mut RawFixedBumpVec<T>) {
+        A::shrink_to_fit(self, vec);
+    }
+}
 
 unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocator
     for BumpScope<'_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
@@ -99,6 +167,70 @@ where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
+    #[inline(always)]
+    fn is_last_allocation(&self, allocation: NonNull<[u8]>) -> bool {
+        unsafe {
+            let size = allocation.len();
+            let start = allocation.cast::<u8>().as_ptr();
+            let end = unsafe { start.add(size) };
+
+            if UP {
+                end == self.chunk.get().pos().as_ptr()
+            } else {
+                start == self.chunk.get().pos().as_ptr()
+            }
+        }
+    }
+
+    fn shrink_to_fit<T>(&self, vec: &mut RawFixedBumpVec<T>) {
+        let old_ptr = vec.initialized.ptr.cast::<u8>();
+        let old_size = vec.capacity * T::SIZE; // we already allocated that amount so this can't overflow
+        let new_size = vec.len() * T::SIZE; // its less than the capacity so this can't overflow
+
+        // Adapted from `Allocator::shrink`.
+        unsafe {
+            let is_last = if UP {
+                old_ptr.as_ptr().add(old_size) == self.chunk.get().pos().as_ptr()
+            } else {
+                old_ptr == self.chunk.get().pos()
+            };
+
+            // if that's not the last allocation, there is nothing we can do
+            if !is_last {
+                return;
+            }
+
+            if UP {
+                let end = nonnull::addr(old_ptr).get() + new_size;
+
+                // Up-aligning a pointer inside a chunk by `MIN_ALIGN` never overflows.
+                let new_pos = up_align_usize_unchecked(end, MIN_ALIGN);
+
+                self.chunk.get().set_pos_addr(new_pos);
+            } else {
+                let old_addr = nonnull::addr(old_ptr);
+                let old_addr_old_end = NonZeroUsize::new_unchecked(old_addr.get() + old_size);
+
+                let new_addr = bump_down(old_addr_old_end, new_size, T::ALIGN.max(MIN_ALIGN));
+                let new_addr = NonZeroUsize::new_unchecked(new_addr);
+                let old_addr_new_end = NonZeroUsize::new_unchecked(old_addr.get() + new_size);
+
+                let new_ptr = nonnull::with_addr(old_ptr, new_addr);
+                let overlaps = old_addr_new_end > new_addr;
+
+                if overlaps {
+                    nonnull::copy(old_ptr, new_ptr, new_size);
+                } else {
+                    nonnull::copy_nonoverlapping(old_ptr, new_ptr, new_size);
+                }
+
+                self.chunk.get().set_pos(new_ptr);
+                nonnull::set_ptr(&mut vec.initialized.ptr, new_ptr.cast());
+            }
+
+            vec.capacity = vec.len();
+        }
+    }
 }
 
 unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocator
@@ -107,6 +239,15 @@ where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
+    #[inline(always)]
+    fn is_last_allocation(&self, allocation: NonNull<[u8]>) -> bool {
+        self.as_scope().is_last_allocation(allocation)
+    }
+
+    #[inline(always)]
+    fn shrink_to_fit<T>(&self, vec: &mut RawFixedBumpVec<T>) {
+        self.as_scope().shrink_to_fit(vec);
+    }
 }
 
 /// An allocator that makes allocations with a lifetime of `'a`.

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -154,33 +154,17 @@ pub unsafe trait BumpAllocator: Allocator {
     where
         Self: Sized,
     {
-        #[cfg(not(no_global_oom_handling))]
-        {
-            let ptr = self.allocate_slice(len);
-            nonnull::slice_from_raw_parts(ptr, len)
-        }
-
-        #[cfg(no_global_oom_handling)]
-        {
-            _ = len;
-            unreachable!()
-        }
+        _ = len;
+        panic!("`prepare_slice_allocation` is not usable when `is_exclusive_allocator` is false")
     }
 
-    /// A specialized version of `allocate`.
-    ///
-    /// # Safety
-    ///
-    /// The caller must behave as if this function returned a `&mut [u8]` in the sense that
-    /// the allocator is mutably borrowed while the memory block is live.
+    /// Does not allocate, just returns a slice of `T` that are currently available.
     unsafe fn try_prepare_slice_allocation<T>(&mut self, len: usize) -> Result<NonNull<[T]>, AllocError>
     where
         Self: Sized,
     {
-        match self.try_allocate_slice(len) {
-            Ok(ptr) => Ok(nonnull::slice_from_raw_parts(ptr, len)),
-            Err(err) => Err(err),
-        }
+        _ = len;
+        panic!("`try_prepare_slice_allocation` is not usable when `is_exclusive_allocator` is false")
     }
 }
 
@@ -525,7 +509,7 @@ where
 
     #[inline(always)]
     fn is_exclusive_allocator(&self) -> bool {
-        BumpScope::is_exclusive_allocator(self)
+        true
     }
 
     #[inline(always)]
@@ -601,7 +585,7 @@ where
 
     #[inline(always)]
     fn is_exclusive_allocator(&self) -> bool {
-        Bump::is_exclusive_allocator(self)
+        true
     }
 
     #[inline(always)]

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -519,7 +519,7 @@ where
 /// [into_box]: crate::BumpBox::into_box
 /// [prepare_slice_allocation]: Self::prepare_slice_allocation
 /// [try_prepare_slice_allocation]: Self::try_prepare_slice_allocation
-pub unsafe trait BumpAllocatorMut: BumpAllocator {
+pub unsafe trait MutBumpAllocator: BumpAllocator {
     /// Does not allocate, just returns a slice of `T` that are currently available.
     ///
     /// # Panics
@@ -579,7 +579,7 @@ pub unsafe trait BumpAllocatorMut: BumpAllocator {
         Self: Sized;
 }
 
-unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorMut
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> MutBumpAllocator
     for BumpScope<'_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
@@ -654,7 +654,7 @@ where
     }
 }
 
-unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorMut
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> MutBumpAllocator
     for Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
@@ -709,7 +709,7 @@ where
     }
 }
 
-unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorMut
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> MutBumpAllocator
     for &mut BumpScope<'_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
@@ -764,7 +764,7 @@ where
     }
 }
 
-unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BumpAllocatorMut
+unsafe impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> MutBumpAllocator
     for &mut Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
@@ -876,9 +876,9 @@ where
 {
 }
 
-/// Shorthand for <code>[BumpAllocatorScope]<'a> + [BumpAllocatorMut]</code>
-pub trait BumpAllocatorScopeMut<'a>: BumpAllocatorScope<'a> + BumpAllocatorMut {}
-impl<'a, T: BumpAllocatorScope<'a> + BumpAllocatorMut> BumpAllocatorScopeMut<'a> for T {}
+/// Shorthand for <code>[BumpAllocatorScope]<'a> + [MutBumpAllocator]</code>
+pub trait MutBumpAllocatorScope<'a>: BumpAllocatorScope<'a> + MutBumpAllocator {}
+impl<'a, T: BumpAllocatorScope<'a> + MutBumpAllocator> MutBumpAllocatorScope<'a> for T {}
 
 #[cold]
 #[inline(never)]

--- a/src/bump_box.rs
+++ b/src/bump_box.rs
@@ -1310,12 +1310,6 @@ impl<'a, T> BumpBox<'a, [T]> {
         self.set_len(self.len() - amount);
     }
 
-    #[inline]
-    pub(crate) unsafe fn set_ptr(&mut self, ptr: NonNull<T>) {
-        let len = self.ptr.len();
-        self.ptr = nonnull::slice_from_raw_parts(ptr, len);
-    }
-
     /// Removes and returns the element at position `index` within the vector,
     /// shifting all elements after it to the left.
     ///

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -7,8 +7,8 @@ use crate::{
     layout::{ArrayLayout, CustomLayout, LayoutProps, SizedLayout},
     polyfill::{nonnull, pointer},
     up_align_usize_unchecked, BaseAllocator, BumpBox, BumpScopeGuard, BumpString, BumpVec, Checkpoint, ErrorBehavior,
-    FixedBumpString, FixedBumpVec, GuaranteedAllocatedStats, MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev,
-    NoDrop, RawChunk, SizedTypeProperties, Stats, SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
+    FixedBumpString, FixedBumpVec, GuaranteedAllocatedStats, MinimumAlignment, MutBumpString, MutBumpVecRev, NoDrop,
+    RawChunk, SizedTypeProperties, Stats, SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
 };
 #[cfg(not(no_global_oom_handling))]
 use crate::{infallible, Infallibly};
@@ -859,7 +859,7 @@ where
         let iter = iter.into_iter();
         let capacity = iter.size_hint().0;
 
-        let mut vec = MutBumpVec::<T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>::generic_with_capacity_in(capacity, self)?;
+        let mut vec = BumpVec::<T, &mut Self>::generic_with_capacity_in(capacity, self)?;
 
         for value in iter {
             vec.generic_push(value)?;

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -7,8 +7,8 @@ use crate::{
     layout::{ArrayLayout, CustomLayout, LayoutProps, SizedLayout},
     polyfill::{nonnull, pointer},
     up_align_usize_unchecked, BaseAllocator, BumpBox, BumpScopeGuard, BumpString, BumpVec, Checkpoint, ErrorBehavior,
-    FixedBumpString, FixedBumpVec, GuaranteedAllocatedStats, MinimumAlignment, MutBumpString, MutBumpVecRev, NoDrop,
-    RawChunk, SizedTypeProperties, Stats, SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
+    FixedBumpString, FixedBumpVec, GuaranteedAllocatedStats, MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev,
+    NoDrop, RawChunk, SizedTypeProperties, Stats, SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
 };
 #[cfg(not(no_global_oom_handling))]
 use crate::{infallible, Infallibly};
@@ -859,7 +859,7 @@ where
         let iter = iter.into_iter();
         let capacity = iter.size_hint().0;
 
-        let mut vec = BumpVec::<T, &mut Self>::generic_with_capacity_in(capacity, self)?;
+        let mut vec = MutBumpVec::<T, &mut Self>::generic_with_capacity_in(capacity, self)?;
 
         for value in iter {
             vec.generic_push(value)?;

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -818,7 +818,7 @@ where
         let iter = iter.into_iter();
         let capacity = iter.size_hint().0;
 
-        let mut vec = BumpVec::<T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>::generic_with_capacity_in(capacity, self)?;
+        let mut vec = BumpVec::<T, &Self>::generic_with_capacity_in(capacity, self)?;
 
         for value in iter {
             vec.generic_push(value)?;
@@ -838,7 +838,7 @@ where
         let mut iter = iter.into_iter();
         let len = iter.len();
 
-        let mut vec = BumpVec::<T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>::generic_with_capacity_in(len, self)?;
+        let mut vec = BumpVec::<T, &Self>::generic_with_capacity_in(len, self)?;
 
         while vec.len() != vec.capacity() {
             match iter.next() {

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -876,7 +876,7 @@ where
         let iter = iter.into_iter();
         let capacity = iter.size_hint().0;
 
-        let mut vec = MutBumpVecRev::<T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>::generic_with_capacity_in(capacity, self)?;
+        let mut vec = MutBumpVecRev::<T, &mut Self>::generic_with_capacity_in(capacity, self)?;
 
         for value in iter {
             vec.generic_push(value)?;

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -93,7 +93,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<UP> {
+    pub fn stats(&self) -> Stats {
         Stats {
             current: Some(unsafe { Chunk::from_raw(self.chunk) }),
         }
@@ -102,7 +102,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<UP> {
+    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats {
         GuaranteedAllocatedStats {
             current: unsafe { Chunk::from_raw(self.chunk) },
         }
@@ -187,7 +187,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<UP> {
+    pub fn stats(&self) -> Stats {
         Stats {
             current: Some(unsafe { Chunk::from_raw(self.chunk) }),
         }
@@ -196,7 +196,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<UP> {
+    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats {
         GuaranteedAllocatedStats {
             current: unsafe { Chunk::from_raw(self.chunk) },
         }

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -1,20 +1,20 @@
-use allocator_api2::alloc::Allocator;
-
 #[cfg(not(no_global_oom_handling))]
 use crate::Infallibly;
 use crate::{
     destructure::destructure,
     error_behavior_generic_methods_allocation_failure, owned_str,
-    polyfill::{self, transmute_mut},
-    BaseAllocator, BumpBox, BumpScope, BumpVec, ErrorBehavior, FixedBumpString, FromUtf16Error, FromUtf8Error,
-    GuaranteedAllocatedStats, MinimumAlignment, Stats, SupportedMinimumAlignment,
+    polyfill::{self, nonnull, transmute_mut, transmute_value},
+    raw_bump_box::RawBumpBox,
+    raw_fixed_bump_string::RawFixedBumpString,
+    BumpAllocator, BumpAllocatorScope, BumpBox, BumpVec, ErrorBehavior, FixedBumpString, FromUtf16Error, FromUtf8Error,
+    Stats,
 };
 use core::{
     alloc::Layout,
     borrow::{Borrow, BorrowMut},
     fmt::{self, Debug, Display},
     hash::Hash,
-    mem,
+    mem::MaybeUninit,
     ops::{Deref, DerefMut, Range, RangeBounds},
     panic::{RefUnwindSafe, UnwindSafe},
     ptr, str,
@@ -66,110 +66,76 @@ macro_rules! bump_format {
     }};
 }
 
-macro_rules! bump_string_declaration {
-    ($($allocator_parameter:tt)*) => {
-        /// A bump allocated [`String`].
-        ///
-        /// When you are done building the string, you can turn it into a `&str` with [`into_str`].
-        ///
-        /// # Examples
-        ///
-        /// You can create a `BumpString` from [a literal string][`&str`] with [`BumpString::from_str_in`]:
-        ///
-        /// [`into_str`]: BumpString::into_str
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// let hello = BumpString::from_str_in("Hello, world!", &bump);
-        /// ```
-        ///
-        /// You can append a [`char`] to a string with the [`push`] method, and
-        /// append a [`&str`] with the [`push_str`] method:
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// let mut hello = BumpString::from_str_in("Hello, ", &bump);
-        ///
-        /// hello.push('w');
-        /// hello.push_str("orld!");
-        ///
-        /// assert_eq!(hello.as_str(), "Hello, world!");
-        /// ```
-        ///
-        /// [`push`]: BumpString::push
-        /// [`push_str`]: BumpString::push_str
-        ///
-        /// If you have a vector of UTF-8 bytes, you can create a `BumpString` from it with
-        /// the [`from_utf8`] method:
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString, bump_vec };
-        /// # let bump: Bump = Bump::new();
-        /// // some bytes, in a vector
-        /// let sparkle_heart = bump_vec![in bump; 240, 159, 146, 150];
-        ///
-        /// // We know these bytes are valid, so we'll use `unwrap()`.
-        /// let sparkle_heart = BumpString::from_utf8(sparkle_heart).unwrap();
-        ///
-        /// assert_eq!("💖", sparkle_heart);
-        /// ```
-        ///
-        /// [`&str`]: prim@str "&str"
-        /// [`from_utf8`]: BumpString::from_utf8
-        // `BumpString` and `BumpVec<u8>` have the same repr.
-        #[repr(C)]
-        pub struct BumpString<
-            'b,
-            'a: 'b,
-            $($allocator_parameter)*,
-            const MIN_ALIGN: usize = 1,
-            const UP: bool = true,
-            const GUARANTEED_ALLOCATED: bool = true,
-        >
-        where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>,
-        {
-            pub(crate) fixed: FixedBumpString<'a>,
-            pub(crate) bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-        }
-    };
+/// A bump allocated [`String`].
+///
+/// When you are done building the string, you can turn it into a `&str` with [`into_str`].
+///
+/// # Examples
+///
+/// You can create a `BumpString` from [a literal string][`&str`] with [`BumpString::from_str_in`]:
+///
+/// [`into_str`]: BumpString::into_str
+///
+/// ```
+/// # use bump_scope::{ Bump, BumpString };
+/// # let bump: Bump = Bump::new();
+/// let hello = BumpString::from_str_in("Hello, world!", &bump);
+/// ```
+///
+/// You can append a [`char`] to a string with the [`push`] method, and
+/// append a [`&str`] with the [`push_str`] method:
+///
+/// ```
+/// # use bump_scope::{ Bump, BumpString };
+/// # let bump: Bump = Bump::new();
+/// let mut hello = BumpString::from_str_in("Hello, ", &bump);
+///
+/// hello.push('w');
+/// hello.push_str("orld!");
+///
+/// assert_eq!(hello.as_str(), "Hello, world!");
+/// ```
+///
+/// [`push`]: BumpString::push
+/// [`push_str`]: BumpString::push_str
+///
+/// If you have a vector of UTF-8 bytes, you can create a `BumpString` from it with
+/// the [`from_utf8`] method:
+///
+/// ```
+/// # use bump_scope::{ Bump, BumpString, bump_vec };
+/// # let bump: Bump = Bump::new();
+/// // some bytes, in a vector
+/// let sparkle_heart = bump_vec![in &bump; 240, 159, 146, 150];
+///
+/// // We know these bytes are valid, so we'll use `unwrap()`.
+/// let sparkle_heart = BumpString::from_utf8(sparkle_heart).unwrap();
+///
+/// assert_eq!("💖", sparkle_heart);
+/// ```
+///
+/// [`&str`]: prim@str "&str"
+/// [`from_utf8`]: BumpString::from_utf8
+// `BumpString` and `BumpVec<u8>` have the same repr.
+#[repr(C)]
+pub struct BumpString<A: BumpAllocator> {
+    pub(crate) fixed: RawFixedBumpString,
+    pub(crate) allocator: A,
 }
 
-crate::maybe_default_allocator!(bump_string_declaration);
+impl<A: BumpAllocator + UnwindSafe> UnwindSafe for BumpString<A> {}
 
-impl<'b, 'a: 'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> UnwindSafe
-    for BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + UnwindSafe,
-{
-}
+impl<A: BumpAllocator + RefUnwindSafe> RefUnwindSafe for BumpString<A> {}
 
-impl<'b, 'a: 'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> RefUnwindSafe
-    for BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + RefUnwindSafe,
-{
-}
-
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> BumpString<A> {
     /// Constructs a new empty `BumpString`.
     ///
     /// The vector will not allocate until elements are pushed onto it.
     #[inline]
-    pub fn new_in(bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+    pub fn new_in(allocator: A) -> Self {
         Self {
-            fixed: FixedBumpString::EMPTY,
-            bump: bump.into(),
+            fixed: RawFixedBumpString::EMPTY,
+            allocator,
         }
     }
 
@@ -183,19 +149,17 @@ where
         for fn with_capacity_in
         for fn try_with_capacity_in
         #[inline]
-        use fn generic_with_capacity_in(capacity: usize, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
-            let bump = bump.into();
-
+        use fn generic_with_capacity_in(capacity: usize, allocator: A) -> Self {
             if capacity == 0 {
                 return Ok(Self {
-                    fixed: FixedBumpString::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpString::EMPTY,
+                    allocator,
                 });
             }
 
             Ok(Self {
-                fixed: bump.generic_alloc_fixed_string(capacity)?,
-                bump,
+                fixed: unsafe { RawFixedBumpString::allocate(&allocator, capacity)? },
+                allocator,
             })
         }
 
@@ -220,11 +184,11 @@ where
         /// ```
         for fn try_from_str_in
         #[inline]
-        use fn generic_from_str_in(string: &str, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
-            let mut this = Self::generic_with_capacity_in(string.len(), bump)?;
+        use fn generic_from_str_in(string: &str, allocator: A) -> Self {
+            let mut this = Self::generic_with_capacity_in(string.len(), allocator)?;
 
             unsafe {
-                ptr::copy_nonoverlapping(string.as_ptr(), this.fixed.initialized.as_mut_ptr(), string.len());
+                ptr::copy_nonoverlapping(string.as_ptr(), this.fixed.as_mut_ptr(), string.len());
                 this.as_mut_vec().set_len(string.len());
             }
 
@@ -307,23 +271,23 @@ where
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
         /// ```
         for fn try_from_utf8_lossy_in
-        use fn generic_from_utf8_lossy_in(v: &[u8], bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+        use fn generic_from_utf8_lossy_in(v: &[u8], allocator: A) -> Self {
             let mut iter = crate::polyfill::str::lossy::utf8_chunks(v);
 
             let first_valid = if let Some(chunk) = iter.next() {
                 let valid = chunk.valid();
                 if chunk.invalid().is_empty() {
                     debug_assert_eq!(valid.len(), v.len());
-                    return Self::generic_from_str_in(valid, bump);
+                    return Self::generic_from_str_in(valid, allocator);
                 }
                 valid
             } else {
-                return Ok(Self::new_in(bump));
+                return Ok(Self::new_in(allocator));
             };
 
             const REPLACEMENT: &str = "\u{FFFD}";
 
-            let mut res = Self::generic_with_capacity_in(v.len(), bump)?;
+            let mut res = Self::generic_with_capacity_in(v.len(), allocator)?;
             res.generic_push_str(first_valid)?;
             res.generic_push_str(REPLACEMENT)?;
 
@@ -375,10 +339,10 @@ where
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
         /// ```
         for fn try_from_utf16_in
-        use fn generic_from_utf16_in(v: &[u16], bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Result<Self, FromUtf16Error> {
+        use fn generic_from_utf16_in(v: &[u16], allocator: A) -> Result<Self, FromUtf16Error> {
             // This isn't done via collect::<Result<_, _>>() for performance reasons.
             // FIXME: the function can be simplified again when #48994 is closed.
-            let mut ret = Self::generic_with_capacity_in(v.len(), bump)?;
+            let mut ret = Self::generic_with_capacity_in(v.len(), allocator)?;
 
             for c in char::decode_utf16(v.iter().copied()) {
                 if let Ok(c) = c {
@@ -426,10 +390,10 @@ where
         /// ```
         for fn try_from_utf16_lossy_in
         #[inline]
-        use fn generic_from_utf16_lossy_in(v: &[u16], bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+        use fn generic_from_utf16_lossy_in(v: &[u16], allocator: A) -> Self {
             let iter = char::decode_utf16(v.iter().copied());
             let capacity = iter.size_hint().0;
-            let mut string = Self::generic_with_capacity_in(capacity, bump)?;
+            let mut string = Self::generic_with_capacity_in(capacity, allocator)?;
 
             for r in iter {
                 string.generic_push(r.unwrap_or(char::REPLACEMENT_CHARACTER))?;
@@ -440,12 +404,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> BumpString<A> {
     /// Converts a vector of bytes to a `BumpString`.
     ///
     /// A string ([`BumpString`]) is made of bytes ([`u8`]), and a vector of bytes
@@ -479,7 +438,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec, BumpString };
     /// # let bump: Bump = Bump::new();
     /// // some bytes, in a vector
-    /// let sparkle_heart = bump_vec![in bump; 240, 159, 146, 150];
+    /// let sparkle_heart = bump_vec![in &bump; 240, 159, 146, 150];
     ///
     /// // We know these bytes are valid, so we'll use `unwrap()`.
     /// let sparkle_heart = BumpString::from_utf8(sparkle_heart).unwrap();
@@ -492,7 +451,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec, BumpString };
     /// # let bump: Bump = Bump::new();
     /// // some invalid bytes, in a vector
-    /// let sparkle_heart = bump_vec![in bump; 0, 159, 146, 150];
+    /// let sparkle_heart = bump_vec![in &bump; 0, 159, 146, 150];
     ///
     /// assert!(BumpString::from_utf8(sparkle_heart).is_err());
     /// ```
@@ -501,14 +460,12 @@ where
     /// [`BumpVec<u8>`]: BumpVec
     /// [`&str`]: prim@str "&str"
     /// [`into_bytes`]: Self::into_bytes
-    pub fn from_utf8(
-        vec: BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-    ) -> Result<Self, FromUtf8Error<BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>> {
+    pub fn from_utf8(vec: BumpVec<u8, A>) -> Result<Self, FromUtf8Error<BumpVec<u8, A>>> {
         #[allow(clippy::missing_transmute_annotations)]
         match str::from_utf8(vec.as_slice()) {
             // SAFETY: `BumpVec<u8>` and `BumpString` have the same representation;
             // only the invariant that the bytes are utf8 is different.
-            Ok(_) => Ok(unsafe { mem::transmute(vec) }),
+            Ok(_) => Ok(unsafe { transmute_value(vec) }),
             Err(error) => Err(FromUtf8Error { error, bytes: vec }),
         }
     }
@@ -528,7 +485,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec, BumpString };
     /// # let bump: Bump = Bump::new();
     /// // some bytes, in a vector
-    /// let sparkle_heart = bump_vec![in bump; 240, 159, 146, 150];
+    /// let sparkle_heart = bump_vec![in &bump; 240, 159, 146, 150];
     ///
     /// let sparkle_heart = unsafe {
     ///     BumpString::from_utf8_unchecked(sparkle_heart)
@@ -537,19 +494,19 @@ where
     /// assert_eq!("💖", sparkle_heart);
     /// ```
     #[must_use]
-    pub unsafe fn from_utf8_unchecked(vec: BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> Self {
+    pub unsafe fn from_utf8_unchecked(vec: BumpVec<u8, A>) -> Self {
         debug_assert!(str::from_utf8(vec.as_slice()).is_ok());
 
         // SAFETY: `BumpVec<u8>` and `BumpString` have the same representation;
         // only the invariant that the bytes are utf8 is different.
-        mem::transmute(vec)
+        transmute_value(vec)
     }
 
     /// Returns this string's capacity, in bytes.
     #[must_use]
     #[inline(always)]
     pub const fn capacity(&self) -> usize {
-        self.fixed.capacity()
+        self.fixed.capacity
     }
 
     /// Returns the length of this string, in bytes, not [`char`]s or
@@ -565,31 +522,7 @@ where
     #[must_use]
     #[inline(always)]
     pub const fn is_empty(&self) -> bool {
-        self.fixed.is_empty()
-    }
-
-    /// Converts this `BumpString` into `&str` that is live for this bump scope.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_str(self) -> &'a mut str {
-        self.into_boxed_str().into_mut()
-    }
-
-    /// Converts a `BumpString` into a `BumpBox<str>`.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_boxed_str(mut self) -> BumpBox<'a, str> {
-        self.shrink_to_fit();
-        self.into_fixed_string().into_boxed_str()
-    }
-
-    /// Turns this `BumpString` into a `FixedBumpString`.
-    ///
-    /// This retains the unused capacity unlike <code>[into_](Self::into_str)([boxed_](Self::into_boxed_str))[str](Self::into_str)</code>.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_fixed_string(self) -> FixedBumpString<'a> {
-        self.into_parts().0
+        self.fixed.len() == 0
     }
 
     /// Converts a `BumpString` into a `BumpVec<u8>`.
@@ -609,10 +542,10 @@ where
     /// ```
     #[inline(always)]
     #[must_use = "`self` will be dropped if the result is not used"]
-    pub fn into_bytes(self) -> BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
+    pub fn into_bytes(self) -> BumpVec<u8, A> {
         // SAFETY: `BumpVec<u8>` and `BumpString` have the same representation;
         // only the invariant that the bytes are utf8 is different.
-        unsafe { mem::transmute(self) }
+        unsafe { transmute_value(self) }
     }
 
     /// Splits the string into two at the given byte index.
@@ -643,7 +576,10 @@ where
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[must_use = "use `.truncate()` if you don't need the other half"]
-    pub fn split_off(&mut self, at: usize) -> Self {
+    pub fn split_off(&mut self, at: usize) -> Self
+    where
+        A: Clone,
+    {
         assert!(self.is_char_boundary(at));
         let other = unsafe { self.as_mut_vec() }.split_off(at);
         unsafe { Self::from_utf8_unchecked(other) }
@@ -668,7 +604,7 @@ where
     /// ```
     #[inline]
     pub fn pop(&mut self) -> Option<char> {
-        self.fixed.pop()
+        unsafe { self.fixed.cook_mut() }.pop()
     }
 
     /// Truncates this string, removing all contents.
@@ -692,7 +628,7 @@ where
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        self.fixed.clear();
+        unsafe { self.fixed.cook_mut() }.clear();
     }
 
     /// Shortens this string to the specified length.
@@ -720,7 +656,7 @@ where
     /// ```
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {
-        self.fixed.truncate(new_len);
+        unsafe { self.fixed.cook_mut() }.truncate(new_len);
     }
 
     /// Removes a [`char`] from this string at a byte position and returns it.
@@ -747,7 +683,7 @@ where
     /// ```
     #[inline]
     pub fn remove(&mut self, idx: usize) -> char {
-        self.fixed.remove(idx)
+        unsafe { self.fixed.cook_mut() }.remove(idx)
     }
 
     /// Retains only the characters specified by the predicate.
@@ -785,7 +721,7 @@ where
     where
         F: FnMut(char) -> bool,
     {
-        self.fixed.retain(f);
+        unsafe { self.fixed.cook_mut() }.retain(f);
     }
 
     /// Removes the specified range from the string in bulk, returning all
@@ -829,28 +765,28 @@ where
     where
         R: RangeBounds<usize>,
     {
-        self.fixed.drain(range)
+        unsafe { self.fixed.cook_mut() }.drain(range)
     }
 
     /// Extracts a string slice containing the entire `BumpString`.
     #[must_use]
     #[inline(always)]
     pub fn as_str(&self) -> &str {
-        self.fixed.as_str()
+        unsafe { self.fixed.cook_ref() }.as_str()
     }
 
     /// Converts a `BumpString` into a mutable string slice.
     #[must_use]
     #[inline(always)]
     pub fn as_mut_str(&mut self) -> &mut str {
-        self.fixed.as_mut_str()
+        unsafe { self.fixed.cook_mut() }.as_mut_str()
     }
 
     /// Returns a byte slice of this `BumpString`'s contents.
     #[must_use]
     #[inline(always)]
     pub fn as_bytes(&self) -> &[u8] {
-        self.fixed.as_bytes()
+        unsafe { self.fixed.cook_ref() }.as_bytes()
     }
 
     /// Returns a mutable reference to the contents of this `BumpString`.
@@ -863,19 +799,14 @@ where
     /// safety, as `BumpString`s must be valid UTF-8.
     #[must_use]
     #[inline(always)]
-    pub unsafe fn as_mut_vec(&mut self) -> &mut BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
+    pub unsafe fn as_mut_vec(&mut self) -> &mut BumpVec<u8, A> {
         // SAFETY: `BumpVec<u8>` and `BumpString` have the same representation;
         // only the invariant that the bytes are utf8 is different.
         transmute_mut(self)
     }
 }
 
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> BumpString<A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Appends the given [`char`] to the end of this string.
         impl
@@ -1340,6 +1271,39 @@ where
         vec.shrink_to_fit();
     }
 
+    /// Returns a reference to the allocator.
+    #[must_use]
+    #[inline(always)]
+    pub fn allocator(&self) -> &A {
+        &self.allocator
+    }
+}
+
+impl<'a, A: BumpAllocatorScope<'a>> BumpString<A> {
+    /// Converts this `BumpString` into `&str` that is live for this bump scope.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_str(self) -> &'a mut str {
+        self.into_boxed_str().into_mut()
+    }
+
+    /// Converts a `BumpString` into a `BumpBox<str>`.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_boxed_str(mut self) -> BumpBox<'a, str> {
+        self.shrink_to_fit();
+        self.into_fixed_string().into_boxed_str()
+    }
+
+    /// Turns this `BumpString` into a `FixedBumpString`.
+    ///
+    /// This retains the unused capacity unlike <code>[into_](Self::into_str)([boxed_](Self::into_boxed_str))[str](Self::into_str)</code>.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_fixed_string(self) -> FixedBumpString<'a> {
+        self.into_parts().0
+    }
+
     /// Creates a `BumpString` from its parts.
     ///
     /// The provided `bump` does not have to be the one the `fixed_string` was allocated in.
@@ -1358,13 +1322,10 @@ where
     /// ```
     #[must_use]
     #[inline(always)]
-    pub fn from_parts(
-        fixed_string: FixedBumpString<'a>,
-        bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>,
-    ) -> Self {
+    pub fn from_parts(string: FixedBumpString<'a>, allocator: A) -> Self {
         Self {
-            fixed: fixed_string,
-            bump: bump.into(),
+            fixed: unsafe { RawFixedBumpString::from_cooked(string) },
+            allocator,
         }
     }
 
@@ -1382,59 +1343,20 @@ where
     /// ```
     #[must_use]
     #[inline(always)]
-    pub fn into_parts(self) -> (FixedBumpString<'a>, &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) {
-        destructure!(let Self { fixed, bump } = self);
-        (fixed, bump)
+    pub fn into_parts(self) -> (FixedBumpString<'a>, A) {
+        destructure!(let Self { fixed, allocator } = self);
+        (unsafe { fixed.cook() }, allocator)
     }
 
-    /// Returns a reference to the base allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn allocator(&self) -> &A {
-        self.bump.allocator()
-    }
-
-    /// Returns a reference to the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn bump(&self) -> &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
-        self.bump
-    }
-}
-
-impl<'b, 'a: 'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, UP> {
-        self.bump.stats()
+    pub fn stats(&self) -> Stats<'a, true> {
+        todo!()
     }
 }
 
-impl<'b, 'a: 'b, A, const MIN_ALIGN: usize, const UP: bool> BumpString<'b, 'a, A, MIN_ALIGN, UP>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
-{
-    /// Returns a type which provides statistics about the memory usage of the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a, UP> {
-        self.bump.guaranteed_allocated_stats()
-    }
-}
-
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> fmt::Write
-    for BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> fmt::Write for BumpString<A> {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.try_push_str(s).map_err(|_| fmt::Error)
@@ -1447,12 +1369,7 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> fmt::Write
-    for Infallibly<BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> fmt::Write for Infallibly<BumpString<A>> {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.0.push_str(s);
@@ -1466,34 +1383,19 @@ where
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Debug
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Debug for BumpString<A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(self.as_str(), f)
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Display
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Display for BumpString<A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Display::fmt(self.as_str(), f)
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Deref
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Deref for BumpString<A> {
     type Target = str;
 
     #[inline]
@@ -1502,24 +1404,14 @@ where
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> DerefMut
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> DerefMut for BumpString<A> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut_str()
     }
 }
 
-impl<'b, 'a: 'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
-    for BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Drop for BumpString<A> {
     fn drop(&mut self) {
         // SAFETY:
         // The dangling pointer can not be a valid ptr into a chunk; because
@@ -1527,95 +1419,70 @@ where
         // may be at is 16. The bump allocator handles deallocate requests
         // from pointers outside its bound just fine by ignoring them.
         unsafe {
-            let ptr = self.fixed.initialized.ptr.cast();
+            let ptr = self.fixed.initialized.as_non_null_ptr().cast();
             let layout = Layout::from_size_align_unchecked(self.fixed.capacity, 1);
-            self.bump.deallocate(ptr, layout);
+            self.allocator.deallocate(ptr, layout);
         }
     }
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Clone
-    for BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator + Clone> Clone for BumpString<A> {
     fn clone(&self) -> Self {
+        let allocator = self.allocator.clone();
+        let ptr = allocator.allocate_slice::<MaybeUninit<u8>>(self.len());
+        let slice = nonnull::slice_from_raw_parts(ptr, self.len());
+        let boxed = unsafe { BumpBox::from_raw(slice) };
+        let boxed = boxed.init_copy(self.as_bytes());
+        let boxed = unsafe { BumpBox::from_utf8_unchecked(boxed) };
+
         Self {
-            fixed: FixedBumpString::from_init(self.bump.alloc_str(self)),
-            bump: self.bump,
+            fixed: RawFixedBumpString {
+                initialized: unsafe { RawBumpBox::from_cooked(boxed) },
+                capacity: self.len(),
+            },
+            allocator,
         }
     }
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> core::ops::AddAssign<&str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> core::ops::AddAssign<&str> for BumpString<A> {
     #[inline]
     fn add_assign(&mut self, rhs: &str) {
         self.push_str(rhs);
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> AsRef<str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> AsRef<str> for BumpString<A> {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> AsMut<str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> AsMut<str> for BumpString<A> {
     #[inline]
     fn as_mut(&mut self) -> &mut str {
         self.as_mut_str()
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Borrow<str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Borrow<str> for BumpString<A> {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> BorrowMut<str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> BorrowMut<str> for BumpString<A> {
     #[inline]
     fn borrow_mut(&mut self) -> &mut str {
         self.as_mut_str()
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> PartialEq for BumpString<A> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         <str as PartialEq>::eq(self, other)
@@ -1636,11 +1503,7 @@ macro_rules! impl_partial_eq {
     ) => {
         $(
             $(#[$attr])*
-            impl<'b, 'a, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<$string_like> for BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-            where
-                MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-                A: BaseAllocator<GUARANTEED_ALLOCATED>,
-            {
+            impl<A: BumpAllocator> PartialEq<$string_like> for BumpString<A> {
                 #[inline]
                 fn eq(&self, other: &$string_like) -> bool {
                     <str as PartialEq>::eq(self, other)
@@ -1653,18 +1516,14 @@ macro_rules! impl_partial_eq {
             }
 
             $(#[$attr])*
-            impl<'b, 'a, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for $string_like
-            where
-                MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-                A: BaseAllocator<GUARANTEED_ALLOCATED>,
-            {
+            impl<A: BumpAllocator> PartialEq<BumpString<A>> for $string_like {
                 #[inline]
-                fn eq(&self, other: &BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+                fn eq(&self, other: &BumpString<A>) -> bool {
                     <str as PartialEq>::eq(self, other)
                 }
 
                 #[inline]
-                fn ne(&self, other: &BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+                fn ne(&self, other: &BumpString<A>) -> bool {
                     <str as PartialEq>::ne(self, other)
                 }
             }
@@ -1684,20 +1543,9 @@ impl_partial_eq! {
     alloc::borrow::Cow<'_, str>,
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Eq
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
-}
+impl<A: BumpAllocator> Eq for BumpString<A> {}
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialOrd
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> PartialOrd for BumpString<A> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
@@ -1724,23 +1572,13 @@ where
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Ord
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Ord for BumpString<A> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         <str as Ord>::cmp(self, other)
     }
 }
 
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Hash
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Hash for BumpString<A> {
     #[inline]
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
@@ -1748,12 +1586,7 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'s, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Extend<&'s str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'s, A: BumpAllocator> Extend<&'s str> for BumpString<A> {
     #[inline]
     fn extend<T: IntoIterator<Item = &'s str>>(&mut self, iter: T) {
         for str in iter {
@@ -1763,12 +1596,7 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Extend<char>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Extend<char> for BumpString<A> {
     fn extend<I: IntoIterator<Item = char>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
         let (lower_bound, _) = iterator.size_hint();
@@ -1778,26 +1606,16 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'s, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Extend<&'s char>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'s, A: BumpAllocator> Extend<&'s char> for BumpString<A> {
     fn extend<I: IntoIterator<Item = &'s char>>(&mut self, iter: I) {
         self.extend(iter.into_iter().copied());
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<'b, 'a, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    From<BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for alloc::string::String
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> From<BumpString<A>> for alloc::string::String {
     #[inline]
-    fn from(value: BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> Self {
+    fn from(value: BumpString<A>) -> Self {
         value.as_str().into()
     }
 }
@@ -1846,12 +1664,7 @@ where
 /// let c = BumpString::from_str_in(a, &bump) + b;
 /// ```
 #[cfg(not(no_global_oom_handling))]
-impl<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> core::ops::Add<&str>
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> core::ops::Add<&str> for BumpString<A> {
     type Output = Self;
 
     #[inline]

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -808,6 +808,13 @@ impl<A: BumpAllocator> BumpString<A> {
         // only the invariant that the bytes are utf8 is different.
         transmute_mut(self)
     }
+
+    /// Returns a type which provides statistics about the memory usage of the bump allocator.
+    #[must_use]
+    #[inline(always)]
+    pub fn stats(&self) -> Stats {
+        self.allocator.stats()
+    }
 }
 
 impl<A: BumpAllocator> BumpString<A> {
@@ -1350,13 +1357,6 @@ impl<'a, A: BumpAllocatorScope<'a>> BumpString<A> {
     pub fn into_parts(self) -> (FixedBumpString<'a>, A) {
         destructure!(let Self { fixed, allocator } = self);
         (unsafe { fixed.cook() }, allocator)
-    }
-
-    /// Returns a type which provides statistics about the memory usage of the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn stats(&self) -> Stats<'a> {
-        todo!()
     }
 }
 

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -41,7 +41,7 @@ use crate::{polyfill::nonnull, raw_bump_box::RawBumpBox};
 /// # let bump: Bump = Bump::new();
 /// #
 /// let greeting = "Hello";
-/// let mut string = bump_format!(in bump, "{greeting} world!");
+/// let mut string = bump_format!(in &bump, "{greeting} world!");
 /// string.push_str(" How are you?");
 ///
 /// assert_eq!(string, "Hello world! How are you?");

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -128,7 +128,6 @@ pub struct BumpString<A: BumpAllocator> {
 }
 
 impl<A: BumpAllocator + UnwindSafe> UnwindSafe for BumpString<A> {}
-
 impl<A: BumpAllocator + RefUnwindSafe> RefUnwindSafe for BumpString<A> {}
 
 impl<A: BumpAllocator> BumpString<A> {
@@ -143,272 +142,6 @@ impl<A: BumpAllocator> BumpString<A> {
         }
     }
 
-    error_behavior_generic_methods_allocation_failure! {
-        /// Constructs a new empty `BumpString` with the specified capacity
-        /// in the provided `BumpScope`.
-        ///
-        /// The string will be able to hold `capacity` bytes without
-        /// reallocating. If `capacity` is 0, the string will not allocate.
-        impl
-        for fn with_capacity_in
-        for fn try_with_capacity_in
-        #[inline]
-        use fn generic_with_capacity_in(capacity: usize, allocator: A) -> Self {
-            if capacity == 0 {
-                return Ok(Self {
-                    fixed: RawFixedBumpString::EMPTY,
-                    allocator,
-                });
-            }
-
-            Ok(Self {
-                fixed: unsafe { RawFixedBumpString::allocate(&allocator, capacity)? },
-                allocator,
-            })
-        }
-
-        /// Constructs a new `BumpString` from a `&str`.
-        impl
-        do examples
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// let string = BumpString::from_str_in("Hello!", &bump);
-        /// assert_eq!(string, "Hello!");
-        /// ```
-        for fn from_str_in
-        do examples
-        /// ```
-        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::try_new()?;
-        /// let string = BumpString::try_from_str_in("Hello!", &bump)?;
-        /// assert_eq!(string, "Hello!");
-        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
-        /// ```
-        for fn try_from_str_in
-        #[inline]
-        use fn generic_from_str_in(string: &str, allocator: A) -> Self {
-            let mut this = Self::generic_with_capacity_in(string.len(), allocator)?;
-
-            unsafe {
-                ptr::copy_nonoverlapping(string.as_ptr(), this.fixed.as_mut_ptr(), string.len());
-                this.as_mut_vec().set_len(string.len());
-            }
-
-            Ok(this)
-        }
-
-        /// Converts a slice of bytes to a string, including invalid characters.
-        ///
-        /// Strings are made of bytes ([`u8`]), and a slice of bytes
-        /// ([`&[u8]`][byteslice]) is made of bytes, so this function converts
-        /// between the two. Not all byte slices are valid strings, however: strings
-        /// are required to be valid UTF-8. During this conversion,
-        /// `from_utf8_lossy()` will replace any invalid UTF-8 sequences with
-        /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD], which looks like this: �
-        ///
-        /// [byteslice]: prim@slice
-        /// [U+FFFD]: core::char::REPLACEMENT_CHARACTER
-        ///
-        /// If you are sure that the byte slice is valid UTF-8, and you don't want
-        /// to incur the overhead of the conversion, there is an unsafe version
-        /// of this function, [`from_utf8_unchecked`], which has the same behavior
-        /// but skips the checks.
-        ///
-        /// [`from_utf8_unchecked`]: Self::from_utf8_unchecked
-        impl
-        #[must_use]
-        do examples
-        /// Basic usage:
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// // some bytes, in a vector
-        /// let sparkle_heart = [240, 159, 146, 150];
-        ///
-        /// let sparkle_heart = BumpString::from_utf8_lossy_in(&sparkle_heart, &bump);
-        ///
-        /// assert_eq!("💖", sparkle_heart);
-        /// ```
-        ///
-        /// Incorrect bytes:
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// // some invalid bytes
-        /// let input = b"Hello \xF0\x90\x80World";
-        /// let output = BumpString::from_utf8_lossy_in(input, &bump);
-        ///
-        /// assert_eq!("Hello �World", output);
-        /// ```
-        for fn from_utf8_lossy_in
-        do examples
-        /// Basic usage:
-        ///
-        /// ```
-        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::try_new()?;
-        /// // some bytes, in a vector
-        /// let sparkle_heart = [240, 159, 146, 150];
-        ///
-        /// let sparkle_heart = BumpString::try_from_utf8_lossy_in(&sparkle_heart, &bump)?;
-        ///
-        /// assert_eq!("💖", sparkle_heart);
-        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
-        /// ```
-        ///
-        /// Incorrect bytes:
-        ///
-        /// ```
-        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::try_new()?;
-        /// // some invalid bytes
-        /// let input = b"Hello \xF0\x90\x80World";
-        /// let output = BumpString::try_from_utf8_lossy_in(input, &bump)?;
-        ///
-        /// assert_eq!("Hello �World", output);
-        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
-        /// ```
-        for fn try_from_utf8_lossy_in
-        use fn generic_from_utf8_lossy_in(v: &[u8], allocator: A) -> Self {
-            let mut iter = crate::polyfill::str::lossy::utf8_chunks(v);
-
-            let first_valid = if let Some(chunk) = iter.next() {
-                let valid = chunk.valid();
-                if chunk.invalid().is_empty() {
-                    debug_assert_eq!(valid.len(), v.len());
-                    return Self::generic_from_str_in(valid, allocator);
-                }
-                valid
-            } else {
-                return Ok(Self::new_in(allocator));
-            };
-
-            const REPLACEMENT: &str = "\u{FFFD}";
-
-            let mut res = Self::generic_with_capacity_in(v.len(), allocator)?;
-            res.generic_push_str(first_valid)?;
-            res.generic_push_str(REPLACEMENT)?;
-
-            for chunk in iter {
-                res.generic_push_str(chunk.valid())?;
-                if !chunk.invalid().is_empty() {
-                    res.generic_push_str(REPLACEMENT)?;
-                }
-            }
-
-            Ok(res)
-        }
-
-        /// Decode a UTF-16–encoded vector `v` into a `BumpString`, returning [`Err`]
-        /// if `v` contains any invalid data.
-        impl
-        #[allow(clippy::missing_errors_doc)]
-        do examples
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// // 𝄞music
-        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
-        ///           0x0073, 0x0069, 0x0063];
-        /// assert_eq!(BumpString::from_str_in("𝄞music", &bump),
-        ///            BumpString::from_utf16_in(v, &bump).unwrap());
-        ///
-        /// // 𝄞mu<invalid>ic
-        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
-        ///           0xD800, 0x0069, 0x0063];
-        /// assert!(BumpString::from_utf16_in(v, &bump).is_err());
-        /// ```
-        for fn from_utf16_in
-        do examples
-        /// ```
-        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::try_new()?;
-        /// // 𝄞music
-        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
-        ///           0x0073, 0x0069, 0x0063];
-        /// assert_eq!(BumpString::try_from_str_in("𝄞music", &bump)?,
-        ///            BumpString::try_from_utf16_in(v, &bump)?.unwrap());
-        ///
-        /// // 𝄞mu<invalid>ic
-        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
-        ///           0xD800, 0x0069, 0x0063];
-        /// assert!(BumpString::try_from_utf16_in(v, &bump)?.is_err());
-        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
-        /// ```
-        for fn try_from_utf16_in
-        use fn generic_from_utf16_in(v: &[u16], allocator: A) -> Result<Self, FromUtf16Error> {
-            // This isn't done via collect::<Result<_, _>>() for performance reasons.
-            // FIXME: the function can be simplified again when #48994 is closed.
-            let mut ret = Self::generic_with_capacity_in(v.len(), allocator)?;
-
-            for c in char::decode_utf16(v.iter().copied()) {
-                if let Ok(c) = c {
-                    ret.generic_push(c)?;
-                } else {
-                    return Ok(Err(FromUtf16Error(())));
-                }
-            }
-
-            Ok(Ok(ret))
-        }
-
-        /// Decode a UTF-16–encoded slice `v` into a `BumpString`, replacing
-        /// invalid data with [the replacement character (`U+FFFD`)][U+FFFD].
-        ///
-        /// [U+FFFD]: core::char::REPLACEMENT_CHARACTER
-        impl
-        #[must_use]
-        do examples
-        /// ```
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::new();
-        /// // 𝄞mus<invalid>ic<invalid>
-        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
-        ///           0x0073, 0xDD1E, 0x0069, 0x0063,
-        ///           0xD834];
-        ///
-        /// assert_eq!(BumpString::from_str_in("𝄞mus\u{FFFD}ic\u{FFFD}", &bump),
-        ///            BumpString::from_utf16_lossy_in(v, &bump));
-        /// ```
-        for fn from_utf16_lossy_in
-        do examples
-        /// ```
-        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
-        /// # use bump_scope::{ Bump, BumpString };
-        /// # let bump: Bump = Bump::try_new()?;
-        /// // 𝄞mus<invalid>ic<invalid>
-        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
-        ///           0x0073, 0xDD1E, 0x0069, 0x0063,
-        ///           0xD834];
-        ///
-        /// assert_eq!(BumpString::try_from_str_in("𝄞mus\u{FFFD}ic\u{FFFD}", &bump)?,
-        ///            BumpString::try_from_utf16_lossy_in(v, &bump)?);
-        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
-        /// ```
-        for fn try_from_utf16_lossy_in
-        #[inline]
-        use fn generic_from_utf16_lossy_in(v: &[u16], allocator: A) -> Self {
-            let iter = char::decode_utf16(v.iter().copied());
-            let capacity = iter.size_hint().0;
-            let mut string = Self::generic_with_capacity_in(capacity, allocator)?;
-
-            for r in iter {
-                string.generic_push(r.unwrap_or(char::REPLACEMENT_CHARACTER))?;
-            }
-
-            Ok(string)
-        }
-    }
-}
-
-impl<A: BumpAllocator> BumpString<A> {
     /// Converts a vector of bytes to a `BumpString`.
     ///
     /// A string ([`BumpString`]) is made of bytes ([`u8`]), and a vector of bytes
@@ -809,16 +542,268 @@ impl<A: BumpAllocator> BumpString<A> {
         transmute_mut(self)
     }
 
-    /// Returns a type which provides statistics about the memory usage of the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn stats(&self) -> Stats {
-        self.allocator.stats()
-    }
-}
-
-impl<A: BumpAllocator> BumpString<A> {
     error_behavior_generic_methods_allocation_failure! {
+        /// Constructs a new empty `BumpString` with the specified capacity
+        /// in the provided `BumpScope`.
+        ///
+        /// The string will be able to hold `capacity` bytes without
+        /// reallocating. If `capacity` is 0, the string will not allocate.
+        impl
+        for fn with_capacity_in
+        for fn try_with_capacity_in
+        #[inline]
+        use fn generic_with_capacity_in(capacity: usize, allocator: A) -> Self {
+            if capacity == 0 {
+                return Ok(Self {
+                    fixed: RawFixedBumpString::EMPTY,
+                    allocator,
+                });
+            }
+
+            Ok(Self {
+                fixed: unsafe { RawFixedBumpString::allocate(&allocator, capacity)? },
+                allocator,
+            })
+        }
+
+        /// Constructs a new `BumpString` from a `&str`.
+        impl
+        do examples
+        /// ```
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::new();
+        /// let string = BumpString::from_str_in("Hello!", &bump);
+        /// assert_eq!(string, "Hello!");
+        /// ```
+        for fn from_str_in
+        do examples
+        /// ```
+        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::try_new()?;
+        /// let string = BumpString::try_from_str_in("Hello!", &bump)?;
+        /// assert_eq!(string, "Hello!");
+        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
+        /// ```
+        for fn try_from_str_in
+        #[inline]
+        use fn generic_from_str_in(string: &str, allocator: A) -> Self {
+            let mut this = Self::generic_with_capacity_in(string.len(), allocator)?;
+
+            unsafe {
+                ptr::copy_nonoverlapping(string.as_ptr(), this.fixed.as_mut_ptr(), string.len());
+                this.as_mut_vec().set_len(string.len());
+            }
+
+            Ok(this)
+        }
+
+        /// Converts a slice of bytes to a string, including invalid characters.
+        ///
+        /// Strings are made of bytes ([`u8`]), and a slice of bytes
+        /// ([`&[u8]`][byteslice]) is made of bytes, so this function converts
+        /// between the two. Not all byte slices are valid strings, however: strings
+        /// are required to be valid UTF-8. During this conversion,
+        /// `from_utf8_lossy()` will replace any invalid UTF-8 sequences with
+        /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD], which looks like this: �
+        ///
+        /// [byteslice]: prim@slice
+        /// [U+FFFD]: core::char::REPLACEMENT_CHARACTER
+        ///
+        /// If you are sure that the byte slice is valid UTF-8, and you don't want
+        /// to incur the overhead of the conversion, there is an unsafe version
+        /// of this function, [`from_utf8_unchecked`], which has the same behavior
+        /// but skips the checks.
+        ///
+        /// [`from_utf8_unchecked`]: Self::from_utf8_unchecked
+        impl
+        #[must_use]
+        do examples
+        /// Basic usage:
+        ///
+        /// ```
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::new();
+        /// // some bytes, in a vector
+        /// let sparkle_heart = [240, 159, 146, 150];
+        ///
+        /// let sparkle_heart = BumpString::from_utf8_lossy_in(&sparkle_heart, &bump);
+        ///
+        /// assert_eq!("💖", sparkle_heart);
+        /// ```
+        ///
+        /// Incorrect bytes:
+        ///
+        /// ```
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::new();
+        /// // some invalid bytes
+        /// let input = b"Hello \xF0\x90\x80World";
+        /// let output = BumpString::from_utf8_lossy_in(input, &bump);
+        ///
+        /// assert_eq!("Hello �World", output);
+        /// ```
+        for fn from_utf8_lossy_in
+        do examples
+        /// Basic usage:
+        ///
+        /// ```
+        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::try_new()?;
+        /// // some bytes, in a vector
+        /// let sparkle_heart = [240, 159, 146, 150];
+        ///
+        /// let sparkle_heart = BumpString::try_from_utf8_lossy_in(&sparkle_heart, &bump)?;
+        ///
+        /// assert_eq!("💖", sparkle_heart);
+        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
+        /// ```
+        ///
+        /// Incorrect bytes:
+        ///
+        /// ```
+        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::try_new()?;
+        /// // some invalid bytes
+        /// let input = b"Hello \xF0\x90\x80World";
+        /// let output = BumpString::try_from_utf8_lossy_in(input, &bump)?;
+        ///
+        /// assert_eq!("Hello �World", output);
+        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
+        /// ```
+        for fn try_from_utf8_lossy_in
+        use fn generic_from_utf8_lossy_in(v: &[u8], allocator: A) -> Self {
+            let mut iter = crate::polyfill::str::lossy::utf8_chunks(v);
+
+            let first_valid = if let Some(chunk) = iter.next() {
+                let valid = chunk.valid();
+                if chunk.invalid().is_empty() {
+                    debug_assert_eq!(valid.len(), v.len());
+                    return Self::generic_from_str_in(valid, allocator);
+                }
+                valid
+            } else {
+                return Ok(Self::new_in(allocator));
+            };
+
+            const REPLACEMENT: &str = "\u{FFFD}";
+
+            let mut res = Self::generic_with_capacity_in(v.len(), allocator)?;
+            res.generic_push_str(first_valid)?;
+            res.generic_push_str(REPLACEMENT)?;
+
+            for chunk in iter {
+                res.generic_push_str(chunk.valid())?;
+                if !chunk.invalid().is_empty() {
+                    res.generic_push_str(REPLACEMENT)?;
+                }
+            }
+
+            Ok(res)
+        }
+
+        /// Decode a UTF-16–encoded vector `v` into a `BumpString`, returning [`Err`]
+        /// if `v` contains any invalid data.
+        impl
+        #[allow(clippy::missing_errors_doc)]
+        do examples
+        /// ```
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::new();
+        /// // 𝄞music
+        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+        ///           0x0073, 0x0069, 0x0063];
+        /// assert_eq!(BumpString::from_str_in("𝄞music", &bump),
+        ///            BumpString::from_utf16_in(v, &bump).unwrap());
+        ///
+        /// // 𝄞mu<invalid>ic
+        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+        ///           0xD800, 0x0069, 0x0063];
+        /// assert!(BumpString::from_utf16_in(v, &bump).is_err());
+        /// ```
+        for fn from_utf16_in
+        do examples
+        /// ```
+        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::try_new()?;
+        /// // 𝄞music
+        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+        ///           0x0073, 0x0069, 0x0063];
+        /// assert_eq!(BumpString::try_from_str_in("𝄞music", &bump)?,
+        ///            BumpString::try_from_utf16_in(v, &bump)?.unwrap());
+        ///
+        /// // 𝄞mu<invalid>ic
+        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+        ///           0xD800, 0x0069, 0x0063];
+        /// assert!(BumpString::try_from_utf16_in(v, &bump)?.is_err());
+        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
+        /// ```
+        for fn try_from_utf16_in
+        use fn generic_from_utf16_in(v: &[u16], allocator: A) -> Result<Self, FromUtf16Error> {
+            // This isn't done via collect::<Result<_, _>>() for performance reasons.
+            // FIXME: the function can be simplified again when #48994 is closed.
+            let mut ret = Self::generic_with_capacity_in(v.len(), allocator)?;
+
+            for c in char::decode_utf16(v.iter().copied()) {
+                if let Ok(c) = c {
+                    ret.generic_push(c)?;
+                } else {
+                    return Ok(Err(FromUtf16Error(())));
+                }
+            }
+
+            Ok(Ok(ret))
+        }
+
+        /// Decode a UTF-16–encoded slice `v` into a `BumpString`, replacing
+        /// invalid data with [the replacement character (`U+FFFD`)][U+FFFD].
+        ///
+        /// [U+FFFD]: core::char::REPLACEMENT_CHARACTER
+        impl
+        #[must_use]
+        do examples
+        /// ```
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::new();
+        /// // 𝄞mus<invalid>ic<invalid>
+        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+        ///           0x0073, 0xDD1E, 0x0069, 0x0063,
+        ///           0xD834];
+        ///
+        /// assert_eq!(BumpString::from_str_in("𝄞mus\u{FFFD}ic\u{FFFD}", &bump),
+        ///            BumpString::from_utf16_lossy_in(v, &bump));
+        /// ```
+        for fn from_utf16_lossy_in
+        do examples
+        /// ```
+        /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
+        /// # use bump_scope::{ Bump, BumpString };
+        /// # let bump: Bump = Bump::try_new()?;
+        /// // 𝄞mus<invalid>ic<invalid>
+        /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+        ///           0x0073, 0xDD1E, 0x0069, 0x0063,
+        ///           0xD834];
+        ///
+        /// assert_eq!(BumpString::try_from_str_in("𝄞mus\u{FFFD}ic\u{FFFD}", &bump)?,
+        ///            BumpString::try_from_utf16_lossy_in(v, &bump)?);
+        /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
+        /// ```
+        for fn try_from_utf16_lossy_in
+        #[inline]
+        use fn generic_from_utf16_lossy_in(v: &[u16], allocator: A) -> Self {
+            let iter = char::decode_utf16(v.iter().copied());
+            let capacity = iter.size_hint().0;
+            let mut string = Self::generic_with_capacity_in(capacity, allocator)?;
+
+            for r in iter {
+                string.generic_push(r.unwrap_or(char::REPLACEMENT_CHARACTER))?;
+            }
+
+            Ok(string)
+        }
         /// Appends the given [`char`] to the end of this string.
         impl
         do examples
@@ -1287,6 +1272,13 @@ impl<A: BumpAllocator> BumpString<A> {
     #[inline(always)]
     pub fn allocator(&self) -> &A {
         &self.allocator
+    }
+
+    /// Returns a type which provides statistics about the memory usage of the bump allocator.
+    #[must_use]
+    #[inline(always)]
+    pub fn stats(&self) -> Stats {
+        self.allocator.stats()
     }
 }
 

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -1355,7 +1355,7 @@ impl<'a, A: BumpAllocatorScope<'a>> BumpString<A> {
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, true> {
+    pub fn stats(&self) -> Stats<'a> {
         todo!()
     }
 }

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -3,8 +3,7 @@ use crate::Infallibly;
 use crate::{
     destructure::destructure,
     error_behavior_generic_methods_allocation_failure, owned_str,
-    polyfill::{self, nonnull, transmute_mut, transmute_value},
-    raw_bump_box::RawBumpBox,
+    polyfill::{self, transmute_mut, transmute_value},
     raw_fixed_bump_string::RawFixedBumpString,
     BumpAllocator, BumpAllocatorScope, BumpBox, BumpVec, ErrorBehavior, FixedBumpString, FromUtf16Error, FromUtf8Error,
     Stats,
@@ -14,11 +13,16 @@ use core::{
     borrow::{Borrow, BorrowMut},
     fmt::{self, Debug, Display},
     hash::Hash,
-    mem::MaybeUninit,
     ops::{Deref, DerefMut, Range, RangeBounds},
     panic::{RefUnwindSafe, UnwindSafe},
     ptr, str,
 };
+
+#[cfg(not(no_global_oom_handling))]
+use core::mem::MaybeUninit;
+
+#[cfg(not(no_global_oom_handling))]
+use crate::{polyfill::nonnull, raw_bump_box::RawBumpBox};
 
 /// This is like [`format!`] but allocates inside a `Bump` or `BumpScope`, returning a [`BumpString`].
 ///

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -38,7 +38,7 @@ pub use splice::Splice;
 
 /// This is like [`vec!`] but allocates inside a `Bump` or `BumpScope`, returning a [`BumpVec`].
 ///
-/// `$bump` can be a [`Bump`](crate::Bump) or [`BumpScope`] (anything where `$bump.as_scope()` returns a `&BumpScope`).
+/// `$bump` can be any type that implements [`BumpAllocator`].
 ///
 /// # Panics
 /// If used without `try`, panics on allocation failure.

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -197,35 +197,33 @@ impl<T, A: BumpAllocator> DerefMut for BumpVec<T, A> {
 
 impl<T, A: BumpAllocator> Drop for BumpVec<T, A> {
     fn drop(&mut self) {
-        if !self.allocator.is_exclusive_allocator() {
-            struct DropGuard<'a, T, A: BumpAllocator>(&'a mut BumpVec<T, A>);
+        struct DropGuard<'a, T, A: BumpAllocator>(&'a mut BumpVec<T, A>);
 
-            impl<T, A: BumpAllocator> Drop for DropGuard<'_, T, A> {
-                fn drop(&mut self) {
-                    // TODO: simplify disclaimer, dangling means size is 0 other things don't really matter
-                    // SAFETY:
-                    // The dangling pointer smaller than 16 can not be a valid ptr into a chunk because
-                    // of the minimum chunk alignment of 16. The bump allocator handles deallocate requests
-                    // from pointers outside its bound just fine by ignoring them.
-                    //
-                    // A deallocation with a dangling pointer higher than 16 would still
-                    // be fine because the layout size is zero and the alignment is higher than
-                    // any requested minimum alignment. So the bump pointer won't move at all.
-                    unsafe {
-                        let ptr = self.0.fixed.initialized.as_non_null_ptr().cast();
-                        let layout = Layout::from_size_align_unchecked(self.0.fixed.capacity * T::SIZE, T::ALIGN);
-                        self.0.allocator.deallocate(ptr, layout);
-                    }
+        impl<T, A: BumpAllocator> Drop for DropGuard<'_, T, A> {
+            fn drop(&mut self) {
+                // TODO: simplify disclaimer, dangling means size is 0 other things don't really matter
+                // SAFETY:
+                // The dangling pointer smaller than 16 can not be a valid ptr into a chunk because
+                // of the minimum chunk alignment of 16. The bump allocator handles deallocate requests
+                // from pointers outside its bound just fine by ignoring them.
+                //
+                // A deallocation with a dangling pointer higher than 16 would still
+                // be fine because the layout size is zero and the alignment is higher than
+                // any requested minimum alignment. So the bump pointer won't move at all.
+                unsafe {
+                    let ptr = self.0.fixed.initialized.as_non_null_ptr().cast();
+                    let layout = Layout::from_size_align_unchecked(self.0.fixed.capacity * T::SIZE, T::ALIGN);
+                    self.0.allocator.deallocate(ptr, layout);
                 }
             }
-
-            let guard = DropGuard(self);
-
-            // destroy the remaining elements
-            guard.0.clear();
-
-            // now `guard` will be dropped and deallocate the memory
         }
+
+        let guard = DropGuard(self);
+
+        // destroy the remaining elements
+        guard.0.clear();
+
+        // now `guard` will be dropped and deallocate the memory
     }
 }
 
@@ -1573,11 +1571,9 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
                         let drop_len = pointer::sub_ptr(self.dst, drop_ptr);
                         ptr::slice_from_raw_parts_mut(drop_ptr, drop_len).drop_in_place();
 
-                        if !self.allocator.is_exclusive_allocator() {
-                            // deallocate memory block (for additional safety notes see `Self::drop::DropGuard::drop`)
-                            let layout = Layout::from_size_align_unchecked(self.cap * T::SIZE, T::ALIGN);
-                            self.allocator.deallocate(self.ptr.cast(), layout);
-                        }
+                        // deallocate memory block (for additional safety notes see `Self::drop::DropGuard::drop`)
+                        let layout = Layout::from_size_align_unchecked(self.cap * T::SIZE, T::ALIGN);
+                        self.allocator.deallocate(self.ptr.cast(), layout);
                     }
                 }
             }
@@ -1663,48 +1659,41 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     pub fn map_in_place<U>(self, f: impl FnMut(T) -> U) -> BumpVec<U, A> {
         destructure!(let Self { fixed, allocator } = self);
 
-        if allocator.is_exclusive_allocator() {
-            let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().map_in_place(f)) };
-            BumpVec { fixed, allocator }
-        } else {
-            // `FixedBumpVec::map_in_place` handles dropping `T`s and `U`s on panic.
-            // What is left to do is deallocating the memory.
+        // `FixedBumpVec::map_in_place` handles dropping `T`s and `U`s on panic.
+        // What is left to do is deallocating the memory.
 
-            struct DropGuard<T, A: BumpAllocator> {
-                ptr: NonNull<T>,
-                cap: usize,
-                allocator: A,
-            }
-
-            impl<T, A: BumpAllocator> DropGuard<T, A> {
-                fn into_allocator(self) -> A {
-                    destructure!(let Self { allocator } = self);
-                    allocator
-                }
-            }
-
-            impl<T, A: BumpAllocator> Drop for DropGuard<T, A> {
-                fn drop(&mut self) {
-                    unsafe {
-                        if !self.allocator.is_exclusive_allocator() {
-                            let layout = Layout::from_size_align_unchecked(self.cap * T::SIZE, T::ALIGN);
-                            self.allocator.deallocate(self.ptr.cast(), layout);
-                        }
-                    }
-                }
-            }
-
-            let guard = DropGuard::<T, _> {
-                ptr: fixed.initialized.as_non_null_ptr().cast(),
-                cap: fixed.capacity,
-                allocator,
-            };
-
-            let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().map_in_place(f)) };
-            let allocator = guard.into_allocator();
-
-            BumpVec { fixed, allocator }
+        struct DropGuard<T, A: BumpAllocator> {
+            ptr: NonNull<T>,
+            cap: usize,
+            allocator: A,
         }
+
+        impl<T, A: BumpAllocator> DropGuard<T, A> {
+            fn into_allocator(self) -> A {
+                destructure!(let Self { allocator } = self);
+                allocator
+            }
+        }
+
+        impl<T, A: BumpAllocator> Drop for DropGuard<T, A> {
+            fn drop(&mut self) {
+                unsafe {
+                    let layout = Layout::from_size_align_unchecked(self.cap * T::SIZE, T::ALIGN);
+                    self.allocator.deallocate(self.ptr.cast(), layout);
+                }
+            }
+        }
+
+        let guard = DropGuard::<T, _> {
+            ptr: fixed.initialized.as_non_null_ptr().cast(),
+            cap: fixed.capacity,
+            allocator,
+        };
+
+        let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().map_in_place(f)) };
+        let allocator = guard.into_allocator();
+
+        BumpVec { fixed, allocator }
     }
 
     /// Creates a splicing iterator that replaces the specified range in the vector
@@ -1908,38 +1897,31 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     ///
     /// `new_capacity` must be greater than the current capacity.
     unsafe fn generic_grow_to<E: ErrorBehavior>(&mut self, new_capacity: usize) -> Result<(), E> {
-        if self.allocator.is_exclusive_allocator() {
-            let mut new_vec = RawFixedBumpVec::allocate(&mut self.allocator, new_capacity)?;
-            ptr::copy_nonoverlapping(self.as_ptr(), new_vec.as_mut_ptr(), self.len());
-            new_vec.set_len(self.len());
-            self.fixed = new_vec;
-        } else {
-            let new_cap = new_capacity;
+        let new_cap = new_capacity;
 
-            if self.capacity() == 0 {
-                self.fixed = RawFixedBumpVec::allocate(&mut self.allocator, new_cap)?;
-                return Ok(());
-            }
-
-            let old_ptr = self.as_non_null_ptr().cast();
-
-            let old_size = self.fixed.capacity * T::SIZE; // we already allocated that amount so this can't overflow
-            let new_size = new_cap.checked_mul(T::SIZE).ok_or_else(|| E::capacity_overflow())?;
-
-            let old_layout = Layout::from_size_align_unchecked(old_size, T::ALIGN);
-            let new_layout = match Layout::from_size_align(new_size, T::ALIGN) {
-                Ok(ok) => ok,
-                Err(_) => return Err(E::capacity_overflow()),
-            };
-
-            let new_ptr = match self.allocator.grow(old_ptr, old_layout, new_layout) {
-                Ok(ok) => ok.cast(),
-                Err(_) => return Err(E::allocation(new_layout)),
-            };
-
-            self.fixed.initialized.set_ptr(new_ptr);
-            self.fixed.capacity = new_cap;
+        if self.capacity() == 0 {
+            self.fixed = RawFixedBumpVec::allocate(&mut self.allocator, new_cap)?;
+            return Ok(());
         }
+
+        let old_ptr = self.as_non_null_ptr().cast();
+
+        let old_size = self.fixed.capacity * T::SIZE; // we already allocated that amount so this can't overflow
+        let new_size = new_cap.checked_mul(T::SIZE).ok_or_else(|| E::capacity_overflow())?;
+
+        let old_layout = Layout::from_size_align_unchecked(old_size, T::ALIGN);
+        let new_layout = match Layout::from_size_align(new_size, T::ALIGN) {
+            Ok(ok) => ok,
+            Err(_) => return Err(E::capacity_overflow()),
+        };
+
+        let new_ptr = match self.allocator.grow(old_ptr, old_layout, new_layout) {
+            Ok(ok) => ok.cast(),
+            Err(_) => return Err(E::allocation(new_layout)),
+        };
+
+        self.fixed.initialized.set_ptr(new_ptr);
+        self.fixed.capacity = new_cap;
 
         Ok(())
     }
@@ -1961,10 +1943,6 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     /// assert_eq!(bump.stats().allocated(), 3 * 4);
     /// ```
     pub fn shrink_to_fit(&mut self) {
-        if self.allocator.is_exclusive_allocator() {
-            return;
-        }
-
         let Self { fixed, allocator } = self;
 
         let old_ptr = fixed.initialized.ptr.cast::<T>();
@@ -2333,42 +2311,15 @@ impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
     #[must_use]
     #[inline(always)]
     pub fn into_fixed_vec(self) -> FixedBumpVec<'a, T> {
-        if self.allocator.is_exclusive_allocator() {
-            todo!()
-        } else {
-            self.into_parts().0
-        }
+        self.into_parts().0
     }
 
     /// Turns this `BumpVec<T>` into a `BumpBox<[T]>`.
     #[must_use]
     #[inline(always)]
     pub fn into_boxed_slice(mut self) -> BumpBox<'a, [T]> {
-        if self.allocator.is_exclusive_allocator() {
-            let mut this = ManuallyDrop::new(self);
-
-            unsafe {
-                if T::IS_ZST {
-                    return BumpBox::from_raw(nonnull::slice_from_raw_parts(NonNull::dangling(), this.len()));
-                }
-
-                if this.capacity() == 0 {
-                    // We didn't touch the allocator, so no need to do anything.
-                    debug_assert_eq!(this.as_non_null_ptr(), NonNull::<T>::dangling());
-                    return BumpBox::from_raw(nonnull::slice_from_raw_parts(NonNull::<T>::dangling(), 0));
-                }
-
-                let ptr = this.as_non_null_ptr();
-                let len = this.len();
-                let cap = this.capacity();
-
-                let slice = this.allocator.use_reserved_allocation(ptr, len, cap);
-                BumpBox::from_raw(slice)
-            }
-        } else {
-            self.shrink_to_fit();
-            self.into_fixed_vec().into_boxed_slice()
-        }
+        self.shrink_to_fit();
+        self.into_fixed_vec().into_boxed_slice()
     }
 
     /// Turns this `BumpVec<T>` into a `&[T]` that is live for this bump scope.
@@ -2404,11 +2355,6 @@ impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
     #[must_use]
     #[inline(always)]
     pub fn from_parts(vec: FixedBumpVec<'a, T>, allocator: A) -> Self {
-        if allocator.is_exclusive_allocator() {
-            // TODO: is this reachable?
-            unreachable!()
-        }
-
         Self {
             fixed: unsafe { RawFixedBumpVec::from_cooked(vec) },
             allocator,
@@ -2429,11 +2375,6 @@ impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
     #[must_use]
     #[inline(always)]
     pub fn into_parts(self) -> (FixedBumpVec<'a, T>, A) {
-        if self.allocator.is_exclusive_allocator() {
-            // TODO: is this reachable?
-            unreachable!()
-        }
-
         destructure!(let Self { fixed, allocator } = self);
         (unsafe { fixed.cook() }, allocator)
     }

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -2317,6 +2317,13 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     pub fn allocator(&self) -> &A {
         &self.allocator
     }
+
+    /// Returns a type which provides statistics about the memory usage of the bump allocator.
+    #[must_use]
+    #[inline(always)]
+    pub fn stats(&self) -> Stats {
+        self.allocator.stats()
+    }
 }
 
 impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
@@ -2429,13 +2436,6 @@ impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
 
         destructure!(let Self { fixed, allocator } = self);
         (unsafe { fixed.cook() }, allocator)
-    }
-
-    /// Returns a type which provides statistics about the memory usage of the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn stats(&self) -> Stats<'a> {
-        todo!()
     }
 }
 

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -288,8 +288,6 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
         for fn try_with_capacity_in
         #[inline]
         use fn generic_with_capacity_in(capacity: usize, allocator: A) -> Self {
-            let mut allocator = allocator;
-
             if T::IS_ZST {
                 return Ok(Self {
                     fixed: RawFixedBumpVec::EMPTY,
@@ -305,7 +303,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
             }
 
             Ok(Self {
-                fixed: unsafe { RawFixedBumpVec::allocate(&mut allocator, capacity)? },
+                fixed: unsafe { RawFixedBumpVec::allocate(&allocator, capacity)? },
                 allocator,
             })
         }
@@ -344,7 +342,6 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
             #![allow(clippy::needless_pass_by_ref_mut)]
 
             let array = ManuallyDrop::new(array);
-            let mut allocator = allocator;
 
             if T::IS_ZST {
                 return Ok(Self {
@@ -360,7 +357,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
                 });
             }
 
-            let mut fixed = unsafe { RawFixedBumpVec::allocate(&mut allocator, N)? };
+            let mut fixed = unsafe { RawFixedBumpVec::allocate(&allocator, N)? };
 
             let src = array.as_ptr();
             let dst = fixed.initialized.ptr.cast::<T>().as_ptr();
@@ -1900,7 +1897,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
         let new_cap = new_capacity;
 
         if self.capacity() == 0 {
-            self.fixed = RawFixedBumpVec::allocate(&mut self.allocator, new_cap)?;
+            self.fixed = RawFixedBumpVec::allocate(&self.allocator, new_cap)?;
             return Ok(());
         }
 

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -307,7 +307,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
             }
 
             Ok(Self {
-                fixed: unsafe { RawFixedBumpVec::allocate_greedy(&mut allocator, capacity)? },
+                fixed: unsafe { RawFixedBumpVec::allocate(&mut allocator, capacity)? },
                 allocator,
             })
         }
@@ -362,7 +362,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
                 });
             }
 
-            let mut fixed = unsafe { RawFixedBumpVec::allocate_greedy(&mut allocator, N)? };
+            let mut fixed = unsafe { RawFixedBumpVec::allocate(&mut allocator, N)? };
 
             let src = array.as_ptr();
             let dst = fixed.initialized.ptr.cast::<T>().as_ptr();
@@ -1909,7 +1909,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     /// `new_capacity` must be greater than the current capacity.
     unsafe fn generic_grow_to<E: ErrorBehavior>(&mut self, new_capacity: usize) -> Result<(), E> {
         if self.allocator.is_exclusive_allocator() {
-            let mut new_vec = RawFixedBumpVec::allocate_greedy(&mut self.allocator, new_capacity)?;
+            let mut new_vec = RawFixedBumpVec::allocate(&mut self.allocator, new_capacity)?;
             ptr::copy_nonoverlapping(self.as_ptr(), new_vec.as_mut_ptr(), self.len());
             new_vec.set_len(self.len());
             self.fixed = new_vec;
@@ -1917,7 +1917,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
             let new_cap = new_capacity;
 
             if self.capacity() == 0 {
-                self.fixed = RawFixedBumpVec::allocate(&self.allocator, new_cap)?;
+                self.fixed = RawFixedBumpVec::allocate(&mut self.allocator, new_cap)?;
                 return Ok(());
             }
 

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -1961,6 +1961,10 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     /// assert_eq!(bump.stats().allocated(), 3 * 4);
     /// ```
     pub fn shrink_to_fit(&mut self) {
+        if self.allocator.supports_greedy_allocations() {
+            return;
+        }
+
         let Self { fixed, allocator } = self;
 
         let old_ptr = fixed.initialized.ptr.cast::<T>();

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -454,9 +454,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
             Ok(vec)
         }
     }
-}
 
-impl<T, A: BumpAllocator> BumpVec<T, A> {
     /// Returns the total number of elements the vector can hold without
     /// reallocating.
     ///
@@ -764,9 +762,7 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
     pub(crate) unsafe fn inc_len(&mut self, amount: usize) {
         unsafe { self.fixed.cook_mut() }.inc_len(amount);
     }
-}
 
-impl<T, A: BumpAllocator> BumpVec<T, A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Appends an element to the back of a collection.
         impl

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -91,6 +91,8 @@ pub use splice::Splice;
 /// Also, note that `bump_vec![in &bump; expr; 0]` is allowed, and produces an empty vector.
 /// This will still evaluate `expr`, however, and immediately drop the resulting value, so
 /// be mindful of side effects.
+///
+/// [`BumpScope`]: crate::BumpScope
 #[macro_export]
 macro_rules! bump_vec {
     [in $bump:expr] => {

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -2434,7 +2434,7 @@ impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, true> {
+    pub fn stats(&self) -> Stats<'a> {
         todo!()
     }
 }

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -3,14 +3,15 @@ mod into_iter;
 mod splice;
 
 use crate::{
-    bump_down,
     destructure::destructure,
     error_behavior_generic_methods_allocation_failure, min_non_zero_cap, owned_slice,
     polyfill::{nonnull, pointer, slice},
-    up_align_usize_unchecked, BaseAllocator, BumpBox, BumpScope, ErrorBehavior, FixedBumpVec, GuaranteedAllocatedStats,
-    MinimumAlignment, NoDrop, SetLenOnDropByPtr, SizedTypeProperties, Stats, SupportedMinimumAlignment,
+    raw_bump_box::RawBumpBox,
+    raw_fixed_bump_vec::RawFixedBumpVec,
+    BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, FixedBumpVec, NoDrop, SetLenOnDropByPtr, SizedTypeProperties,
+    Stats,
 };
-use allocator_api2::alloc::{AllocError, Allocator};
+use allocator_api2::alloc::AllocError;
 use core::{
     alloc::Layout,
     borrow::{Borrow, BorrowMut},
@@ -18,9 +19,7 @@ use core::{
     hash::Hash,
     iter,
     marker::PhantomData,
-    mem,
     mem::{ManuallyDrop, MaybeUninit},
-    num::NonZeroUsize,
     ops::{Deref, DerefMut, Index, IndexMut, RangeBounds},
     panic::{RefUnwindSafe, UnwindSafe},
     ptr::{self, NonNull},
@@ -55,7 +54,7 @@ pub use splice::Splice;
 /// ```
 /// # use bump_scope::{ bump_vec, Bump, BumpVec };
 /// # let bump: Bump = Bump::new();
-/// let vec: BumpVec<i32> = bump_vec![in bump];
+/// let vec: BumpVec<i32, _> = bump_vec![in &bump];
 /// assert!(vec.is_empty());
 /// ```
 ///
@@ -64,7 +63,7 @@ pub use splice::Splice;
 /// ```
 /// # use bump_scope::{ bump_vec, Bump };
 /// # let bump: Bump = Bump::new();
-/// let vec = bump_vec![in bump; 1, 2, 3];
+/// let vec = bump_vec![in &bump; 1, 2, 3];
 /// assert_eq!(vec[0], 1);
 /// assert_eq!(vec[1], 2);
 /// assert_eq!(vec[2], 3);
@@ -75,7 +74,7 @@ pub use splice::Splice;
 /// ```
 /// # use bump_scope::{ bump_vec, Bump };
 /// # let bump: Bump = Bump::new();
-/// let vec = bump_vec![in bump; 1; 3];
+/// let vec = bump_vec![in &bump; 1; 3];
 /// assert_eq!(vec, [1, 1, 1]);
 /// ```
 ///
@@ -85,169 +84,120 @@ pub use splice::Splice;
 ///
 /// This will use `clone` to duplicate an expression, so one should be careful
 /// using this with types having a nonstandard `Clone` implementation. For
-/// example, `bump_vec![in bump; Rc::new(1); 5]` will create a vector of five references
+/// example, `bump_vec![in &bump; Rc::new(1); 5]` will create a vector of five references
 /// to the same boxed integer value, not five references pointing to independently
 /// boxed integers.
 ///
-/// Also, note that `bump_vec![in bump; expr; 0]` is allowed, and produces an empty vector.
+/// Also, note that `bump_vec![in &bump; expr; 0]` is allowed, and produces an empty vector.
 /// This will still evaluate `expr`, however, and immediately drop the resulting value, so
 /// be mindful of side effects.
 #[macro_export]
 macro_rules! bump_vec {
     [in $bump:expr] => {
-        $crate::BumpVec::new_in($bump.as_scope())
+        $crate::BumpVec::new_in($bump)
     };
     [in $bump:expr; $($values:expr),* $(,)?] => {
-        $crate::BumpVec::from_array_in([$($values),*], $bump.as_scope())
+        $crate::BumpVec::from_array_in([$($values),*], $bump)
     };
     [in $bump:expr; $value:expr; $count:expr] => {
-        $crate::BumpVec::from_elem_in($value, $count, $bump.as_scope())
+        $crate::BumpVec::from_elem_in($value, $count, $bump)
     };
     [try in $bump:expr] => {
-        Ok::<_, $crate::allocator_api2::alloc::AllocError>($crate::BumpVec::new_in($bump.as_scope()))
+        Ok::<_, $crate::allocator_api2::alloc::AllocError>($crate::BumpVec::new_in($bump))
     };
     [try in $bump:expr; $($values:expr),* $(,)?] => {
-        $crate::BumpVec::try_from_array_in([$($values),*], $bump.as_scope())
+        $crate::BumpVec::try_from_array_in([$($values),*], $bump)
     };
     [try in $bump:expr; $value:expr; $count:expr] => {
-        $crate::BumpVec::try_from_elem_in($value, $count, $bump.as_scope())
+        $crate::BumpVec::try_from_elem_in($value, $count, $bump)
     };
 }
 
-macro_rules! bump_vec_declaration {
-    ($($allocator_parameter:tt)*) => {
-        /// A bump allocated [`Vec`](alloc::vec::Vec).
-        ///
-        /// The main difference to `Vec` is that it can be turned into a slice that is live for this bump scope (`'a`).
-        /// Such a slice can be live while entering new scopes.
-        ///
-        /// This would not be possible with `Vec`:
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, BumpVec };
-        /// # let mut bump: Bump = Bump::new();
-        /// let bump = bump.as_mut_scope();
-        ///
-        /// let slice = {
-        ///     let mut vec = BumpVec::new_in(&*bump);
-        ///
-        ///     vec.push(1);
-        ///     vec.push(2);
-        ///     vec.push(3);
-        ///
-        ///     vec.into_slice()
-        /// };
-        ///
-        /// bump.scoped(|bump| {
-        ///     // allocate more things
-        /// });
-        ///
-        /// assert_eq!(slice, [1, 2, 3]);
-        /// ```
-        ///
-        /// # Examples
-        ///
-        /// This type can be used to allocate a slice, when `alloc_*` methods are too limiting:
-        /// ```
-        /// use bump_scope::{ Bump, BumpVec };
-        /// let bump: Bump = Bump::new();
-        /// let mut vec = BumpVec::new_in(&bump);
-        ///
-        /// vec.push(1);
-        /// vec.push(2);
-        /// vec.push(3);
-        ///
-        /// let slice: &[i32] = vec.into_slice();
-        ///
-        /// assert_eq!(slice, [1, 2, 3]);
-        /// ```
-        // `BumpString` and `BumpVec<u8>` have the same repr.
-        #[repr(C)]
-        pub struct BumpVec<
-            'b,
-            'a: 'b,
-            T,
-            $($allocator_parameter)*,
-            const MIN_ALIGN: usize = 1,
-            const UP: bool = true,
-            const GUARANTEED_ALLOCATED: bool = true,
-        >
-        where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>,
-        {
-            pub(crate) fixed: FixedBumpVec<'a, T>,
-            pub(crate) bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-        }
-    };
+/// A bump allocated [`Vec`](alloc::vec::Vec).
+///
+/// The main difference to `Vec` is that it can be turned into a slice that is live for this bump scope (`'a`).
+/// Such a slice can be live while entering new scopes.
+///
+/// This would not be possible with `Vec`:
+///
+/// ```
+/// # use bump_scope::{ Bump, BumpVec };
+/// # let mut bump: Bump = Bump::new();
+/// let bump = bump.as_mut_scope();
+///
+/// let slice = {
+///     let mut vec = BumpVec::new_in(&*bump);
+///
+///     vec.push(1);
+///     vec.push(2);
+///     vec.push(3);
+///
+///     vec.into_slice()
+/// };
+///
+/// bump.scoped(|bump| {
+///     // allocate more things
+/// });
+///
+/// assert_eq!(slice, [1, 2, 3]);
+/// ```
+///
+/// # Examples
+///
+/// This type can be used to allocate a slice, when `alloc_*` methods are too limiting:
+/// ```
+/// use bump_scope::{ Bump, BumpVec };
+/// let bump: Bump = Bump::new();
+/// let mut vec = BumpVec::new_in(&bump);
+///
+/// vec.push(1);
+/// vec.push(2);
+/// vec.push(3);
+///
+/// let slice: &[i32] = vec.into_slice();
+///
+/// assert_eq!(slice, [1, 2, 3]);
+/// ```
+// `BumpString` and `BumpVec<u8>` have the same repr.
+#[repr(C)]
+pub struct BumpVec<T, A: BumpAllocator> {
+    pub(crate) fixed: RawFixedBumpVec<T>,
+    pub(crate) allocator: A,
 }
 
-crate::maybe_default_allocator!(bump_vec_declaration);
-
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> UnwindSafe
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, A: BumpAllocator> UnwindSafe for BumpVec<T, A>
 where
     T: UnwindSafe,
     A: UnwindSafe,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> RefUnwindSafe
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, A: BumpAllocator> RefUnwindSafe for BumpVec<T, A>
 where
     T: RefUnwindSafe,
     A: RefUnwindSafe,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Deref
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> Deref for BumpVec<T, A> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        &self.fixed
+        unsafe { self.fixed.cook_ref() }
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DerefMut
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> DerefMut for BumpVec<T, A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.fixed
+        unsafe { self.fixed.cook_mut() }
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> Drop for BumpVec<T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'i, 'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
-            &'i mut BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-        )
-        where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>;
+        struct DropGuard<'a, T, A: BumpAllocator>(&'a mut BumpVec<T, A>);
 
-        impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
-            for DropGuard<'_, '_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-        where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>,
-        {
+        impl<T, A: BumpAllocator> Drop for DropGuard<'_, T, A> {
             fn drop(&mut self) {
                 // SAFETY:
                 // The dangling pointer smaller than 16 can not be a valid ptr into a chunk because
@@ -258,9 +208,9 @@ where
                 // be fine because the layout size is zero and the alignment is higher than
                 // any requested minimum alignment. So the bump pointer won't move at all.
                 unsafe {
-                    let ptr = self.0.fixed.initialized.ptr.cast();
+                    let ptr = self.0.fixed.initialized.as_non_null_ptr().cast();
                     let layout = Layout::from_size_align_unchecked(self.0.fixed.capacity * T::SIZE, T::ALIGN);
-                    self.0.bump.deallocate(ptr, layout);
+                    self.0.allocator.deallocate(ptr, layout);
                 }
             }
         }
@@ -275,27 +225,25 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Clone
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-    T: Clone,
-{
+impl<T: Clone, A: BumpAllocator + Clone> Clone for BumpVec<T, A> {
     fn clone(&self) -> Self {
+        let allocator = self.allocator.clone();
+        let ptr = allocator.allocate_slice::<MaybeUninit<T>>(self.len());
+        let slice = nonnull::slice_from_raw_parts(ptr, self.len());
+        let boxed = unsafe { BumpBox::from_raw(slice) };
+        let boxed = boxed.init_clone(self);
+
         Self {
-            fixed: FixedBumpVec::from_init(self.bump.alloc_slice_clone(self)),
-            bump: self.bump,
+            fixed: RawFixedBumpVec {
+                initialized: unsafe { RawBumpBox::from_cooked(boxed) },
+                capacity: self.len(),
+            },
+            allocator,
         }
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> BumpVec<T, A> {
     /// Constructs a new empty `BumpVec<T>`.
     ///
     /// The vector will not allocate until elements are pushed onto it.
@@ -306,13 +254,13 @@ where
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
     /// # #[allow(unused_mut)]
-    /// let mut vec = BumpVec::<i32>::new_in(&bump);
+    /// let mut vec = BumpVec::<i32, _>::new_in(&bump);
     /// ```
     #[inline]
-    pub fn new_in(bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+    pub const fn new_in(allocator: A) -> Self {
         Self {
-            fixed: FixedBumpVec::EMPTY,
-            bump: bump.into(),
+            fixed: RawFixedBumpVec::EMPTY,
+            allocator,
         }
     }
 
@@ -336,26 +284,24 @@ where
         for fn with_capacity_in
         for fn try_with_capacity_in
         #[inline]
-        use fn generic_with_capacity_in(capacity: usize, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
-            let bump = bump.into();
-
+        use fn generic_with_capacity_in(capacity: usize, allocator: A) -> Self {
             if T::IS_ZST {
                 return Ok(Self {
-                    fixed: FixedBumpVec::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpVec::EMPTY,
+                    allocator,
                 });
             }
 
             if capacity == 0 {
                 return Ok(Self {
-                    fixed: FixedBumpVec::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpVec::EMPTY,
+                    allocator,
                 });
             }
 
             Ok(Self {
-                fixed: bump.generic_alloc_fixed_vec(capacity)?,
-                bump,
+                fixed: unsafe { RawFixedBumpVec::allocate(&allocator, capacity)? },
+                allocator,
             })
         }
 
@@ -364,11 +310,11 @@ where
         for fn from_elem_in
         for fn try_from_elem_in
         #[inline]
-        use fn generic_from_elem_in(value: T, count: usize, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_elem_in(value: T, count: usize, allocator: A) -> Self
         where {
             T: Clone
         } in {
-            let mut vec = Self::generic_with_capacity_in(count, bump)?;
+            let mut vec = Self::generic_with_capacity_in(count, allocator)?;
 
             unsafe {
                 if count != 0 {
@@ -388,38 +334,37 @@ where
         for fn from_array_in
         for fn try_from_array_in
         #[inline]
-        use fn generic_from_array_in<{const N: usize}>(array: [T; N], bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+        use fn generic_from_array_in<{const N: usize}>(array: [T; N], allocator: A) -> Self {
             #![allow(clippy::needless_pass_by_value)]
             #![allow(clippy::needless_pass_by_ref_mut)]
 
             let array = ManuallyDrop::new(array);
-            let bump = bump.into();
 
             if T::IS_ZST {
                 return Ok(Self {
-                    fixed: FixedBumpVec { initialized: unsafe { BumpBox::from_raw(nonnull::slice_from_raw_parts(NonNull::dangling(), N)) }, capacity: usize::MAX },
-                    bump,
+                    fixed: RawFixedBumpVec { initialized: unsafe { RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(NonNull::dangling(), N)) }, capacity: usize::MAX },
+                    allocator,
                 });
             }
 
             if N == 0 {
                 return Ok(Self {
-                    fixed: FixedBumpVec::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpVec::EMPTY,
+                    allocator,
                 });
             }
 
-            let mut fixed = bump.generic_alloc_fixed_vec(N)?;
+            let mut fixed = unsafe { RawFixedBumpVec::allocate(&allocator, N)? };
 
             let src = array.as_ptr();
-            let dst = fixed.as_mut_ptr();
+            let dst = fixed.initialized.ptr.cast::<T>().as_ptr();
 
             unsafe {
                 ptr::copy_nonoverlapping(src, dst, N);
                 fixed.set_len(N);
             }
 
-            Ok(Self { fixed, bump })
+            Ok(Self { fixed, allocator })
         }
 
         /// Create a new [`BumpVec`] whose elements are taken from an iterator and allocated in the given `bump`.
@@ -447,12 +392,20 @@ where
         /// ```
         for fn try_from_iter_in
         #[inline]
-        use fn generic_from_iter_in<{I}>(iter: I, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_iter_in<{I}>(iter: I, allocator: A) -> Self
         where {
             I: IntoIterator<Item = T>
         } in {
-            let bump = bump.into();
-            Ok(Self { fixed: FixedBumpVec::generic_from_iter_in(iter, bump)?, bump })
+            let iter = iter.into_iter();
+            let capacity = iter.size_hint().0;
+
+            let mut vec = Self::generic_with_capacity_in(capacity, allocator)?;
+
+            for value in iter {
+                vec.generic_push(value)?;
+            }
+
+            Ok(vec)
         }
 
         /// Create a new [`BumpVec`] whose elements are taken from an iterator and allocated in the given `bump`.
@@ -478,23 +431,30 @@ where
         /// ```
         for fn try_from_iter_exact_in
         #[inline]
-        use fn generic_from_iter_exact_in<{I}>(iter: I, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_iter_exact_in<{I}>(iter: I, allocator: A) -> Self
         where {
             I: IntoIterator<Item = T>,
             I::IntoIter: ExactSizeIterator,
         } in {
-            let bump = bump.into();
-            Ok(Self { fixed: FixedBumpVec::generic_from_iter_exact_in(iter, bump)?, bump })
+            let mut iter = iter.into_iter();
+            let len = iter.len();
+
+            let mut vec = Self::generic_with_capacity_in(len, allocator)?;
+
+            while vec.len() != vec.capacity() {
+                match iter.next() {
+                    // SAFETY: we checked above that `len != capacity`, so there is space
+                    Some(value) => unsafe { vec.unchecked_push(value) },
+                    None => break,
+                }
+            }
+
+            Ok(vec)
         }
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> BumpVec<T, A> {
     /// Returns the total number of elements the vector can hold without
     /// reallocating.
     ///
@@ -503,13 +463,13 @@ where
     /// ```
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
-    /// let vec = BumpVec::<i32>::with_capacity_in(2048, &bump);
+    /// let vec = BumpVec::<i32, _>::with_capacity_in(2048, &bump);
     /// assert!(vec.capacity() >= 2048);
     /// ```
     #[must_use]
     #[inline(always)]
     pub const fn capacity(&self) -> usize {
-        self.fixed.capacity()
+        self.fixed.capacity
     }
 
     /// Returns the number of elements in the vector, also referred to
@@ -524,7 +484,7 @@ where
     #[must_use]
     #[inline(always)]
     pub const fn is_empty(&self) -> bool {
-        self.fixed.is_empty()
+        self.fixed.len() == 0
     }
 
     /// Splits the collection into two at the given index.
@@ -544,7 +504,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, BumpVec, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 3];
     /// let vec2 = vec.split_off(1);
     /// assert_eq!(vec, [1]);
     /// assert_eq!(vec2, [2, 3]);
@@ -552,9 +512,13 @@ where
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[must_use = "use `.truncate()` if you don't need the other half"]
-    pub fn split_off(&mut self, at: usize) -> Self {
+    pub fn split_off(&mut self, at: usize) -> Self
+    where
+        A: Clone,
+    {
         #[cold]
         #[inline(never)]
+        #[track_caller]
         fn assert_failed(at: usize, len: usize) -> ! {
             panic!("`at` split index (is {at}) should be <= len (is {len})");
         }
@@ -563,13 +527,8 @@ where
             assert_failed(at, self.len());
         }
 
-        if at == 0 {
-            // the new vector can take over the original buffer and avoid the copy
-            return mem::replace(self, BumpVec::with_capacity_in(self.capacity(), self.bump()));
-        }
-
         let other_len = self.len() - at;
-        let mut other = BumpVec::with_capacity_in(other_len, self.bump());
+        let mut other = Self::with_capacity_in(other_len, self.allocator().clone());
 
         // Unsafely `set_len` and copy items to `other`.
         unsafe {
@@ -578,7 +537,6 @@ where
 
             ptr::copy_nonoverlapping(self.as_ptr().add(at), other.as_mut_ptr(), other.len());
         }
-
         other
     }
 
@@ -586,7 +544,7 @@ where
     /// is empty.
     #[inline(always)]
     pub fn pop(&mut self) -> Option<T> {
-        self.fixed.pop()
+        unsafe { self.fixed.cook_mut() }.pop()
     }
 
     /// Clears the vector, removing all values.
@@ -595,13 +553,13 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 3];
     /// vec.clear();
     /// assert!(vec.is_empty());
     /// ```
     #[inline(always)]
     pub fn clear(&mut self) {
-        self.fixed.clear();
+        unsafe { self.fixed.cook_mut() }.clear();
     }
 
     /// Shortens the vector, keeping the first `len` elements and dropping
@@ -624,7 +582,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
     /// #
-    /// let mut vec = bump_vec![in bump; 1, 2, 3, 4, 5];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 3, 4, 5];
     /// vec.truncate(2);
     /// assert_eq!(vec, [1, 2]);
     /// ```
@@ -636,7 +594,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
     /// #
-    /// let mut vec = bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 3];
     /// vec.truncate(8);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```
@@ -648,7 +606,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
     /// #
-    /// let mut vec = bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 3];
     /// vec.truncate(0);
     /// assert_eq!(vec, []);
     /// ```
@@ -656,7 +614,7 @@ where
     /// [`clear`]: Self::clear
     /// [`drain`]: Self::drain
     pub fn truncate(&mut self, len: usize) {
-        self.fixed.truncate(len);
+        unsafe { self.fixed.cook_mut() }.truncate(len);
     }
 
     /// Removes and returns the element at position `index` within the vector,
@@ -674,13 +632,13 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut v = bump_vec![in bump; 1, 2, 3];
+    /// let mut v = bump_vec![in &bump; 1, 2, 3];
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
     /// ```
     #[track_caller]
     pub fn remove(&mut self, index: usize) -> T {
-        self.fixed.remove(index)
+        unsafe { self.fixed.cook_mut() }.remove(index)
     }
 
     /// Removes an element from the vector and returns it.
@@ -699,7 +657,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
     /// #
-    /// let mut v = bump_vec![in bump; "foo", "bar", "baz", "qux"];
+    /// let mut v = bump_vec![in &bump; "foo", "bar", "baz", "qux"];
     ///
     /// assert_eq!(v.swap_remove(1), "bar");
     /// assert_eq!(v, ["foo", "qux", "baz"]);
@@ -709,7 +667,7 @@ where
     /// ```
     #[inline]
     pub fn swap_remove(&mut self, index: usize) -> T {
-        self.fixed.swap_remove(index)
+        unsafe { self.fixed.cook_mut() }.swap_remove(index)
     }
 
     /// Extracts a slice containing the entire vector.
@@ -718,7 +676,7 @@ where
     #[must_use]
     #[inline(always)]
     pub const fn as_slice(&self) -> &[T] {
-        self.fixed.as_slice()
+        unsafe { self.fixed.cook_ref() }.as_slice()
     }
 
     /// Extracts a mutable slice containing the entire vector.
@@ -727,7 +685,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        self.fixed.as_mut_slice()
+        unsafe { self.fixed.cook_mut() }.as_mut_slice()
     }
 
     /// Returns a raw pointer to the slice, or a dangling raw pointer
@@ -750,7 +708,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn as_non_null_ptr(&self) -> NonNull<T> {
-        self.fixed.as_non_null_ptr()
+        self.fixed.initialized.as_non_null_ptr().cast()
     }
 
     /// Returns a raw nonnull pointer to the slice, or a dangling raw pointer
@@ -758,7 +716,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn as_non_null_slice(&self) -> NonNull<[T]> {
-        self.fixed.as_non_null_slice()
+        self.fixed.initialized.as_non_null_ptr()
     }
 
     /// Appends an element to the back of the collection.
@@ -767,7 +725,7 @@ where
     /// Vector must not be full.
     #[inline(always)]
     pub unsafe fn unchecked_push(&mut self, value: T) {
-        self.fixed.unchecked_push(value);
+        unsafe { self.fixed.cook_mut() }.unchecked_push(value);
     }
 
     /// Appends an element to the back of the collection.
@@ -776,7 +734,7 @@ where
     /// Vector must not be full.
     #[inline(always)]
     pub unsafe fn unchecked_push_with(&mut self, f: impl FnOnce() -> T) {
-        self.fixed.unchecked_push_with(f);
+        unsafe { self.fixed.cook_mut() }.unchecked_push_with(f);
     }
 
     /// Forces the length of the vector to `new_len`.
@@ -802,16 +760,11 @@ where
 
     #[inline]
     pub(crate) unsafe fn inc_len(&mut self, amount: usize) {
-        self.fixed.inc_len(amount);
+        unsafe { self.fixed.cook_mut() }.inc_len(amount);
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> BumpVec<T, A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Appends an element to the back of a collection.
         impl
@@ -819,7 +772,7 @@ where
         /// ```
         /// # use bump_scope::{ bump_vec, Bump };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1, 2];
+        /// let mut vec = bump_vec![in &bump; 1, 2];
         /// vec.push(3);
         /// assert_eq!(vec, [1, 2, 3]);
         /// ```
@@ -829,7 +782,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ bump_vec, Bump };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1, 2]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2]?;
         /// vec.try_push(3);
         /// assert_eq!(vec, [1, 2, 3]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -861,7 +814,7 @@ where
         /// ```
         /// # use bump_scope::{ bump_vec, Bump, BumpVec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3];
         /// vec.insert(1, 4);
         /// assert_eq!(vec, [1, 4, 2, 3]);
         /// vec.insert(4, 5);
@@ -873,7 +826,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ bump_vec, Bump, BumpVec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3]?;
         /// vec.try_insert(1, 4)?;
         /// assert_eq!(vec, [1, 4, 2, 3]);
         /// vec.try_insert(4, 5)?;
@@ -989,7 +942,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 0, 1, 2, 3, 4];
+        /// let mut vec = bump_vec![in &bump; 0, 1, 2, 3, 4];
         ///
         /// vec.extend_from_within_copy(2..);
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -1006,7 +959,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 0, 1, 2, 3, 4]?;
+        /// let mut vec = bump_vec![try in &bump; 0, 1, 2, 3, 4]?;
         ///
         /// vec.try_extend_from_within_copy(2..)?;
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -1054,7 +1007,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 0, 1, 2, 3, 4];
+        /// let mut vec = bump_vec![in &bump; 0, 1, 2, 3, 4];
         ///
         /// vec.extend_from_within_clone(2..);
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -1071,7 +1024,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 0, 1, 2, 3, 4]?;
+        /// let mut vec = bump_vec![try in &bump; 0, 1, 2, 3, 4]?;
         ///
         /// vec.try_extend_from_within_clone(2..)?;
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -1139,7 +1092,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3];
         /// vec.extend_zeroed(2);
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// ```
@@ -1149,7 +1102,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3]?;
         /// vec.try_extend_zeroed(2)?;
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1185,7 +1138,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1];
+        /// let mut vec = bump_vec![in &bump; 1];
         /// vec.reserve(10);
         /// assert!(vec.capacity() >= 11);
         /// ```
@@ -1195,7 +1148,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1]?;
+        /// let mut vec = bump_vec![try in &bump; 1]?;
         /// vec.try_reserve(10)?;
         /// assert!(vec.capacity() >= 11);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1229,7 +1182,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1];
+        /// let mut vec = bump_vec![in &bump; 1];
         /// vec.reserve_exact(10);
         /// assert!(vec.capacity() >= 11);
         /// ```
@@ -1239,7 +1192,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1]?;
+        /// let mut vec = bump_vec![try in &bump; 1]?;
         /// vec.try_reserve_exact(10)?;
         /// assert!(vec.capacity() >= 11);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1273,12 +1226,12 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; "hello"];
+        /// let mut vec = bump_vec![in &bump; "hello"];
         /// vec.resize(3, "world");
         /// assert_eq!(vec, ["hello", "world", "world"]);
         /// drop(vec);
         ///
-        /// let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3, 4];
         /// vec.resize(2, 0);
         /// assert_eq!(vec, [1, 2]);
         /// ```
@@ -1288,12 +1241,12 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; "hello"]?;
+        /// let mut vec = bump_vec![try in &bump; "hello"]?;
         /// vec.try_resize(3, "world")?;
         /// assert_eq!(vec, ["hello", "world", "world"]);
         /// drop(vec);
         ///
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3, 4]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3, 4]?;
         /// vec.try_resize(2, 0)?;
         /// assert_eq!(vec, [1, 2]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1331,12 +1284,12 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3];
         /// vec.resize_with(5, Default::default);
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// drop(vec);
         ///
-        /// let mut vec = bump_vec![in bump];
+        /// let mut vec = bump_vec![in &bump];
         /// let mut p = 1;
         /// vec.resize_with(4, || { p *= 2; p });
         /// assert_eq!(vec, [2, 4, 8, 16]);
@@ -1347,12 +1300,12 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3]?;
         /// vec.try_resize_with(5, Default::default);
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// drop(vec);
         ///
-        /// let mut vec = bump_vec![try in bump]?;
+        /// let mut vec = bump_vec![try in &bump]?;
         /// let mut p = 1;
         /// vec.try_resize_with(4, || { p *= 2; p })?;
         /// assert_eq!(vec, [2, 4, 8, 16]);
@@ -1384,11 +1337,11 @@ where
         /// ```
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::new();
-        /// let mut vec = bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3];
         /// vec.resize_zeroed(5);
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         ///
-        /// let mut vec = bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3];
         /// vec.resize_zeroed(2);
         /// assert_eq!(vec, [1, 2]);
         /// ```
@@ -1398,11 +1351,11 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, bump_vec };
         /// # let bump: Bump = Bump::try_new()?;
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3]?;
         /// vec.try_resize_zeroed(5)?;
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         ///
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3]?;
         /// vec.try_resize_zeroed(2)?;
         /// assert_eq!(vec, [1, 2]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1432,7 +1385,7 @@ where
         /// // needs a scope because of lifetime shenanigans
         /// let bump = bump.as_scope();
         /// let mut slice = bump.alloc_slice_copy(&[4, 5, 6]);
-        /// let mut vec = bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = bump_vec![in &bump; 1, 2, 3];
         /// vec.append(&mut slice);
         /// assert_eq!(vec, [1, 2, 3, 4, 5, 6]);
         /// assert_eq!(slice, []);
@@ -1446,7 +1399,7 @@ where
         /// // needs a scope because of lifetime shenanigans
         /// let bump = bump.as_scope();
         /// let mut slice = bump.try_alloc_slice_copy(&[4, 5, 6])?;
-        /// let mut vec = bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = bump_vec![try in &bump; 1, 2, 3]?;
         /// vec.try_append(&mut slice)?;
         /// assert_eq!(vec, [1, 2, 3, 4, 5, 6]);
         /// assert_eq!(slice, []);
@@ -1475,7 +1428,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
-    /// let vec_a: BumpVec<u8> = BumpVec::from_iter_in([1, 2, 3, 4], &bump);
+    /// let vec_a: BumpVec<u8, _> = BumpVec::from_iter_in([1, 2, 3, 4], &bump);
     /// assert_eq!(vec_a.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4);
     ///
@@ -1488,11 +1441,11 @@ where
     /// ```
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
-    /// let vec_a: BumpVec<u32> = BumpVec::from_iter_in([1, 2, 3, 4], &bump);
+    /// let vec_a: BumpVec<u32, _> = BumpVec::from_iter_in([1, 2, 3, 4], &bump);
     /// assert_eq!(vec_a.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4 * 4);
     ///
-    /// let vec_b: BumpVec<u16> = vec_a.map(|i| i as u16);
+    /// let vec_b: BumpVec<u16, _> = vec_a.map(|i| i as u16);
     /// assert_eq!(vec_b.capacity(), 8);
     /// assert_eq!(bump.stats().allocated(), 4 * 4);
     /// ```
@@ -1502,17 +1455,20 @@ where
     /// ```
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
-    /// let vec_a: BumpVec<u16> = BumpVec::from_iter_in([1, 2, 3, 4], &bump);
+    /// let vec_a: BumpVec<u16, _> = BumpVec::from_iter_in([1, 2, 3, 4], &bump);
     /// assert_eq!(vec_a.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4 * 2);
     ///
-    /// let vec_b: BumpVec<u32> = vec_a.map(|i| i as u32);
+    /// let vec_b: BumpVec<u32, _> = vec_a.map(|i| i as u32);
     /// assert_eq!(vec_b.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4 * 2 + 4 * 4);
     /// ```
     #[inline(always)]
     #[cfg(not(no_global_oom_handling))]
-    pub fn map<U>(self, f: impl FnMut(T) -> U) -> BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
+    pub fn map<U>(self, f: impl FnMut(T) -> U) -> BumpVec<U, A>
+    where
+        A: Clone,
+    {
         infallible(self.generic_map(f))
     }
 
@@ -1529,7 +1485,7 @@ where
     /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::try_new()?;
-    /// let vec_a: BumpVec<u8> = BumpVec::try_from_iter_in([1, 2, 3, 4], &bump)?;
+    /// let vec_a: BumpVec<u8, _> = BumpVec::try_from_iter_in([1, 2, 3, 4], &bump)?;
     /// assert_eq!(vec_a.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4);
     ///
@@ -1544,11 +1500,11 @@ where
     /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::try_new()?;
-    /// let vec_a: BumpVec<u32> = BumpVec::try_from_iter_in([1, 2, 3, 4], &bump)?;
+    /// let vec_a: BumpVec<u32, _> = BumpVec::try_from_iter_in([1, 2, 3, 4], &bump)?;
     /// assert_eq!(vec_a.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4 * 4);
     ///
-    /// let vec_b: BumpVec<u16> = vec_a.try_map(|i| i as u16)?;
+    /// let vec_b: BumpVec<u16, _> = vec_a.try_map(|i| i as u16)?;
     /// assert_eq!(vec_b.capacity(), 8);
     /// assert_eq!(bump.stats().allocated(), 4 * 4);
     /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1560,48 +1516,46 @@ where
     /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::try_new()?;
-    /// let vec_a: BumpVec<u16> = BumpVec::try_from_iter_in([1, 2, 3, 4], &bump)?;
+    /// let vec_a: BumpVec<u16, _> = BumpVec::try_from_iter_in([1, 2, 3, 4], &bump)?;
     /// assert_eq!(vec_a.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4 * 2);
     ///
-    /// let vec_b: BumpVec<u32> = vec_a.try_map(|i| i as u32)?;
+    /// let vec_b: BumpVec<u32, _> = vec_a.try_map(|i| i as u32)?;
     /// assert_eq!(vec_b.capacity(), 4);
     /// assert_eq!(bump.stats().allocated(), 4 * 2 + 4 * 4);
     /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
     /// ```
     #[inline(always)]
-    pub fn try_map<U>(
-        self,
-        f: impl FnMut(T) -> U,
-    ) -> Result<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>, AllocError> {
+    pub fn try_map<U>(self, f: impl FnMut(T) -> U) -> Result<BumpVec<U, A>, AllocError>
+    where
+        A: Clone,
+    {
         self.generic_map(f)
     }
 
     #[inline]
-    fn generic_map<B: ErrorBehavior, U>(
-        self,
-        mut f: impl FnMut(T) -> U,
-    ) -> Result<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>, B> {
+    fn generic_map<B: ErrorBehavior, U>(self, mut f: impl FnMut(T) -> U) -> Result<BumpVec<U, A>, B>
+    where
+        A: Clone,
+    {
         if !T::IS_ZST && !U::IS_ZST && T::ALIGN >= U::ALIGN && T::SIZE >= U::SIZE {
-            struct DropGuard<'b, 'a, T, U, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-            where
-                MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-                A: BaseAllocator<GUARANTEED_ALLOCATED>,
-            {
+            struct DropGuard<T, U, A: BumpAllocator> {
                 ptr: NonNull<T>,
                 cap: usize,
                 end: *mut T,
                 src: *mut T,
                 dst: *mut U,
-                bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
+                allocator: A,
             }
 
-            impl<T, U, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
-                for DropGuard<'_, '_, T, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-            where
-                MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-                A: BaseAllocator<GUARANTEED_ALLOCATED>,
-            {
+            impl<T, U, A: BumpAllocator> DropGuard<T, U, A> {
+                fn into_allocator(self) -> A {
+                    destructure!(let Self { allocator } = self);
+                    allocator
+                }
+            }
+
+            impl<T, U, A: BumpAllocator> Drop for DropGuard<T, U, A> {
                 fn drop(&mut self) {
                     unsafe {
                         // drop `T`s
@@ -1616,25 +1570,25 @@ where
 
                         // deallocate memory block (for additional safety notes see `Self::drop::DropGuard::drop`)
                         let layout = Layout::from_size_align_unchecked(self.cap * T::SIZE, T::ALIGN);
-                        self.bump.deallocate(self.ptr.cast(), layout);
+                        self.allocator.deallocate(self.ptr.cast(), layout);
                     }
                 }
             }
 
-            let (fixed, bump) = self.into_parts();
-            let cap = fixed.capacity();
-            let slice = fixed.into_boxed_slice().into_raw();
+            destructure!(let Self { fixed, allocator } = self);
+            let cap = fixed.capacity;
+            let slice = unsafe { fixed.cook() }.into_boxed_slice().into_raw();
             let ptr = slice.cast::<T>();
             let len = slice.len();
 
             unsafe {
-                let mut guard = DropGuard {
+                let mut guard = DropGuard::<T, U, A> {
                     ptr,
                     cap,
                     end: ptr.as_ptr().add(len),
                     src: ptr.as_ptr(),
-                    dst: ptr.as_ptr().cast::<U>(),
-                    bump,
+                    dst: ptr.as_ptr().cast(),
+                    allocator,
                 };
 
                 while guard.src < guard.end {
@@ -1645,19 +1599,21 @@ where
                     guard.dst = guard.dst.add(1);
                 }
 
-                mem::forget(guard);
-
+                let allocator = guard.into_allocator();
                 let new_cap = (cap * T::SIZE) / U::SIZE;
 
-                Ok(BumpVec::from_parts(
-                    FixedBumpVec::from_raw_parts(BumpBox::from_raw(nonnull::slice_from_raw_parts(ptr.cast(), len)), new_cap),
-                    bump,
-                ))
+                Ok(BumpVec {
+                    fixed: RawFixedBumpVec {
+                        initialized: RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(ptr.cast(), len)),
+                        capacity: new_cap,
+                    },
+                    allocator,
+                })
             }
         } else {
             // fallback
-            let bump = self.bump();
-            Ok(BumpVec::generic_from_iter_exact_in(self.into_iter().map(f), bump)?)
+            let allocator = self.allocator.clone();
+            Ok(BumpVec::generic_from_iter_exact_in(self.into_iter().map(f), allocator)?)
         }
     }
 
@@ -1680,10 +1636,10 @@ where
     /// ```
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
-    /// let a: BumpVec<u32> = BumpVec::from_iter_exact_in([0, 1, 2], &bump);
+    /// let a: BumpVec<u32, _> = BumpVec::from_iter_exact_in([0, 1, 2], &bump);
     /// assert_eq!(a.capacity(), 3);
     ///
-    /// let b: BumpVec<u16> = a.map_in_place(|i| i as u16);
+    /// let b: BumpVec<u16, _> = a.map_in_place(|i| i as u16);
     /// assert_eq!(b.capacity(), 6);
     ///
     /// assert_eq!(b, [0, 1, 2]);
@@ -1693,51 +1649,48 @@ where
     /// ```compile_fail,E0080
     /// # use bump_scope::{ Bump, BumpVec };
     /// # let bump: Bump = Bump::new();
-    /// let a: BumpVec<u16> = BumpVec::from_iter_exact_in([0, 1, 2], &bump);
-    /// let b: BumpVec<u32> = a.map_in_place(|i| i as u32);
+    /// let a: BumpVec<u16, _> = BumpVec::from_iter_exact_in([0, 1, 2], &bump);
+    /// let b: BumpVec<u32, _> = a.map_in_place(|i| i as u32);
     /// # _ = b;
     /// ```
-    pub fn map_in_place<U>(self, f: impl FnMut(T) -> U) -> BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
+    pub fn map_in_place<U>(self, f: impl FnMut(T) -> U) -> BumpVec<U, A> {
         // `FixedBumpVec::map_in_place` handles dropping `T`s and `U`s on panic.
         // What is left to do is deallocating the memory.
 
-        struct DropGuard<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-        where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>,
-        {
+        struct DropGuard<T, A: BumpAllocator> {
             ptr: NonNull<T>,
             cap: usize,
-            bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
+            allocator: A,
         }
 
-        impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
-            for DropGuard<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-        where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>,
-        {
+        impl<T, A: BumpAllocator> DropGuard<T, A> {
+            fn into_allocator(self) -> A {
+                destructure!(let Self { allocator } = self);
+                allocator
+            }
+        }
+
+        impl<T, A: BumpAllocator> Drop for DropGuard<T, A> {
             fn drop(&mut self) {
                 unsafe {
                     let layout = Layout::from_size_align_unchecked(self.cap * T::SIZE, T::ALIGN);
-                    self.bump.deallocate(self.ptr.cast(), layout);
+                    self.allocator.deallocate(self.ptr.cast(), layout);
                 }
             }
         }
 
-        let (fixed, bump) = self.into_parts();
+        destructure!(let Self { fixed, allocator } = self);
 
-        let guard = DropGuard {
-            ptr: fixed.as_non_null_ptr(),
-            cap: fixed.capacity(),
-            bump,
+        let guard = DropGuard::<T, _> {
+            ptr: fixed.initialized.as_non_null_ptr().cast(),
+            cap: fixed.capacity,
+            allocator,
         };
 
-        let fixed = fixed.map_in_place(f);
+        let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().map_in_place(f)) };
+        let allocator = guard.into_allocator();
 
-        mem::forget(guard);
-
-        BumpVec { fixed, bump }
+        BumpVec { fixed, allocator }
     }
 
     /// Creates a splicing iterator that replaces the specified range in the vector
@@ -1769,7 +1722,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut v = bump_vec![in bump; 1, 2, 3, 4];
+    /// let mut v = bump_vec![in &bump; 1, 2, 3, 4];
     /// let new = [7, 8, 9];
     /// let u = bump.alloc_iter(v.splice(1..3, new));
     /// assert_eq!(v, [1, 7, 8, 9, 4]);
@@ -1777,11 +1730,7 @@ where
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[inline]
-    pub fn splice<R, I>(
-        &mut self,
-        range: R,
-        replace_with: I,
-    ) -> Splice<'_, I::IntoIter, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, I::IntoIter, A>
     where
         R: RangeBounds<usize>,
         I: IntoIterator<Item = T>,
@@ -1845,7 +1794,7 @@ where
     {
         self.generic_reserve(n)?;
         unsafe {
-            self.fixed.extend_with_unchecked(n, value);
+            self.fixed.cook_mut().extend_with_unchecked(n, value);
         }
         Ok(())
     }
@@ -1948,84 +1897,27 @@ where
         let new_cap = new_capacity;
 
         if self.capacity() == 0 {
-            self.fixed = self.bump.generic_alloc_fixed_vec(new_cap)?;
+            self.fixed = RawFixedBumpVec::allocate(&self.allocator, new_cap)?;
             return Ok(());
         }
 
-        let old_ptr = self.as_non_null_ptr();
+        let old_ptr = self.as_non_null_ptr().cast();
+
         let old_size = self.fixed.capacity * T::SIZE; // we already allocated that amount so this can't overflow
         let new_size = new_cap.checked_mul(T::SIZE).ok_or_else(|| E::capacity_overflow())?;
 
-        if UP {
-            let is_last = nonnull::byte_add(old_ptr, old_size).cast() == self.bump.chunk.get().pos();
+        let old_layout = Layout::from_size_align_unchecked(old_size, T::ALIGN);
+        let new_layout = match Layout::from_size_align(new_size, T::ALIGN) {
+            Ok(ok) => ok,
+            Err(_) => return Err(E::capacity_overflow()),
+        };
 
-            if is_last {
-                let chunk_end = self.bump.chunk.get().content_end();
-                let remaining = nonnull::addr(chunk_end).get() - nonnull::addr(old_ptr).get();
+        let new_ptr = match self.allocator.grow(old_ptr, old_layout, new_layout) {
+            Ok(ok) => ok.cast(),
+            Err(_) => return Err(E::allocation(new_layout)),
+        };
 
-                if new_size <= remaining {
-                    // There is enough space! We will grow in place. Just need to update the bump pointer.
-
-                    let old_addr = nonnull::addr(old_ptr);
-                    let new_end = old_addr.get() + new_size;
-
-                    // Up-aligning a pointer inside a chunks content by `MIN_ALIGN` never overflows.
-                    let new_pos = up_align_usize_unchecked(new_end, MIN_ALIGN);
-
-                    self.bump.chunk.get().set_pos_addr(new_pos);
-                } else {
-                    // The current chunk doesn't have enough space to allocate this layout. We need to allocate in another chunk.
-                    let new_ptr = self.bump.do_alloc_slice_in_another_chunk::<E, T>(new_cap)?.cast();
-                    nonnull::copy_nonoverlapping::<u8>(old_ptr.cast(), new_ptr.cast(), old_size);
-                    self.fixed.initialized.set_ptr(new_ptr);
-                }
-            } else {
-                let new_ptr = self.bump.do_alloc_slice::<E, T>(new_cap)?.cast();
-                nonnull::copy_nonoverlapping::<u8>(old_ptr.cast(), new_ptr.cast(), old_size);
-                self.fixed.initialized.set_ptr(new_ptr);
-            }
-        } else {
-            let is_last = old_ptr.cast() == self.bump.chunk.get().pos();
-
-            if is_last {
-                // We may be able to reuse the currently allocated space. Just need to check if the current chunk has enough space for that.
-                let additional_size = new_size - old_size;
-
-                let old_addr = nonnull::addr(old_ptr);
-                let new_addr = bump_down(old_addr, additional_size, T::ALIGN.max(MIN_ALIGN));
-
-                let very_start = nonnull::addr(self.bump.chunk.get().content_start());
-
-                if new_addr >= very_start.get() {
-                    // There is enough space in the current chunk! We will reuse the allocated space.
-
-                    let new_addr = NonZeroUsize::new_unchecked(new_addr);
-                    let new_addr_end = new_addr.get() + new_size;
-
-                    let new_ptr = nonnull::with_addr(old_ptr, new_addr);
-
-                    // Check if the regions don't overlap so we may use the faster `copy_nonoverlapping`.
-                    if new_addr_end < old_addr.get() {
-                        nonnull::copy_nonoverlapping::<u8>(old_ptr.cast(), new_ptr.cast(), old_size);
-                    } else {
-                        nonnull::copy::<u8>(old_ptr.cast(), new_ptr.cast(), old_size);
-                    }
-
-                    self.bump.chunk.get().set_pos(new_ptr.cast());
-                    self.fixed.initialized.set_ptr(new_ptr);
-                } else {
-                    // The current chunk doesn't have enough space to allocate this layout. We need to allocate in another chunk.
-                    let new_ptr = self.bump.do_alloc_slice_in_another_chunk::<E, T>(new_cap)?.cast();
-                    nonnull::copy_nonoverlapping::<u8>(old_ptr.cast(), new_ptr.cast(), old_size);
-                    self.fixed.initialized.set_ptr(new_ptr);
-                }
-            } else {
-                let new_ptr = self.bump.do_alloc_slice::<E, T>(new_cap)?.cast();
-                nonnull::copy_nonoverlapping::<u8>(old_ptr.cast(), new_ptr.cast(), old_size);
-                self.fixed.initialized.set_ptr(new_ptr);
-            }
-        }
-
+        self.fixed.initialized.set_ptr(new_ptr);
         self.fixed.capacity = new_cap;
         Ok(())
     }
@@ -2047,130 +1939,31 @@ where
     /// assert_eq!(bump.stats().allocated(), 3 * 4);
     /// ```
     pub fn shrink_to_fit(&mut self) {
-        let old_ptr = self.as_non_null_ptr().cast::<u8>();
-        let old_size = self.fixed.capacity * T::SIZE; // we already allocated that amount so this can't overflow
-        let new_size = self.len() * T::SIZE; // its less than the capacity so this can't overflow
+        let Self { fixed, allocator } = self;
+        allocator.shrink_to_fit(fixed);
 
-        // Adapted from `Allocator::shrink`.
-        unsafe {
-            let is_last = if UP {
-                old_ptr.as_ptr().add(old_size) == self.bump.chunk.get().pos().as_ptr()
-            } else {
-                old_ptr == self.bump.chunk.get().pos()
-            };
+        // let old_ptr = self.as_non_null_ptr().cast();
 
-            // if that's not the last allocation, there is nothing we can do
-            if !is_last {
-                return;
-            }
+        // let old_size = self.fixed.capacity * T::SIZE; // we already allocated that amount so this can't overflow
+        // let new_size = self.len() * T::SIZE; // its less than the capacity so this can't overflow
 
-            if UP {
-                let end = nonnull::addr(old_ptr).get() + new_size;
+        // if !self
+        //     .allocator
+        //     .is_last_allocation(nonnull::slice_from_raw_parts(old_ptr, old_size))
+        // {
+        //     return;
+        // }
 
-                // Up-aligning a pointer inside a chunk by `MIN_ALIGN` never overflows.
-                let new_pos = up_align_usize_unchecked(end, MIN_ALIGN);
+        // let old_layout = unsafe { Layout::from_size_align_unchecked(old_size, T::ALIGN) };
+        // let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, T::ALIGN) };
 
-                self.bump.chunk.get().set_pos_addr(new_pos);
-            } else {
-                let old_addr = nonnull::addr(old_ptr);
-                let old_addr_old_end = NonZeroUsize::new_unchecked(old_addr.get() + old_size);
+        // let new_ptr = match unsafe { self.allocator.shrink(old_ptr, old_layout, new_layout) } {
+        //     Ok(ok) => ok.cast(),
+        //     Err(_) => unreachable!(),
+        // };
 
-                let new_addr = bump_down(old_addr_old_end, new_size, T::ALIGN.max(MIN_ALIGN));
-                let new_addr = NonZeroUsize::new_unchecked(new_addr);
-                let old_addr_new_end = NonZeroUsize::new_unchecked(old_addr.get() + new_size);
-
-                let new_ptr = nonnull::with_addr(old_ptr, new_addr);
-                let overlaps = old_addr_new_end > new_addr;
-
-                if overlaps {
-                    nonnull::copy(old_ptr, new_ptr, new_size);
-                } else {
-                    nonnull::copy_nonoverlapping(old_ptr, new_ptr, new_size);
-                }
-
-                self.bump.chunk.get().set_pos(new_ptr);
-                self.fixed.initialized.set_ptr(new_ptr.cast());
-            }
-
-            self.fixed.capacity = self.len();
-        }
-    }
-
-    /// Turns this `BumpVec<T>` into a `FixedBumpVec<T>`.
-    ///
-    /// This retains the unused capacity unlike <code>[into_](Self::into_slice)([boxed_](Self::into_boxed_slice))[slice](Self::into_slice)</code>.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_fixed_vec(self) -> FixedBumpVec<'a, T> {
-        self.into_parts().0
-    }
-
-    /// Turns this `BumpVec<T>` into a `BumpBox<[T]>`.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_boxed_slice(mut self) -> BumpBox<'a, [T]> {
-        self.shrink_to_fit();
-        self.into_fixed_vec().into_boxed_slice()
-    }
-
-    /// Turns this `BumpVec<T>` into a `&[T]` that is live for this bump scope.
-    ///
-    /// This is only available for [`NoDrop`] types so you don't omit dropping a value for which it matters.
-    ///
-    /// `!NoDrop` types can still be turned into slices via <code>BumpBox::[leak](BumpBox::leak)(vec.[into_boxed_slice](Self::into_boxed_slice)())</code>.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_slice(self) -> &'a mut [T]
-    where
-        [T]: NoDrop,
-    {
-        self.into_boxed_slice().into_mut()
-    }
-
-    /// Creates a `BumpVec<T>` from its parts.
-    ///
-    /// The provided `bump` does not have to be the one the `fixed_vec` was allocated in.
-    ///
-    /// ```
-    /// # use bump_scope::{ Bump, BumpVec };
-    /// # let bump: Bump = Bump::new();
-    /// let mut fixed_vec = bump.alloc_fixed_vec(3);
-    /// fixed_vec.push(1);
-    /// fixed_vec.push(2);
-    /// fixed_vec.push(3);
-    /// let mut vec = BumpVec::from_parts(fixed_vec, &bump);
-    /// vec.push(4);
-    /// vec.push(5);
-    /// assert_eq!(vec, [1, 2, 3, 4, 5]);
-    /// ```
-    #[must_use]
-    #[inline(always)]
-    pub fn from_parts(
-        fixed_vec: FixedBumpVec<'a, T>,
-        bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>,
-    ) -> Self {
-        Self {
-            fixed: fixed_vec,
-            bump: bump.into(),
-        }
-    }
-
-    /// Turns this `BumpVec<T>` into its parts.
-    /// ```
-    /// # use bump_scope::{ Bump, BumpVec };
-    /// # let bump: Bump = Bump::new();
-    /// let mut vec = BumpVec::new_in(&bump);
-    /// vec.reserve(10);
-    /// vec.push(1);
-    /// let mut fixed_vec = vec.into_parts().0;
-    /// assert_eq!(fixed_vec.capacity(), 10);
-    /// assert_eq!(fixed_vec, [1]);
-    /// ```
-    #[must_use]
-    #[inline(always)]
-    pub fn into_parts(self) -> (FixedBumpVec<'a, T>, &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) {
-        destructure!(let Self { fixed, bump } = self);
-        (fixed, bump)
+        // self.fixed.initialized.ptr = nonnull::slice_from_raw_parts(new_ptr, self.len());
+        // self.fixed.capacity = self.len();
     }
 
     /// # Safety
@@ -2224,7 +2017,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
     /// #
-    /// let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 3, 4];
     ///
     /// vec.retain(|x| if *x <= 3 {
     ///     *x += 1;
@@ -2240,7 +2033,7 @@ where
     where
         F: FnMut(&mut T) -> bool,
     {
-        self.fixed.retain(f)
+        unsafe { self.fixed.cook_mut() }.retain(f)
     }
 
     /// Removes the specified range from the vector in bulk, returning all
@@ -2266,7 +2059,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut v = bump_vec![in bump; 1, 2, 3];
+    /// let mut v = bump_vec![in &bump; 1, 2, 3];
     /// let u = bump.alloc_iter(v.drain(1..));
     /// assert_eq!(v, [1]);
     /// assert_eq!(u, [2, 3]);
@@ -2279,7 +2072,7 @@ where
     where
         R: RangeBounds<usize>,
     {
-        self.fixed.drain(range)
+        unsafe { self.fixed.cook_mut() }.drain(range)
     }
 
     /// Creates an iterator which uses a closure to determine if an element should be removed.
@@ -2298,7 +2091,7 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
     /// # let bump: Bump = Bump::new();
-    /// # let mut vec = bump_vec![in bump; 1, 2, 3, 4, 5, 6];
+    /// # let mut vec = bump_vec![in &bump; 1, 2, 3, 4, 5, 6];
     /// let mut i = 0;
     /// while i < vec.len() {
     ///     if some_predicate(&mut vec[i]) {
@@ -2325,7 +2118,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut numbers = bump_vec![in bump; 1, 2, 3, 4, 5, 6, 8, 9, 11, 13, 14, 15];
+    /// let mut numbers = bump_vec![in &bump; 1, 2, 3, 4, 5, 6, 8, 9, 11, 13, 14, 15];
     ///
     /// let evens = numbers.extract_if(|x| *x % 2 == 0).collect::<Vec<_>>();
     /// let odds = numbers;
@@ -2339,7 +2132,7 @@ where
     where
         F: FnMut(&mut T) -> bool,
     {
-        self.fixed.extract_if(filter)
+        unsafe { self.fixed.cook_mut() }.extract_if(filter)
     }
 
     /// Removes consecutive repeated elements in the vector according to the
@@ -2352,7 +2145,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; 1, 2, 2, 3, 2];
+    /// let mut vec = bump_vec![in &bump; 1, 2, 2, 3, 2];
     ///
     /// vec.dedup();
     ///
@@ -2363,7 +2156,7 @@ where
     where
         T: PartialEq,
     {
-        self.fixed.dedup();
+        unsafe { self.fixed.cook_mut() }.dedup();
     }
 
     /// Removes all but the first of consecutive elements in the vector that resolve to the same
@@ -2376,7 +2169,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; 10, 20, 21, 30, 20];
+    /// let mut vec = bump_vec![in &bump; 10, 20, 21, 30, 20];
     ///
     /// vec.dedup_by_key(|i| *i / 10);
     ///
@@ -2388,7 +2181,7 @@ where
         F: FnMut(&mut T) -> K,
         K: PartialEq,
     {
-        self.fixed.dedup_by_key(key);
+        unsafe { self.fixed.cook_mut() }.dedup_by_key(key);
     }
 
     /// Removes all but the first of consecutive elements in the vector satisfying a given equality
@@ -2405,7 +2198,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; "foo", "bar", "Bar", "baz", "bar"];
+    /// let mut vec = bump_vec![in &bump; "foo", "bar", "Bar", "baz", "bar"];
     ///
     /// vec.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
     ///
@@ -2415,7 +2208,7 @@ where
     where
         F: FnMut(&mut T, &mut T) -> bool,
     {
-        self.fixed.dedup_by(same_bucket);
+        unsafe { self.fixed.cook_mut() }.dedup_by(same_bucket);
     }
 
     /// Returns the remaining spare capacity of the vector as a slice of
@@ -2505,54 +2298,98 @@ where
         }
     }
 
-    /// Returns a reference to the base allocator.
+    /// Returns a reference to the allocator.
     #[must_use]
     #[inline(always)]
     pub fn allocator(&self) -> &A {
-        self.bump.allocator()
-    }
-
-    /// Returns a reference to the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn bump(&self) -> &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
-        self.bump
+        &self.allocator
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'a, T, A: BumpAllocatorScope<'a>> BumpVec<T, A> {
+    /// Turns this `BumpVec<T>` into a `FixedBumpVec<T>`.
+    ///
+    /// This retains the unused capacity unlike <code>[into_](Self::into_slice)([boxed_](Self::into_boxed_slice))[slice](Self::into_slice)</code>.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_fixed_vec(self) -> FixedBumpVec<'a, T> {
+        self.into_parts().0
+    }
+
+    /// Turns this `BumpVec<T>` into a `BumpBox<[T]>`.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_boxed_slice(mut self) -> BumpBox<'a, [T]> {
+        self.shrink_to_fit();
+        self.into_fixed_vec().into_boxed_slice()
+    }
+
+    /// Turns this `BumpVec<T>` into a `&[T]` that is live for this bump scope.
+    ///
+    /// This is only available for [`NoDrop`] types so you don't omit dropping a value for which it matters.
+    ///
+    /// `!NoDrop` types can still be turned into slices via <code>BumpBox::[leak](BumpBox::leak)(vec.[into_boxed_slice](Self::into_boxed_slice)())</code>.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_slice(self) -> &'a mut [T]
+    where
+        [T]: NoDrop,
+    {
+        self.into_boxed_slice().into_mut()
+    }
+
+    /// Creates a `BumpVec<T>` from its parts.
+    ///
+    /// The provided `bump` does not have to be the one the `fixed_vec` was allocated in.
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, BumpVec };
+    /// # let bump: Bump = Bump::new();
+    /// let mut fixed_vec = bump.alloc_fixed_vec(3);
+    /// fixed_vec.push(1);
+    /// fixed_vec.push(2);
+    /// fixed_vec.push(3);
+    /// let mut vec = BumpVec::from_parts(fixed_vec, &bump);
+    /// vec.push(4);
+    /// vec.push(5);
+    /// assert_eq!(vec, [1, 2, 3, 4, 5]);
+    /// ```
+    #[must_use]
+    #[inline(always)]
+    pub fn from_parts(vec: FixedBumpVec<'a, T>, allocator: A) -> Self {
+        Self {
+            fixed: unsafe { RawFixedBumpVec::from_cooked(vec) },
+            allocator,
+        }
+    }
+
+    /// Turns this `BumpVec<T>` into its parts.
+    /// ```
+    /// # use bump_scope::{ Bump, BumpVec };
+    /// # let bump: Bump = Bump::new();
+    /// let mut vec = BumpVec::new_in(&bump);
+    /// vec.reserve(10);
+    /// vec.push(1);
+    /// let mut fixed_vec = vec.into_parts().0;
+    /// assert_eq!(fixed_vec.capacity(), 10);
+    /// assert_eq!(fixed_vec, [1]);
+    /// ```
+    #[must_use]
+    #[inline(always)]
+    pub fn into_parts(self) -> (FixedBumpVec<'a, T>, A) {
+        destructure!(let Self { fixed, allocator } = self);
+        (unsafe { fixed.cook() }, allocator)
+    }
+
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, UP> {
-        self.bump.stats()
+    pub fn stats(&self) -> Stats<'a, true> {
+        todo!()
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool> BumpVec<'b, 'a, T, A, MIN_ALIGN, UP>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
-{
-    /// Returns a type which provides statistics about the memory usage of the bump allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a, UP> {
-        self.bump.guaranteed_allocated_stats()
-    }
-}
-
-impl<'b, 'a: 'b, T, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    BumpVec<'b, 'a, [T; N], A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, const N: usize, A: BumpAllocator> BumpVec<[T; N], A> {
     /// Takes a `BumpVec<[T; N]>` and flattens it into a `BumpVec<T>`.
     ///
     /// # Panics
@@ -2569,37 +2406,27 @@ where
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
     /// #
-    /// let mut vec = bump_vec![in bump; [1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    /// let mut vec = bump_vec![in &bump; [1, 2, 3], [4, 5, 6], [7, 8, 9]];
     /// assert_eq!(vec.pop(), Some([7, 8, 9]));
     ///
     /// let mut flattened = vec.into_flattened();
     /// assert_eq!(flattened.pop(), Some(6));
     /// ```
     #[must_use]
-    pub fn into_flattened(self) -> BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
-        let (fixed, bump) = self.into_parts();
-        let fixed = fixed.into_flattened();
-        BumpVec { fixed, bump }
+    pub fn into_flattened(self) -> BumpVec<T, A> {
+        destructure!(let Self { fixed, allocator } = self);
+        let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().into_flattened()) };
+        BumpVec { fixed, allocator }
     }
 }
 
-impl<'b, 'a: 'b, T: Debug, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Debug
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T: Debug, A: BumpAllocator> Debug for BumpVec<T, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(self.as_slice(), f)
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, I: SliceIndex<[T]>> Index<I>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator, I: SliceIndex<[T]>> Index<I> for BumpVec<T, A> {
     type Output = I::Output;
 
     #[inline(always)]
@@ -2608,12 +2435,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, I: SliceIndex<[T]>>
-    IndexMut<I> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator, I: SliceIndex<[T]>> IndexMut<I> for BumpVec<T, A> {
     #[inline(always)]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         IndexMut::index_mut(self.as_mut_slice(), index)
@@ -2621,12 +2443,7 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Extend<T>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + 'a,
-{
+impl<T, A: BumpAllocator> Extend<T> for BumpVec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
@@ -2640,13 +2457,7 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, 't, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Extend<&'t T>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + 'a,
-    T: Clone + 't,
-{
+impl<'t, T: Clone + 't, A: BumpAllocator> Extend<&'t T> for BumpVec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = &'t T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
@@ -2659,30 +2470,23 @@ where
     }
 }
 
-impl<'b0, 'a0: 'b0, 'b1, 'a1: 'b1, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<BumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>
-    for BumpVec<'b0, 'a0, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A: BumpAllocator> PartialEq<BumpVec<U, A>> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &BumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &BumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<[U; N]> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, const N: usize, A: BumpAllocator> PartialEq<[U; N]> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -2696,11 +2500,8 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<&[U; N]> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, const N: usize, A: BumpAllocator> PartialEq<&[U; N]> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -2714,11 +2515,8 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<&mut [U; N]> for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, const N: usize, A: BumpAllocator> PartialEq<&mut [U; N]> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -2732,11 +2530,8 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<[U]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A: BumpAllocator> PartialEq<[U]> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -2750,12 +2545,8 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<&[U]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A: BumpAllocator> PartialEq<&[U]> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -2769,11 +2560,8 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<&mut [U]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A: BumpAllocator> PartialEq<&mut [U]> for BumpVec<T, A>
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
@@ -2787,101 +2575,85 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for [T]
+impl<T, U, A: BumpAllocator> PartialEq<BumpVec<U, A>> for [T]
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for &[T]
+impl<T, U, A: BumpAllocator> PartialEq<BumpVec<U, A>> for &[T]
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for &mut [T]
+impl<T, U, A: BumpAllocator> PartialEq<BumpVec<U, A>> for &mut [T]
 where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &BumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &BumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> IntoIterator for BumpVec<T, A> {
     type Item = T;
-    type IntoIter = IntoIter<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>;
+    type IntoIter = IntoIter<T, A>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         unsafe {
-            let me = ManuallyDrop::new(self);
+            destructure!(let Self { fixed, allocator } = self);
 
-            let begin = me.as_non_null_ptr();
+            let cap = fixed.capacity;
+            let slice = fixed.initialized.into_ptr();
+            let begin = slice.cast::<T>();
+
             let end = if T::IS_ZST {
-                nonnull::wrapping_byte_add(begin, me.len())
+                nonnull::wrapping_byte_add(begin, slice.len())
             } else {
-                nonnull::add(begin, me.len())
+                nonnull::add(begin, slice.len())
             };
 
             IntoIter {
                 buf: begin,
-                cap: me.capacity(),
+                cap,
 
                 ptr: begin,
                 end,
 
-                bump: me.bump,
+                allocator,
                 marker: PhantomData,
             }
         }
     }
 }
 
-impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
-    for &'c BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'c, T, A: BumpAllocator> IntoIterator for &'c BumpVec<T, A> {
     type Item = &'c T;
     type IntoIter = slice::Iter<'c, T>;
 
@@ -2891,12 +2663,7 @@ where
     }
 }
 
-impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
-    for &'c mut BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'c, T, A: BumpAllocator> IntoIterator for &'c mut BumpVec<T, A> {
     type Item = &'c mut T;
     type IntoIter = slice::IterMut<'c, T>;
 
@@ -2906,60 +2673,35 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsRef<[T]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> AsRef<[T]> for BumpVec<T, A> {
     #[inline(always)]
     fn as_ref(&self) -> &[T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsMut<[T]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> AsMut<[T]> for BumpVec<T, A> {
     #[inline(always)]
     fn as_mut(&mut self) -> &mut [T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Borrow<[T]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> Borrow<[T]> for BumpVec<T, A> {
     #[inline(always)]
     fn borrow(&self) -> &[T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BorrowMut<[T]>
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> BorrowMut<[T]> for BumpVec<T, A> {
     #[inline(always)]
     fn borrow_mut(&mut self) -> &mut [T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T: Hash, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Hash
-    for BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T: Hash, A: BumpAllocator> Hash for BumpVec<T, A> {
     #[inline(always)]
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.as_slice().hash(state);
@@ -2968,12 +2710,7 @@ where
 
 /// Returns [`ErrorKind::OutOfMemory`](std::io::ErrorKind::OutOfMemory) when allocations fail.
 #[cfg(feature = "std")]
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> std::io::Write
-    for BumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + 'a,
-{
+impl<A: BumpAllocator> std::io::Write for BumpVec<u8, A> {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.try_extend_from_slice_copy(buf).is_err() {

--- a/src/bump_vec/into_iter.rs
+++ b/src/bump_vec/into_iter.rs
@@ -3,16 +3,18 @@ use core::{
     fmt::Debug,
     iter::FusedIterator,
     marker::PhantomData,
-    mem::{self, MaybeUninit},
+    mem,
     ptr::{self, NonNull},
     slice,
 };
 
-use crate::{
-    polyfill::nonnull, raw_fixed_bump_vec::RawFixedBumpVec, BumpAllocator, BumpBox, FixedBumpVec, SizedTypeProperties,
-};
+use crate::{polyfill::nonnull, BumpAllocator, SizedTypeProperties};
 
-use super::BumpVec;
+#[cfg(not(no_global_oom_handling))]
+use core::mem::MaybeUninit;
+
+#[cfg(not(no_global_oom_handling))]
+use crate::{raw_fixed_bump_vec::RawFixedBumpVec, BumpBox, BumpVec, FixedBumpVec};
 
 /// An iterator that moves out of a vector.
 ///

--- a/src/bump_vec/splice.rs
+++ b/src/bump_vec/splice.rs
@@ -2,58 +2,35 @@
 
 use core::{ptr, slice};
 
-use crate::{BaseAllocator, MinimumAlignment, SupportedMinimumAlignment};
+use crate::BumpAllocator;
 
 use super::Drain;
 
-macro_rules! splice_declaration {
-    ($($allocator_parameter:tt)*) => {
-        /// A splicing iterator for `BumpVec`.
-        ///
-        /// This struct is created by [`BumpVec::splice()`].
-        /// See its documentation for more.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use bump_scope::{ Bump, bump_vec };
-        /// # let bump: Bump = Bump::new();
-        /// let mut v = bump_vec![in bump; 0, 1, 2];
-        /// let new = [7, 8];
-        /// let old = bump.alloc_iter_exact(v.splice(1.., new));
-        /// assert_eq!(old, [1, 2]);
-        /// assert_eq!(v, [0, 7, 8]);
-        /// ```
-        ///
-        /// [`BumpVec::splice()`]: crate::BumpVec::splice
-        #[derive(Debug)]
-        pub struct Splice<
-            'a,
-            I,
-            $($allocator_parameter)*,
-            const MIN_ALIGN: usize = 1,
-            const UP: bool = true,
-            const GUARANTEED_ALLOCATED: bool = true,
-        > where
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED>,
-            I: Iterator + 'a,
-        {
-            pub(super) drain: Drain<'a, I::Item, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-            pub(super) replace_with: I,
-        }
-    };
+/// A splicing iterator for `BumpVec`.
+///
+/// This struct is created by [`BumpVec::splice()`].
+/// See its documentation for more.
+///
+/// # Example
+///
+/// ```
+/// # use bump_scope::{ Bump, bump_vec };
+/// # let bump: Bump = Bump::new();
+/// let mut v = bump_vec![in &bump; 0, 1, 2];
+/// let new = [7, 8];
+/// let old = bump.alloc_iter_exact(v.splice(1.., new));
+/// assert_eq!(old, [1, 2]);
+/// assert_eq!(v, [0, 7, 8]);
+/// ```
+///
+/// [`BumpVec::splice()`]: crate::BumpVec::splice
+#[derive(Debug)]
+pub struct Splice<'a, I: Iterator + 'a, A: BumpAllocator> {
+    pub(super) drain: Drain<'a, I::Item, A>,
+    pub(super) replace_with: I,
 }
 
-crate::maybe_default_allocator!(splice_declaration);
-
-impl<I, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Iterator
-    for Splice<'_, I, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    I: Iterator,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<I: Iterator, A: BumpAllocator> Iterator for Splice<'_, I, A> {
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -65,34 +42,15 @@ where
     }
 }
 
-impl<I, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DoubleEndedIterator
-    for Splice<'_, I, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    I: Iterator,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<I: Iterator, A: BumpAllocator> DoubleEndedIterator for Splice<'_, I, A> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.drain.next_back()
     }
 }
 
-impl<I, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> ExactSizeIterator
-    for Splice<'_, I, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    I: Iterator,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
-}
+impl<I: Iterator, A: BumpAllocator> ExactSizeIterator for Splice<'_, I, A> {}
 
-impl<I, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Drop
-    for Splice<'_, I, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    I: Iterator,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<I: Iterator, A: BumpAllocator> Drop for Splice<'_, I, A> {
     fn drop(&mut self) {
         self.drain.by_ref().for_each(drop);
         // At this point draining is done and the only remaining tasks are splicing
@@ -125,7 +83,8 @@ where
 
             // Collect any remaining elements.
             // This is a zero-length vector which does not allocate if `lower_bound` was exact.
-            let mut collected = self.drain.vec.as_ref().bump.alloc_iter(&mut self.replace_with).into_iter();
+            // TODO: allocate with `BumpVec` in the `A`
+            let mut collected = (&mut self.replace_with).collect::<Vec<_>>().into_iter();
 
             // Now we have an exact count.
             #[allow(clippy::len_zero)]
@@ -135,18 +94,15 @@ where
                 debug_assert!(filled);
                 debug_assert_eq!(collected.len(), 0);
             }
+
+            drop(collected);
         }
         // Let `Drain::drop` move the tail back if necessary and restore `vec.len`.
     }
 }
 
 /// Private helper methods for `Splice::drop`
-impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    Drain<'_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> Drain<'_, T, A> {
     /// The range from `self.vec.len` to `self.tail_start` contains elements
     /// that have been moved out.
     /// Fill that range as much as possible with new elements from the `replace_with` iterator.

--- a/src/chunk_raw.rs
+++ b/src/chunk_raw.rs
@@ -545,11 +545,4 @@ impl<const UP: bool, A> RawChunk<UP, A> {
     pub(crate) fn allocator(self) -> NonNull<A> {
         unsafe { NonNull::from(&self.header.as_ref().allocator) }
     }
-
-    #[inline(always)]
-    pub(crate) fn without_allocator(self) -> RawChunk<UP, ()> {
-        RawChunk {
-            header: self.header.cast(),
-        }
-    }
 }

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -29,8 +29,8 @@ pub(crate) trait ErrorBehavior: Sized {
     ) -> Result<NonNull<u8>, Self>;
 
     fn allocate_layout(allocator: &impl BumpAllocator, layout: Layout) -> Result<NonNull<u8>, Self>;
-    fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<u8>, Self>;
-    fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<u8>, Self>;
+    fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
+    fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
 }
 
 #[cfg(not(no_global_oom_handling))]
@@ -88,12 +88,12 @@ impl ErrorBehavior for Infallible {
     }
 
     #[inline(always)]
-    fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<u8>, Self> {
+    fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self> {
         Ok(allocator.allocate_sized::<T>())
     }
 
     #[inline(always)]
-    fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<u8>, Self> {
+    fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self> {
         Ok(allocator.allocate_slice::<T>(len))
     }
 }
@@ -159,12 +159,12 @@ impl ErrorBehavior for AllocError {
     }
 
     #[inline(always)]
-    fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<u8>, Self> {
+    fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self> {
         allocator.try_allocate_sized::<T>()
     }
 
     #[inline(always)]
-    fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<u8>, Self> {
+    fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self> {
         allocator.try_allocate_slice::<T>(len)
     }
 }

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -33,6 +33,7 @@ pub(crate) trait ErrorBehavior: Sized {
     #[allow(dead_code)]
     fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
+    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self>;
 }
 
 #[cfg(not(no_global_oom_handling))]
@@ -97,6 +98,11 @@ impl ErrorBehavior for Infallible {
     #[inline(always)]
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self> {
         Ok(allocator.allocate_slice::<T>(len))
+    }
+
+    #[inline(always)]
+    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
+        Ok(allocator.allocate_slice_greedy::<T>(len))
     }
 }
 
@@ -168,6 +174,11 @@ impl ErrorBehavior for AllocError {
     #[inline(always)]
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self> {
         allocator.try_allocate_slice::<T>(len)
+    }
+
+    #[inline(always)]
+    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
+        allocator.try_allocate_slice_greedy::<T>(len)
     }
 }
 

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -28,7 +28,9 @@ pub(crate) trait ErrorBehavior: Sized {
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,
     ) -> Result<NonNull<u8>, Self>;
 
+    #[allow(dead_code)]
     fn allocate_layout(allocator: &impl BumpAllocator, layout: Layout) -> Result<NonNull<u8>, Self>;
+    #[allow(dead_code)]
     fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
 }

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -102,7 +102,7 @@ impl ErrorBehavior for Infallible {
 
     #[inline(always)]
     unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
-        Ok(allocator.allocate_slice_greedy::<T>(len))
+        Ok(allocator.prepare_slice_allocation::<T>(len))
     }
 }
 
@@ -178,7 +178,7 @@ impl ErrorBehavior for AllocError {
 
     #[inline(always)]
     unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
-        allocator.try_allocate_slice_greedy::<T>(len)
+        allocator.try_prepare_slice_allocation::<T>(len)
     }
 }
 

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -1,6 +1,6 @@
 #[cfg(not(no_global_oom_handling))]
 use crate::{capacity_overflow, format_trait_error, handle_alloc_error, Infallible};
-use crate::{layout, AllocError, BumpAllocator, Layout, NonNull, RawChunk, SupportedMinimumAlignment};
+use crate::{layout, AllocError, BumpAllocator, BumpAllocatorMut, Layout, NonNull, RawChunk, SupportedMinimumAlignment};
 use layout::LayoutProps;
 
 pub(crate) trait ErrorBehavior: Sized {
@@ -33,7 +33,7 @@ pub(crate) trait ErrorBehavior: Sized {
     #[allow(dead_code)]
     fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
-    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self>;
+    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self>;
 }
 
 #[cfg(not(no_global_oom_handling))]
@@ -101,7 +101,7 @@ impl ErrorBehavior for Infallible {
     }
 
     #[inline(always)]
-    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
+    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
         Ok(allocator.prepare_slice_allocation::<T>(len))
     }
 }
@@ -177,7 +177,7 @@ impl ErrorBehavior for AllocError {
     }
 
     #[inline(always)]
-    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
+    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
         allocator.try_prepare_slice_allocation::<T>(len)
     }
 }

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -34,6 +34,10 @@ pub(crate) trait ErrorBehavior: Sized {
     fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
     unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self>;
+    unsafe fn prepare_slice_allocation_rev<T>(
+        allocator: &mut impl BumpAllocatorMut,
+        len: usize,
+    ) -> Result<(NonNull<T>, usize), Self>;
 }
 
 #[cfg(not(no_global_oom_handling))]
@@ -103,6 +107,14 @@ impl ErrorBehavior for Infallible {
     #[inline(always)]
     unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
         Ok(allocator.prepare_slice_allocation::<T>(len))
+    }
+
+    #[inline(always)]
+    unsafe fn prepare_slice_allocation_rev<T>(
+        allocator: &mut impl BumpAllocatorMut,
+        len: usize,
+    ) -> Result<(NonNull<T>, usize), Self> {
+        Ok(allocator.prepare_slice_allocation_rev::<T>(len))
     }
 }
 
@@ -179,6 +191,14 @@ impl ErrorBehavior for AllocError {
     #[inline(always)]
     unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
         allocator.try_prepare_slice_allocation::<T>(len)
+    }
+
+    #[inline(always)]
+    unsafe fn prepare_slice_allocation_rev<T>(
+        allocator: &mut impl BumpAllocatorMut,
+        len: usize,
+    ) -> Result<(NonNull<T>, usize), Self> {
+        allocator.try_prepare_slice_allocation_rev::<T>(len)
     }
 }
 

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -1,6 +1,6 @@
 #[cfg(not(no_global_oom_handling))]
 use crate::{capacity_overflow, format_trait_error, handle_alloc_error, Infallible};
-use crate::{layout, AllocError, BumpAllocator, BumpAllocatorMut, Layout, NonNull, RawChunk, SupportedMinimumAlignment};
+use crate::{layout, AllocError, BumpAllocator, Layout, MutBumpAllocator, NonNull, RawChunk, SupportedMinimumAlignment};
 use layout::LayoutProps;
 
 pub(crate) trait ErrorBehavior: Sized {
@@ -33,9 +33,9 @@ pub(crate) trait ErrorBehavior: Sized {
     #[allow(dead_code)]
     fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
-    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self>;
+    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl MutBumpAllocator, len: usize) -> Result<NonNull<[T]>, Self>;
     unsafe fn prepare_slice_allocation_rev<T>(
-        allocator: &mut impl BumpAllocatorMut,
+        allocator: &mut impl MutBumpAllocator,
         len: usize,
     ) -> Result<(NonNull<T>, usize), Self>;
 }
@@ -105,13 +105,13 @@ impl ErrorBehavior for Infallible {
     }
 
     #[inline(always)]
-    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
+    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl MutBumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
         Ok(allocator.prepare_slice_allocation::<T>(len))
     }
 
     #[inline(always)]
     unsafe fn prepare_slice_allocation_rev<T>(
-        allocator: &mut impl BumpAllocatorMut,
+        allocator: &mut impl MutBumpAllocator,
         len: usize,
     ) -> Result<(NonNull<T>, usize), Self> {
         Ok(allocator.prepare_slice_allocation_rev::<T>(len))
@@ -189,13 +189,13 @@ impl ErrorBehavior for AllocError {
     }
 
     #[inline(always)]
-    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
+    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl MutBumpAllocator, len: usize) -> Result<NonNull<[T]>, Self> {
         allocator.try_prepare_slice_allocation::<T>(len)
     }
 
     #[inline(always)]
     unsafe fn prepare_slice_allocation_rev<T>(
-        allocator: &mut impl BumpAllocatorMut,
+        allocator: &mut impl MutBumpAllocator,
         len: usize,
     ) -> Result<(NonNull<T>, usize), Self> {
         allocator.try_prepare_slice_allocation_rev::<T>(len)

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -33,7 +33,7 @@ pub(crate) trait ErrorBehavior: Sized {
     #[allow(dead_code)]
     fn allocate_sized<T>(allocator: &impl BumpAllocator) -> Result<NonNull<T>, Self>;
     fn allocate_slice<T>(allocator: &impl BumpAllocator, len: usize) -> Result<NonNull<T>, Self>;
-    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self>;
+    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self>;
 }
 
 #[cfg(not(no_global_oom_handling))]
@@ -101,7 +101,7 @@ impl ErrorBehavior for Infallible {
     }
 
     #[inline(always)]
-    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
+    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
         Ok(allocator.prepare_slice_allocation::<T>(len))
     }
 }
@@ -177,7 +177,7 @@ impl ErrorBehavior for AllocError {
     }
 
     #[inline(always)]
-    unsafe fn allocate_slice_greedy<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
+    unsafe fn prepare_slice_allocation<T>(allocator: &mut impl BumpAllocatorMut, len: usize) -> Result<NonNull<[T]>, Self> {
         allocator.try_prepare_slice_allocation::<T>(len)
     }
 }

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BaseAllocator, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec, MinimumAlignment, MutBumpString, MutBumpVec,
-    MutBumpVecRev, SupportedMinimumAlignment,
+    BaseAllocator, BumpAllocator, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec, MinimumAlignment,
+    MutBumpString, MutBumpVec, MutBumpVecRev, SupportedMinimumAlignment,
 };
 use ::serde::Serialize;
 use allocator_api2::alloc::AllocError;
@@ -34,13 +34,7 @@ where
     }
 }
 
-impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
-    for BumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-    T: Serialize,
-{
+impl<T: Serialize, A: BumpAllocator> Serialize for BumpVec<T, A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -84,12 +78,7 @@ impl Serialize for FixedBumpString<'_> {
     }
 }
 
-impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
-    for BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<A: BumpAllocator> Serialize for BumpString<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -185,13 +174,7 @@ where
     }
 }
 
-impl<'de, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DeserializeSeed<'de>
-    for &'_ mut BumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Deserialize<'de>,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, T: Deserialize<'de>, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut BumpVec<T, A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -202,13 +185,7 @@ where
     }
 }
 
-impl<'de, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Visitor<'de>
-    for &'_ mut BumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Deserialize<'de>,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, T: Deserialize<'de>, A: BumpAllocator> Visitor<'de> for &'_ mut BumpVec<T, A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -349,12 +326,7 @@ impl<'de> Visitor<'de> for &'_ mut FixedBumpString<'_> {
     }
 }
 
-impl<'de, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DeserializeSeed<'de>
-    for &'_ mut BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut BumpString<A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -365,12 +337,7 @@ where
     }
 }
 
-impl<'de, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Visitor<'de>
-    for &'_ mut BumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, A: BumpAllocator> Visitor<'de> for &'_ mut BumpString<A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -43,11 +43,7 @@ impl<T: Serialize, A: BumpAllocator> Serialize for BumpVec<T, A> {
     }
 }
 
-impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
-    for MutBumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Serialize,
-{
+impl<T: Serialize, A> Serialize for MutBumpVec<T, A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -87,9 +83,7 @@ impl<A: BumpAllocator> Serialize for BumpString<A> {
     }
 }
 
-impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
-    for MutBumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<A> Serialize for MutBumpString<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -208,13 +202,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocator> Visitor<'de> for &'_ mut BumpVe
     }
 }
 
-impl<'de, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DeserializeSeed<'de>
-    for &'_ mut MutBumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Deserialize<'de>,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, T: Deserialize<'de>, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpVec<T, A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -225,13 +213,7 @@ where
     }
 }
 
-impl<'de, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Visitor<'de>
-    for &'_ mut MutBumpVec<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Deserialize<'de>,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, T: Deserialize<'de>, A: BumpAllocator> Visitor<'de> for &'_ mut MutBumpVec<T, A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -352,12 +334,7 @@ impl<'de, A: BumpAllocator> Visitor<'de> for &'_ mut BumpString<A> {
     }
 }
 
-impl<'de, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DeserializeSeed<'de>
-    for &'_ mut MutBumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpString<A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -368,12 +345,7 @@ where
     }
 }
 
-impl<'de, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Visitor<'de>
-    for &'_ mut MutBumpString<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, A: BumpAllocator> Visitor<'de> for &mut MutBumpString<A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BaseAllocator, BumpAllocator, BumpAllocatorMut, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec,
-    MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev, SupportedMinimumAlignment,
+    BumpAllocator, BumpAllocatorMut, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec, MutBumpString, MutBumpVec,
+    MutBumpVecRev,
 };
 use ::serde::Serialize;
 use allocator_api2::alloc::AllocError;
@@ -52,11 +52,7 @@ impl<T: Serialize, A> Serialize for MutBumpVec<T, A> {
     }
 }
 
-impl<T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Serialize
-    for MutBumpVecRev<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Serialize,
-{
+impl<T: Serialize, A> Serialize for MutBumpVecRev<T, A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -236,13 +232,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> Visitor<'de> for &'_ mut Mut
     }
 }
 
-impl<'de, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DeserializeSeed<'de>
-    for &'_ mut MutBumpVecRev<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Deserialize<'de>,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> DeserializeSeed<'de> for &mut MutBumpVecRev<T, A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -253,13 +243,7 @@ where
     }
 }
 
-impl<'de, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Visitor<'de>
-    for &'_ mut MutBumpVecRev<'_, '_, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: Deserialize<'de>,
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> Visitor<'de> for &mut MutBumpVecRev<T, A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BaseAllocator, BumpAllocator, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec, MinimumAlignment,
-    MutBumpString, MutBumpVec, MutBumpVecRev, SupportedMinimumAlignment,
+    BaseAllocator, BumpAllocator, BumpAllocatorMut, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec,
+    MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev, SupportedMinimumAlignment,
 };
 use ::serde::Serialize;
 use allocator_api2::alloc::AllocError;
@@ -110,7 +110,7 @@ fn too_many_elements<E: de::Error>(len: usize, at_most: usize) -> E {
 fn map_alloc_error<E: de::Error>(result: Result<(), AllocError>) -> Result<(), E> {
     match result {
         Ok(()) => Ok(()),
-        Err(AllocError) => return Err(E::custom(&AllocationFailed)),
+        Err(AllocError) => Err(E::custom(&AllocationFailed)),
     }
 }
 
@@ -202,7 +202,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocator> Visitor<'de> for &'_ mut BumpVe
     }
 }
 
-impl<'de, T: Deserialize<'de>, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpVec<T, A> {
+impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> DeserializeSeed<'de> for &'_ mut MutBumpVec<T, A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -213,7 +213,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocator> DeserializeSeed<'de> for &'_ mu
     }
 }
 
-impl<'de, T: Deserialize<'de>, A: BumpAllocator> Visitor<'de> for &'_ mut MutBumpVec<T, A> {
+impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> Visitor<'de> for &'_ mut MutBumpVec<T, A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -293,7 +293,7 @@ impl<'de> DeserializeSeed<'de> for &'_ mut FixedBumpString<'_> {
     }
 }
 
-impl<'de> Visitor<'de> for &'_ mut FixedBumpString<'_> {
+impl Visitor<'_> for &'_ mut FixedBumpString<'_> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -319,7 +319,7 @@ impl<'de, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut BumpString<A> {
     }
 }
 
-impl<'de, A: BumpAllocator> Visitor<'de> for &'_ mut BumpString<A> {
+impl<A: BumpAllocator> Visitor<'_> for &'_ mut BumpString<A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -334,7 +334,7 @@ impl<'de, A: BumpAllocator> Visitor<'de> for &'_ mut BumpString<A> {
     }
 }
 
-impl<'de, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpString<A> {
+impl<'de, A: BumpAllocatorMut> DeserializeSeed<'de> for &'_ mut MutBumpString<A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -345,7 +345,7 @@ impl<'de, A: BumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpString<A> {
     }
 }
 
-impl<'de, A: BumpAllocator> Visitor<'de> for &mut MutBumpString<A> {
+impl<A: BumpAllocatorMut> Visitor<'_> for &mut MutBumpString<A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BumpAllocator, BumpAllocatorMut, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec, MutBumpString, MutBumpVec,
+    BumpAllocator, BumpBox, BumpString, BumpVec, FixedBumpString, FixedBumpVec, MutBumpAllocator, MutBumpString, MutBumpVec,
     MutBumpVecRev,
 };
 use ::serde::Serialize;
@@ -198,7 +198,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocator> Visitor<'de> for &'_ mut BumpVe
     }
 }
 
-impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> DeserializeSeed<'de> for &'_ mut MutBumpVec<T, A> {
+impl<'de, T: Deserialize<'de>, A: MutBumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpVec<T, A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -209,7 +209,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> DeserializeSeed<'de> for &'_
     }
 }
 
-impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> Visitor<'de> for &'_ mut MutBumpVec<T, A> {
+impl<'de, T: Deserialize<'de>, A: MutBumpAllocator> Visitor<'de> for &'_ mut MutBumpVec<T, A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -232,7 +232,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> Visitor<'de> for &'_ mut Mut
     }
 }
 
-impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> DeserializeSeed<'de> for &mut MutBumpVecRev<T, A> {
+impl<'de, T: Deserialize<'de>, A: MutBumpAllocator> DeserializeSeed<'de> for &mut MutBumpVecRev<T, A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -243,7 +243,7 @@ impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> DeserializeSeed<'de> for &mu
     }
 }
 
-impl<'de, T: Deserialize<'de>, A: BumpAllocatorMut> Visitor<'de> for &mut MutBumpVecRev<T, A> {
+impl<'de, T: Deserialize<'de>, A: MutBumpAllocator> Visitor<'de> for &mut MutBumpVecRev<T, A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
@@ -318,7 +318,7 @@ impl<A: BumpAllocator> Visitor<'_> for &'_ mut BumpString<A> {
     }
 }
 
-impl<'de, A: BumpAllocatorMut> DeserializeSeed<'de> for &'_ mut MutBumpString<A> {
+impl<'de, A: MutBumpAllocator> DeserializeSeed<'de> for &'_ mut MutBumpString<A> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -329,7 +329,7 @@ impl<'de, A: BumpAllocatorMut> DeserializeSeed<'de> for &'_ mut MutBumpString<A>
     }
 }
 
-impl<A: BumpAllocatorMut> Visitor<'_> for &mut MutBumpString<A> {
+impl<A: MutBumpAllocator> Visitor<'_> for &mut MutBumpString<A> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {

--- a/src/features/zerocopy.rs
+++ b/src/features/zerocopy.rs
@@ -20,6 +20,7 @@ where
     /// let init = uninit.init_zeroed();
     /// assert_eq!(*init, 0);
     /// ```
+    #[must_use]
     pub fn init_zeroed(self) -> BumpBox<'a, T> {
         unsafe {
             self.ptr.as_ptr().write_bytes(0, 1);
@@ -43,6 +44,7 @@ where
     /// let init = uninit.init_zeroed();
     /// assert_eq!(*init, [0; 10]);
     /// ```
+    #[must_use]
     pub fn init_zeroed(self) -> BumpBox<'a, [T]> {
         unsafe {
             let len = self.len();

--- a/src/fixed_bump_string.rs
+++ b/src/fixed_bump_string.rs
@@ -1,8 +1,7 @@
 use crate::{
     error_behavior_generic_methods_if, owned_str,
     polyfill::{self, nonnull, transmute_mut},
-    BaseAllocator, BumpBox, BumpScope, BumpString, ErrorBehavior, FixedBumpVec, FromUtf8Error, MinimumAlignment, NoDrop,
-    SupportedMinimumAlignment,
+    BumpAllocatorScope, BumpBox, BumpString, ErrorBehavior, FixedBumpVec, FromUtf8Error, NoDrop,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -210,15 +209,8 @@ impl<'a> FixedBumpString<'a> {
     /// Turns this `FixedBumpString<T>` into a `BumpVec<T>`.
     #[must_use]
     #[inline(always)]
-    pub fn into_string<'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
-        self,
-        bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-    ) -> BumpString<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-    where
-        MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-        A: BaseAllocator<GUARANTEED_ALLOCATED>,
-    {
-        BumpString::from_parts(self, bump)
+    pub fn into_string<A: BumpAllocatorScope<'a>>(self, allocator: A) -> BumpString<A> {
+        BumpString::from_parts(self, allocator)
     }
 
     /// Converts a `FixedBumpString` into a `FixedBumpVec<u8>`.

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -2,8 +2,7 @@ use crate::{
     error_behavior_generic_methods_allocation_failure, error_behavior_generic_methods_if, owned_slice,
     polyfill::{self, nonnull, pointer, slice},
     set_len_on_drop_by_ptr::SetLenOnDropByPtr,
-    BaseAllocator, BumpAllocatorScope, BumpBox, BumpScope, BumpVec, ErrorBehavior, MinimumAlignment, NoDrop,
-    SizedTypeProperties, SupportedMinimumAlignment,
+    BumpAllocatorScope, BumpBox, BumpVec, ErrorBehavior, NoDrop, SizedTypeProperties,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -81,23 +80,12 @@ impl<'a, T> FixedBumpVec<'a, T> {
         /// ```
         for fn try_from_iter_in
         #[inline]
-        use fn generic_from_iter_in<{
-            I,
-            A,
-            const MIN_ALIGN: usize,
-            const UP: bool,
-            const GUARANTEED_ALLOCATED: bool,
-        } {
-            'b,
-        }>(iter: I, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_iter_in<{I, A}>(iter: I, allocator: A) -> Self
         where {
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED> + 'b,
             I: IntoIterator<Item = T>,
-            'a: 'b,
+            A: BumpAllocatorScope<'a>,
         } in {
-            let bump = bump.into();
-            Ok(Self::from_init(bump.generic_alloc_iter(iter)?))
+            Ok(BumpVec::generic_from_iter_in(iter, allocator)?.into_fixed_vec())
         }
 
         /// Create a new [`FixedBumpVec`] whose elements are taken from an iterator and allocated in the given `bump`.
@@ -123,24 +111,13 @@ impl<'a, T> FixedBumpVec<'a, T> {
         /// ```
         for fn try_from_iter_exact_in
         #[inline]
-        use fn generic_from_iter_exact_in<{
-            I,
-            A,
-            const MIN_ALIGN: usize,
-            const UP: bool,
-            const GUARANTEED_ALLOCATED: bool,
-        } {
-            'b,
-        }>(iter: I, bump: impl Into<&'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_iter_exact_in<{I, A}>(iter: I, allocator: A) -> Self
         where {
-            MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-            A: BaseAllocator<GUARANTEED_ALLOCATED> + 'b,
             I: IntoIterator<Item = T>,
             I::IntoIter: ExactSizeIterator,
-            'a: 'b,
+            A: BumpAllocatorScope<'a>,
         } in {
-            let bump = bump.into();
-            Ok(Self::from_init(bump.generic_alloc_iter_exact(iter)?))
+            Ok(BumpVec::generic_from_iter_exact_in(iter, allocator)?.into_fixed_vec())
         }
     }
 

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -1517,7 +1517,7 @@ impl<'a, T, const N: usize> FixedBumpVec<'a, [T; N]> {
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut vec = mut_bump_vec![in bump; [1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    /// let mut vec = mut_bump_vec![in &mut bump; [1, 2, 3], [4, 5, 6], [7, 8, 9]];
     /// assert_eq!(vec.pop(), Some([7, 8, 9]));
     ///
     /// let mut flattened = vec.into_flattened();

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -2,8 +2,8 @@ use crate::{
     error_behavior_generic_methods_allocation_failure, error_behavior_generic_methods_if, owned_slice,
     polyfill::{self, nonnull, pointer, slice},
     set_len_on_drop_by_ptr::SetLenOnDropByPtr,
-    BaseAllocator, BumpBox, BumpScope, BumpVec, ErrorBehavior, MinimumAlignment, NoDrop, SizedTypeProperties,
-    SupportedMinimumAlignment,
+    BaseAllocator, BumpAllocatorScope, BumpBox, BumpScope, BumpVec, ErrorBehavior, MinimumAlignment, NoDrop,
+    SizedTypeProperties, SupportedMinimumAlignment,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -225,15 +225,8 @@ impl<'a, T> FixedBumpVec<'a, T> {
     /// Turns this `FixedBumpVec<T>` into a `BumpVec<T>`.
     #[must_use]
     #[inline(always)]
-    pub fn into_vec<'b, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
-        self,
-        bump: &'b BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-    ) -> BumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-    where
-        MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-        A: BaseAllocator<GUARANTEED_ALLOCATED>,
-    {
-        BumpVec::from_parts(self, bump)
+    pub fn into_vec<A: BumpAllocatorScope<'a>>(self, allocator: A) -> BumpVec<T, A> {
+        BumpVec::from_parts(self, allocator)
     }
 
     /// Removes the last element from a vector and returns it, or [`None`] if it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,7 @@ pub mod owned_slice;
 pub mod owned_str;
 mod polyfill;
 mod raw_bump_box;
+mod raw_fixed_bump_string;
 mod raw_fixed_bump_vec;
 mod set_len_on_drop;
 mod set_len_on_drop_by_ptr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,8 +728,8 @@ macro_rules! bump_scope_methods {
             $crate::condition! {
                 if $is_scope {
                     debug_assert!(self.stats().big_to_small().any(|c| {
-                        c.chunk.header_ptr() == checkpoint.chunk.cast() &&
-                        c.chunk.contains_addr_or_end(checkpoint.address.get())
+                        c.chunk == checkpoint.chunk.cast() &&
+                        crate::stats::raw!(c.contains_addr_or_end(checkpoint.address.get()))
                     }));
 
                     checkpoint.reset_within_chunk();
@@ -746,7 +746,7 @@ macro_rules! bump_scope_methods {
         #[inline(always)]
         pub fn guaranteed_allocated_stats(
             &self,
-        ) -> $crate::condition! { if $is_scope { GuaranteedAllocatedStats<'a, UP> } else { GuaranteedAllocatedStats<UP> } } {
+        ) -> $crate::condition! { if $is_scope { GuaranteedAllocatedStats<'a> } else { GuaranteedAllocatedStats } } {
             GuaranteedAllocatedStats {
                 current: crate::Chunk::new_guaranteed_allocated(self.as_scope()),
             }
@@ -768,7 +768,7 @@ macro_rules! bump_common_methods {
                 /// Returns a type which provides statistics about the memory usage of the bump allocator.
                 #[must_use]
                 #[inline(always)]
-                pub fn stats(&self) -> Stats<'a, UP> {
+                pub fn stats(&self) -> Stats<'a> {
                     Stats {
                         current: crate::Chunk::new(self.as_scope()),
                     }
@@ -777,7 +777,7 @@ macro_rules! bump_common_methods {
                 /// Returns a type which provides statistics about the memory usage of the bump allocator.
                 #[must_use]
                 #[inline(always)]
-                pub fn stats(&self) -> Stats<UP> {
+                pub fn stats(&self) -> Stats {
                     self.as_scope().stats()
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ pub use allocator_api2;
 use allocator_api2::alloc::handle_alloc_error;
 use allocator_api2::alloc::{AllocError, Allocator};
 pub use bump::Bump;
-pub use bump_allocator::{BumpAllocator, BumpAllocatorScope};
+pub use bump_allocator::{BumpAllocator, BumpAllocatorMut, BumpAllocatorScope, BumpAllocatorScopeMut};
 pub use bump_box::BumpBox;
 #[cfg(feature = "std")]
 pub use bump_pool::{BumpPool, BumpPoolGuard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ pub use allocator_api2;
 use allocator_api2::alloc::handle_alloc_error;
 use allocator_api2::alloc::{AllocError, Allocator};
 pub use bump::Bump;
-pub use bump_allocator::{BumpAllocator, BumpAllocatorMut, BumpAllocatorScope, BumpAllocatorScopeMut};
+pub use bump_allocator::{BumpAllocator, BumpAllocatorScope, MutBumpAllocator, MutBumpAllocatorScope};
 pub use bump_box::BumpBox;
 #[cfg(feature = "std")]
 pub use bump_pool::{BumpPool, BumpPoolGuard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ pub use allocator_api2;
 use allocator_api2::alloc::handle_alloc_error;
 use allocator_api2::alloc::{AllocError, Allocator};
 pub use bump::Bump;
-pub use bump_allocator::BumpAllocator;
+pub use bump_allocator::{BumpAllocator, BumpAllocatorScope};
 pub use bump_box::BumpBox;
 #[cfg(feature = "std")]
 pub use bump_pool::{BumpPool, BumpPoolGuard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,6 @@ use core::convert::Infallible;
 use core::{
     alloc::Layout,
     fmt::{self, Debug},
-    marker::PhantomData,
     mem::{self, MaybeUninit},
     num::NonZeroUsize,
     ptr::NonNull,
@@ -488,68 +487,6 @@ pub mod private {
     #[cfg(not(no_global_oom_handling))]
     pub const fn format_trait_error() -> ! {
         panic!("formatting trait implementation returned an error");
-    }
-}
-
-/// Associates a lifetime to a wrapped type.
-///
-/// This is used for [`BumpBox::into_box`] to attach a lifetime to the `Box`.
-#[derive(Debug, Clone)]
-pub struct WithLifetime<'a, A> {
-    inner: A,
-    marker: PhantomData<&'a mut ()>,
-}
-
-#[allow(missing_docs)]
-impl<A> WithLifetime<'_, A> {
-    #[inline(always)]
-    pub fn new(inner: A) -> Self {
-        Self {
-            inner,
-            marker: PhantomData,
-        }
-    }
-
-    #[inline(always)]
-    pub fn into_inner(self) -> A {
-        self.inner
-    }
-}
-
-unsafe impl<A: Allocator> Allocator for WithLifetime<'_, A> {
-    #[inline(always)]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.inner.allocate(layout)
-    }
-
-    #[inline(always)]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.inner.allocate_zeroed(layout)
-    }
-
-    #[inline(always)]
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        self.inner.deallocate(ptr, layout);
-    }
-
-    #[inline(always)]
-    unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.inner.grow(ptr, old_layout, new_layout)
-    }
-
-    #[inline(always)]
-    unsafe fn grow_zeroed(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        self.inner.grow_zeroed(ptr, old_layout, new_layout)
-    }
-
-    #[inline(always)]
-    unsafe fn shrink(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.inner.shrink(ptr, old_layout, new_layout)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,8 @@ pub mod owned_slice;
 /// Contains types associated with owned strings.
 pub mod owned_str;
 mod polyfill;
+mod raw_bump_box;
+mod raw_fixed_bump_vec;
 mod set_len_on_drop;
 mod set_len_on_drop_by_ptr;
 mod stats;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ mod from_utf8_error;
 mod layout;
 mod mut_bump_string;
 /// Contains [`MutBumpVec`] and associated types.
-mod mut_bump_vec;
+pub mod mut_bump_vec;
 /// Contains [`MutBumpVecRev`] and associated types.
 mod mut_bump_vec_rev;
 /// Contains types associated with owned slices.
@@ -338,6 +338,7 @@ pub use from_utf16_error::FromUtf16Error;
 pub use from_utf8_error::FromUtf8Error;
 use layout::ArrayLayout;
 pub use mut_bump_string::MutBumpString;
+#[doc(inline)]
 pub use mut_bump_vec::MutBumpVec;
 pub use mut_bump_vec_rev::MutBumpVecRev;
 #[cfg(not(no_global_oom_handling))]

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -1301,7 +1301,7 @@ where
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, UP> {
+    pub fn stats(&self) -> Stats<'a> {
         self.bump.stats()
     }
 }
@@ -1316,7 +1316,7 @@ where
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a, UP> {
+    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a> {
         self.bump.guaranteed_allocated_stats()
     }
 }

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -2,7 +2,7 @@ use crate::{
     error_behavior_generic_methods_allocation_failure, owned_str,
     polyfill::{self, transmute_mut, transmute_value},
     raw_fixed_bump_string::RawFixedBumpString,
-    BumpAllocatorMut, BumpAllocatorScopeMut, BumpBox, ErrorBehavior, FromUtf16Error, FromUtf8Error, MutBumpVec, Stats,
+    BumpBox, ErrorBehavior, FromUtf16Error, FromUtf8Error, MutBumpAllocator, MutBumpAllocatorScope, MutBumpVec, Stats,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -500,7 +500,7 @@ impl<A> MutBumpString<A> {
     }
 }
 
-impl<A: BumpAllocatorMut> MutBumpString<A> {
+impl<A: MutBumpAllocator> MutBumpString<A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Constructs a new empty `MutBumpString` with at least the specified capacity
         /// with the provided `BumpScope`.
@@ -1223,7 +1223,7 @@ impl<A: BumpAllocatorMut> MutBumpString<A> {
     }
 }
 
-impl<'a, A: BumpAllocatorScopeMut<'a>> MutBumpString<A> {
+impl<'a, A: MutBumpAllocatorScope<'a>> MutBumpString<A> {
     /// Converts this `MutBumpString` into `&str` that is live for this bump scope.
     ///
     /// Unused capacity does not take up space.<br/>
@@ -1246,7 +1246,7 @@ impl<'a, A: BumpAllocatorScopeMut<'a>> MutBumpString<A> {
     }
 }
 
-impl<A: BumpAllocatorMut> fmt::Write for MutBumpString<A> {
+impl<A: MutBumpAllocator> fmt::Write for MutBumpString<A> {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.try_push_str(s).map_err(|_| fmt::Error)
@@ -1259,7 +1259,7 @@ impl<A: BumpAllocatorMut> fmt::Write for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<A: BumpAllocatorMut> fmt::Write for Infallibly<MutBumpString<A>> {
+impl<A: MutBumpAllocator> fmt::Write for Infallibly<MutBumpString<A>> {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.0.push_str(s);
@@ -1302,7 +1302,7 @@ impl<A> DerefMut for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<A: BumpAllocatorMut> core::ops::AddAssign<&str> for MutBumpString<A> {
+impl<A: MutBumpAllocator> core::ops::AddAssign<&str> for MutBumpString<A> {
     #[inline]
     fn add_assign(&mut self, rhs: &str) {
         self.push_str(rhs);
@@ -1441,7 +1441,7 @@ impl<A> Hash for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'s, A: BumpAllocatorMut> Extend<&'s str> for MutBumpString<A> {
+impl<'s, A: MutBumpAllocator> Extend<&'s str> for MutBumpString<A> {
     #[inline]
     fn extend<T: IntoIterator<Item = &'s str>>(&mut self, iter: T) {
         for str in iter {
@@ -1451,7 +1451,7 @@ impl<'s, A: BumpAllocatorMut> Extend<&'s str> for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<A: BumpAllocatorMut> Extend<char> for MutBumpString<A> {
+impl<A: MutBumpAllocator> Extend<char> for MutBumpString<A> {
     fn extend<I: IntoIterator<Item = char>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
         let (lower_bound, _) = iterator.size_hint();
@@ -1461,7 +1461,7 @@ impl<A: BumpAllocatorMut> Extend<char> for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'s, A: BumpAllocatorMut> Extend<&'s char> for MutBumpString<A> {
+impl<'s, A: MutBumpAllocator> Extend<&'s char> for MutBumpString<A> {
     fn extend<I: IntoIterator<Item = &'s char>>(&mut self, iter: I) {
         self.extend(iter.into_iter().copied());
     }

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -160,7 +160,7 @@ impl<A: BumpAllocatorMut> MutBumpString<A> {
             }
 
             Ok(Self {
-                fixed: unsafe { RawFixedBumpString::allocate_greedy(&mut allocator, capacity)? },
+                fixed: unsafe { RawFixedBumpString::prepare_allocation(&mut allocator, capacity)? },
                 allocator,
             })
         }

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -2,7 +2,7 @@ use crate::{
     error_behavior_generic_methods_allocation_failure, owned_str,
     polyfill::{self, transmute_mut, transmute_value},
     raw_fixed_bump_string::RawFixedBumpString,
-    BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, FromUtf16Error, FromUtf8Error, MutBumpVec, Stats,
+    BumpAllocatorMut, BumpAllocatorScopeMut, BumpBox, ErrorBehavior, FromUtf16Error, FromUtf8Error, MutBumpVec, Stats,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -137,7 +137,7 @@ impl<A> MutBumpString<A> {
     }
 }
 
-impl<A: BumpAllocator> MutBumpString<A> {
+impl<A: BumpAllocatorMut> MutBumpString<A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Constructs a new empty `MutBumpString` with at least the specified capacity
         /// with the provided `BumpScope`.
@@ -775,7 +775,7 @@ impl<A> MutBumpString<A> {
     }
 }
 
-impl<A: BumpAllocator> MutBumpString<A> {
+impl<A: BumpAllocatorMut> MutBumpString<A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Appends the given [`char`] to the end of this string.
         impl
@@ -1229,7 +1229,7 @@ impl<A: BumpAllocator> MutBumpString<A> {
     }
 }
 
-impl<'a, A: BumpAllocatorScope<'a>> MutBumpString<A> {
+impl<'a, A: BumpAllocatorScopeMut<'a>> MutBumpString<A> {
     /// Converts this `MutBumpString` into `&str` that is live for this bump scope.
     ///
     /// Unused capacity does not take up space.<br/>
@@ -1252,7 +1252,7 @@ impl<'a, A: BumpAllocatorScope<'a>> MutBumpString<A> {
     }
 }
 
-impl<A: BumpAllocator> fmt::Write for MutBumpString<A> {
+impl<A: BumpAllocatorMut> fmt::Write for MutBumpString<A> {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.try_push_str(s).map_err(|_| fmt::Error)
@@ -1265,7 +1265,7 @@ impl<A: BumpAllocator> fmt::Write for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<A: BumpAllocator> fmt::Write for Infallibly<MutBumpString<A>> {
+impl<A: BumpAllocatorMut> fmt::Write for Infallibly<MutBumpString<A>> {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.0.push_str(s);
@@ -1308,7 +1308,7 @@ impl<A> DerefMut for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<A: BumpAllocator> core::ops::AddAssign<&str> for MutBumpString<A> {
+impl<A: BumpAllocatorMut> core::ops::AddAssign<&str> for MutBumpString<A> {
     #[inline]
     fn add_assign(&mut self, rhs: &str) {
         self.push_str(rhs);
@@ -1447,7 +1447,7 @@ impl<A> Hash for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'s, A: BumpAllocator> Extend<&'s str> for MutBumpString<A> {
+impl<'s, A: BumpAllocatorMut> Extend<&'s str> for MutBumpString<A> {
     #[inline]
     fn extend<T: IntoIterator<Item = &'s str>>(&mut self, iter: T) {
         for str in iter {
@@ -1457,7 +1457,7 @@ impl<'s, A: BumpAllocator> Extend<&'s str> for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<A: BumpAllocator> Extend<char> for MutBumpString<A> {
+impl<A: BumpAllocatorMut> Extend<char> for MutBumpString<A> {
     fn extend<I: IntoIterator<Item = char>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
         let (lower_bound, _) = iterator.size_hint();
@@ -1467,7 +1467,7 @@ impl<A: BumpAllocator> Extend<char> for MutBumpString<A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'s, A: BumpAllocator> Extend<&'s char> for MutBumpString<A> {
+impl<'s, A: BumpAllocatorMut> Extend<&'s char> for MutBumpString<A> {
     fn extend<I: IntoIterator<Item = &'s char>>(&mut self, iter: I) {
         self.extend(iter.into_iter().copied());
     }

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -1,14 +1,20 @@
+mod into_iter;
+
+pub use into_iter::IntoIter;
+
 use crate::{
     error_behavior_generic_methods_allocation_failure, min_non_zero_cap, owned_slice,
     polyfill::{nonnull, pointer, slice},
-    BaseAllocator, BumpBox, BumpScope, ErrorBehavior, FixedBumpVec, GuaranteedAllocatedStats, MinimumAlignment, NoDrop,
-    SetLenOnDropByPtr, SizedTypeProperties, Stats, SupportedMinimumAlignment,
+    raw_bump_box::RawBumpBox,
+    raw_fixed_bump_vec::RawFixedBumpVec,
+    BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, NoDrop, SetLenOnDropByPtr, SizedTypeProperties, Stats,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
     fmt::Debug,
     hash::Hash,
     iter,
+    marker::PhantomData,
     mem::{ManuallyDrop, MaybeUninit},
     ops::{Deref, DerefMut, Index, IndexMut, RangeBounds},
     panic::{RefUnwindSafe, UnwindSafe},
@@ -34,7 +40,7 @@ use core::{
 /// ```
 /// # use bump_scope::{ mut_bump_vec, Bump, MutBumpVec };
 /// # let mut bump: Bump = Bump::new();
-/// let vec: MutBumpVec<i32> = mut_bump_vec![in bump];
+/// let vec: MutBumpVec<i32, _> = mut_bump_vec![in &mut bump];
 /// assert!(vec.is_empty());
 /// ```
 ///
@@ -43,7 +49,7 @@ use core::{
 /// ```
 /// # use bump_scope::{ mut_bump_vec, Bump };
 /// # let mut bump: Bump = Bump::new();
-/// let vec = mut_bump_vec![in bump; 1, 2, 3];
+/// let vec = mut_bump_vec![in &mut bump; 1, 2, 3];
 /// assert_eq!(vec[0], 1);
 /// assert_eq!(vec[1], 2);
 /// assert_eq!(vec[2], 3);
@@ -54,7 +60,7 @@ use core::{
 /// ```
 /// # use bump_scope::{ mut_bump_vec, Bump };
 /// # let mut bump: Bump = Bump::new();
-/// let vec = mut_bump_vec![in bump; 1; 3];
+/// let vec = mut_bump_vec![in &mut bump; 1; 3];
 /// assert_eq!(vec, [1, 1, 1]);
 /// ```
 ///
@@ -64,124 +70,88 @@ use core::{
 ///
 /// This will use `clone` to duplicate an expression, so one should be careful
 /// using this with types having a nonstandard `Clone` implementation. For
-/// example, `mut_bump_vec![in bump; Rc::new(1); 5]` will create a vector of five references
+/// example, `mut_bump_vec![in &mut bump; Rc::new(1); 5]` will create a vector of five references
 /// to the same boxed integer value, not five references pointing to independently
 /// boxed integers.
 ///
-/// Also, note that `mut_bump_vec![in bump; expr; 0]` is allowed, and produces an empty vector.
+/// Also, note that `mut_bump_vec![in &mut bump; expr; 0]` is allowed, and produces an empty vector.
 /// This will still evaluate `expr`, however, and immediately drop the resulting value, so
 /// be mindful of side effects.
 #[macro_export]
 macro_rules! mut_bump_vec {
     [in $bump:expr] => {
-        $crate::MutBumpVec::new_in($bump.as_mut_scope())
+        $crate::MutBumpVec::new_in($bump)
     };
     [in $bump:expr; $($values:expr),* $(,)?] => {
-        $crate::MutBumpVec::from_array_in([$($values),*], $bump.as_mut_scope())
+        $crate::MutBumpVec::from_array_in([$($values),*], $bump)
     };
     [in $bump:expr; $value:expr; $count:expr] => {
-        $crate::MutBumpVec::from_elem_in($value, $count, $bump.as_mut_scope())
+        $crate::MutBumpVec::from_elem_in($value, $count, $bump)
     };
     [try in $bump:expr] => {
-        Ok::<_, $crate::allocator_api2::alloc::AllocError>($crate::MutBumpVec::new_in($bump.as_mut_scope()))
+        Ok::<_, $crate::allocator_api2::alloc::AllocError>($crate::MutBumpVec::new_in($bump))
     };
     [try in $bump:expr; $($values:expr),* $(,)?] => {
-        $crate::MutBumpVec::try_from_array_in([$($values),*], $bump.as_mut_scope())
+        $crate::MutBumpVec::try_from_array_in([$($values),*], $bump)
     };
     [try in $bump:expr; $value:expr; $count:expr] => {
-        $crate::MutBumpVec::try_from_elem_in($value, $count, $bump.as_mut_scope())
+        $crate::MutBumpVec::try_from_elem_in($value, $count, $bump)
     };
 }
 
-macro_rules! mut_bump_vec_declaration {
-    ($($allocator_parameter:tt)*) => {
-        /// A type like [`BumpVec`](crate::BumpVec), optimized for a `&mut Bump(Scope)`.
-        ///
-        /// It has the advantage that it can assume the entire remaining chunk space as its capacity.
-        /// It also only needs to update the bump pointer when calling <code>[into_](Self::into_slice)([boxed_](Self::into_boxed_slice))[slice](Self::into_slice)</code>.
-        ///
-        /// # Examples
-        ///
-        /// This type can be used to allocate a slice, when `alloc_*` methods are too limiting:
-        /// ```
-        /// use bump_scope::{ Bump, MutBumpVec };
-        /// let mut bump: Bump = Bump::new();
-        /// let mut vec = MutBumpVec::new_in(&mut bump);
-        ///
-        /// vec.push(1);
-        /// vec.push(2);
-        /// vec.push(3);
-        ///
-        /// let slice: &[i32] = vec.into_slice();
-        ///
-        /// assert_eq!(slice, [1, 2, 3]);
-        /// ```
-        //
-        // MutBumpVec never actually moves a bump pointer.
-        // It may force allocation of a new chunk, but it does not move the pointer within.
-        // So we don't need to move the bump pointer when dropping.
-        //
-        // If we want to reset the bump pointer to a previous chunk, we use a bump scope.
-        // We could do it here, by resetting to the last non-empty chunk but that would require a loop.
-        // Chunk allocations are supposed to be very rare, so this wouldn't be worth it.
-        #[repr(C)]
-        pub struct MutBumpVec<
-            'b,
-            'a: 'b,
-            T,
-            $($allocator_parameter)*,
-            const MIN_ALIGN: usize = 1,
-            const UP: bool = true,
-            const GUARANTEED_ALLOCATED: bool = true,
-        > {
-            fixed: FixedBumpVec<'b, T>,
-            pub(crate) bump: &'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
-        }
-    };
+/// A type like [`BumpVec`](crate::BumpVec), optimized for a `&mut Bump(Scope)`.
+///
+/// It has the advantage that it can assume the entire remaining chunk space as its capacity.
+/// It also only needs to update the bump pointer when calling <code>[into_](Self::into_slice)([boxed_](Self::into_boxed_slice))[slice](Self::into_slice)</code>.
+///
+/// # Examples
+///
+/// This type can be used to allocate a slice, when `alloc_*` methods are too limiting:
+/// ```
+/// use bump_scope::{ Bump, MutBumpVec };
+/// let mut bump: Bump = Bump::new();
+/// let mut vec = MutBumpVec::new_in(&mut bump);
+///
+/// vec.push(1);
+/// vec.push(2);
+/// vec.push(3);
+///
+/// let slice: &[i32] = vec.into_slice();
+///
+/// assert_eq!(slice, [1, 2, 3]);
+/// ```
+//
+// MutBumpVec never actually moves a bump pointer.
+// It may force allocation of a new chunk, but it does not move the pointer within.
+// So we don't need to move the bump pointer when dropping.
+//
+// If we want to reset the bump pointer to a previous chunk, we use a bump scope.
+// We could do it here, by resetting to the last non-empty chunk but that would require a loop.
+// Chunk allocations are supposed to be very rare, so this wouldn't be worth it.
+#[repr(C)]
+pub struct MutBumpVec<T, A> {
+    fixed: RawFixedBumpVec<T>,
+    pub(crate) allocator: A,
 }
 
-crate::maybe_default_allocator!(mut_bump_vec_declaration);
+impl<T: UnwindSafe, A: UnwindSafe> UnwindSafe for MutBumpVec<T, A> {}
+impl<T: RefUnwindSafe, A: RefUnwindSafe> RefUnwindSafe for MutBumpVec<T, A> {}
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> UnwindSafe
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: UnwindSafe,
-    A: UnwindSafe,
-{
-}
-
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> RefUnwindSafe
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    T: RefUnwindSafe,
-    A: RefUnwindSafe,
-{
-}
-
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Deref
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> Deref for MutBumpVec<T, A> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        &self.fixed
+        unsafe { self.fixed.cook_ref() }
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> DerefMut
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> DerefMut for MutBumpVec<T, A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.fixed
+        unsafe { self.fixed.cook_mut() }
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> MutBumpVec<T, A> {
     /// Constructs a new empty `MutBumpVec<T>`.
     ///
     /// The vector will not allocate until elements are pushed onto it.
@@ -192,14 +162,14 @@ where
     /// # use bump_scope::{ Bump, MutBumpVec };
     /// # let mut bump: Bump = Bump::new();
     /// # #[allow(unused_mut)]
-    /// let mut vec = MutBumpVec::<i32>::new_in(&mut bump);
+    /// let mut vec = MutBumpVec::<i32, _>::new_in(&mut bump);
     /// # let _ = vec;
     /// ```
     #[inline]
-    pub fn new_in(bump: impl Into<&'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+    pub fn new_in(allocator: A) -> Self {
         Self {
-            fixed: FixedBumpVec::EMPTY,
-            bump: bump.into(),
+            fixed: RawFixedBumpVec::EMPTY,
+            allocator,
         }
     }
 
@@ -223,31 +193,26 @@ where
         for fn with_capacity_in
         for fn try_with_capacity_in
         #[inline]
-        use fn generic_with_capacity_in(capacity: usize, bump: impl Into<&'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
-            let bump = bump.into();
+        use fn generic_with_capacity_in(capacity: usize, allocator: A) -> Self {
+            let mut allocator = allocator;
 
             if T::IS_ZST {
                 return Ok(Self {
-                    fixed: FixedBumpVec::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpVec::EMPTY,
+                    allocator,
                 });
             }
 
             if capacity == 0 {
                 return Ok(Self {
-                    fixed: FixedBumpVec::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpVec::EMPTY,
+                    allocator,
                 });
             }
 
-            let (ptr, capacity) = bump.alloc_greedy(capacity)?;
-
             Ok(Self {
-                fixed: FixedBumpVec {
-                    initialized: unsafe{ BumpBox::from_raw(nonnull::slice_from_raw_parts(ptr, 0)) },
-                    capacity,
-                },
-                bump,
+                fixed: unsafe { RawFixedBumpVec::allocate_greedy(&mut allocator, capacity)? },
+                allocator,
             })
         }
 
@@ -256,11 +221,11 @@ where
         for fn from_elem_in
         for fn try_from_elem_in
         #[inline]
-        use fn generic_from_elem_in(value: T, count: usize, bump: impl Into<&'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_elem_in(value: T, count: usize, allocator: A) -> Self
         where {
             T: Clone
         } in {
-            let mut vec = Self::generic_with_capacity_in(count, bump)?;
+            let mut vec = Self::generic_with_capacity_in(count, allocator)?;
 
             unsafe {
                 if count != 0 {
@@ -280,37 +245,38 @@ where
         for fn from_array_in
         for fn try_from_array_in
         #[inline]
-        use fn generic_from_array_in<{const N: usize}>(array: [T; N], bump: impl Into<&'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self {
+        use fn generic_from_array_in<{const N: usize}>(array: [T; N], allocator: A) -> Self {
             #![allow(clippy::needless_pass_by_value)]
             #![allow(clippy::needless_pass_by_ref_mut)]
 
             let array = ManuallyDrop::new(array);
-            let bump = bump.into();
+            let mut allocator = allocator;
 
             if T::IS_ZST {
                 return Ok(Self {
-                    fixed: FixedBumpVec { initialized: unsafe { BumpBox::from_raw(nonnull::slice_from_raw_parts(NonNull::dangling(), N)) }, capacity: usize::MAX },
-                    bump,
+                    fixed: RawFixedBumpVec { initialized: unsafe { RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(NonNull::dangling(), N)) }, capacity: usize::MAX },
+                    allocator,
                 });
             }
 
             if N == 0 {
                 return Ok(Self {
-                    fixed: FixedBumpVec::EMPTY,
-                    bump,
+                    fixed: RawFixedBumpVec::EMPTY,
+                    allocator,
                 });
             }
 
-            let (ptr, capacity) = bump.alloc_greedy(N)?;
+            let mut fixed = unsafe { RawFixedBumpVec::allocate_greedy(&mut allocator, N)? };
 
             let src = array.as_ptr();
-            let dst = ptr.as_ptr();
-            unsafe { ptr::copy_nonoverlapping(src, dst, N) };
+            let dst = fixed.initialized.ptr.cast::<T>().as_ptr();
 
-            Ok(Self {
-                fixed: FixedBumpVec { initialized: unsafe { BumpBox::from_raw(nonnull::slice_from_raw_parts(ptr, N)) }, capacity },
-                bump,
-            })
+            unsafe {
+                ptr::copy_nonoverlapping(src, dst, N);
+                fixed.set_len(N);
+            }
+
+            Ok(Self { fixed, allocator })
         }
 
         /// Create a new [`MutBumpVec`] whose elements are taken from an iterator and allocated in the given `bump`.
@@ -336,13 +302,13 @@ where
         /// ```
         for fn try_from_iter_in
         #[inline]
-        use fn generic_from_iter_in<{I}>(iter: I, bump: impl Into<&'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>) -> Self
+        use fn generic_from_iter_in<{I}>(iter: I, allocator: A) -> Self
         where {
             I: IntoIterator<Item = T>
         } in {
             let iter = iter.into_iter();
             let capacity = iter.size_hint().0;
-            let mut vec = Self::generic_with_capacity_in(capacity, bump)?;
+            let mut vec = Self::generic_with_capacity_in(capacity, allocator)?;
 
             for value in iter {
                 vec.generic_push(value)?;
@@ -353,9 +319,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> MutBumpVec<T, A> {
     /// Returns the total number of elements the vector can hold without
     /// reallocating.
     ///
@@ -364,13 +328,13 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// ```
     /// # use bump_scope::{ Bump, MutBumpVec };
     /// # let mut bump: Bump = Bump::new();
-    /// let vec = MutBumpVec::<i32>::with_capacity_in(2048, &mut bump);
+    /// let vec = MutBumpVec::<i32, _>::with_capacity_in(2048, &mut bump);
     /// assert!(vec.capacity() >= 2048);
     /// ```
     #[must_use]
     #[inline(always)]
     pub const fn capacity(&self) -> usize {
-        self.fixed.capacity()
+        self.fixed.capacity
     }
 
     /// Returns the number of elements in the vector, also referred to
@@ -385,14 +349,14 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     #[must_use]
     #[inline(always)]
     pub const fn is_empty(&self) -> bool {
-        self.fixed.is_empty()
+        self.fixed.len() == 0
     }
 
     /// Removes the last element from a vector and returns it, or [`None`] if it
     /// is empty.
     #[inline(always)]
     pub fn pop(&mut self) -> Option<T> {
-        self.fixed.pop()
+        unsafe { self.fixed.cook_mut() }.pop()
     }
 
     /// Clears the vector, removing all values.
@@ -401,13 +365,13 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// ```
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
-    /// let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
     /// vec.clear();
     /// assert!(vec.is_empty());
     /// ```
     #[inline(always)]
     pub fn clear(&mut self) {
-        self.fixed.clear();
+        unsafe { self.fixed.cook_mut() }.clear();
     }
 
     /// Shortens the vector, keeping the first `len` elements and dropping
@@ -430,7 +394,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut vec = mut_bump_vec![in bump; 1, 2, 3, 4, 5];
+    /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3, 4, 5];
     /// vec.truncate(2);
     /// assert_eq!(vec, [1, 2]);
     /// ```
@@ -442,7 +406,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
     /// vec.truncate(8);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```
@@ -454,7 +418,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+    /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
     /// vec.truncate(0);
     /// assert_eq!(vec, []);
     /// ```
@@ -462,7 +426,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// [`clear`]: Self::clear
     /// [`drain`]: Self::drain
     pub fn truncate(&mut self, len: usize) {
-        self.fixed.truncate(len);
+        unsafe { self.fixed.cook_mut() }.truncate(len);
     }
 
     /// Removes and returns the element at position `index` within the vector,
@@ -481,15 +445,14 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// ```
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
-    /// let mut v = mut_bump_vec![in bump; 1, 2, 3];
+    /// let mut v = mut_bump_vec![in &mut bump; 1, 2, 3];
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
     /// ```
     #[track_caller]
     pub fn remove(&mut self, index: usize) -> T {
-        self.fixed.remove(index)
+        unsafe { self.fixed.cook_mut() }.remove(index)
     }
-
     /// Removes an element from the vector and returns it.
     ///
     /// The removed element is replaced by the last element of the vector.
@@ -507,7 +470,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut v = mut_bump_vec![in bump; "foo", "bar", "baz", "qux"];
+    /// let mut v = mut_bump_vec![in &mut bump; "foo", "bar", "baz", "qux"];
     ///
     /// assert_eq!(v.swap_remove(1), "bar");
     /// assert_eq!(v, ["foo", "qux", "baz"]);
@@ -519,7 +482,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// [`remove`]: Self::remove
     #[inline]
     pub fn swap_remove(&mut self, index: usize) -> T {
-        self.fixed.swap_remove(index)
+        unsafe { self.fixed.cook_mut() }.swap_remove(index)
     }
 
     /// Extracts a slice containing the entire vector.
@@ -528,7 +491,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     #[must_use]
     #[inline(always)]
     pub const fn as_slice(&self) -> &[T] {
-        self.fixed.as_slice()
+        unsafe { self.fixed.cook_ref() }.as_slice()
     }
 
     /// Extracts a mutable slice containing the entire vector.
@@ -537,7 +500,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     #[must_use]
     #[inline(always)]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        self.fixed.as_mut_slice()
+        unsafe { self.fixed.cook_mut() }.as_mut_slice()
     }
 
     /// Returns a raw pointer to the slice, or a dangling raw pointer
@@ -568,7 +531,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     #[must_use]
     #[inline(always)]
     pub fn as_non_null_slice(&self) -> NonNull<[T]> {
-        self.fixed.as_non_null_slice()
+        self.fixed.initialized.ptr
     }
 
     /// Appends an element to the back of the collection.
@@ -577,7 +540,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// Vector must not be full.
     #[inline(always)]
     pub unsafe fn unchecked_push(&mut self, value: T) {
-        self.fixed.unchecked_push(value);
+        unsafe { self.fixed.cook_mut() }.unchecked_push(value);
     }
 
     /// Appends an element to the back of the collection.
@@ -586,7 +549,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     /// Vector must not be full.
     #[inline(always)]
     pub unsafe fn unchecked_push_with(&mut self, f: impl FnOnce() -> T) {
-        self.fixed.unchecked_push_with(f);
+        unsafe { self.fixed.cook_mut() }.unchecked_push_with(f);
     }
 
     /// Forces the length of the vector to `new_len`.
@@ -612,16 +575,11 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 
     #[inline]
     pub(crate) unsafe fn inc_len(&mut self, amount: usize) {
-        self.fixed.inc_len(amount);
+        unsafe { self.fixed.cook_mut() }.inc_len(amount);
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, A: BumpAllocator> MutBumpVec<T, A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Appends an element to the back of a collection.
         impl
@@ -1196,13 +1154,13 @@ where
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
         /// {
-        ///     let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        ///     let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         ///     vec.resize_zeroed(5);
         ///     assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// }
         ///
         /// {
-        ///    let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        ///    let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         ///    vec.resize_zeroed(2);
         ///    assert_eq!(vec, [1, 2]);
         /// }
@@ -1301,10 +1259,10 @@ where
     /// ```
     /// # use bump_scope::{ Bump, MutBumpVec };
     /// # let mut bump: Bump = Bump::new();
-    /// let a: MutBumpVec<u32> = MutBumpVec::from_iter_in([0, 1, 2], &mut bump);
+    /// let a: MutBumpVec<u32, _> = MutBumpVec::from_iter_in([0, 1, 2], &mut bump);
     /// let a_capacity = a.capacity();
     ///
-    /// let b: MutBumpVec<u16> = a.map_in_place(|i| i as u16);
+    /// let b: MutBumpVec<u16, _> = a.map_in_place(|i| i as u16);
     /// assert_eq!(b.capacity(), a_capacity * 2);
     ///
     /// assert_eq!(b, [0, 1, 2]);
@@ -1314,14 +1272,14 @@ where
     /// ```compile_fail,E0080
     /// # use bump_scope::{ Bump, MutBumpVec };
     /// # let mut bump: Bump = Bump::new();
-    /// let a: MutBumpVec<u16> = MutBumpVec::from_iter_in([0, 1, 2], &mut bump);
-    /// let b: MutBumpVec<u32> = a.map_in_place(|i| i as u32);
+    /// let a: MutBumpVec<u16, _> = MutBumpVec::from_iter_in([0, 1, 2], &mut bump);
+    /// let b: MutBumpVec<u32, _> = a.map_in_place(|i| i as u32);
     /// # _ = b;
     /// ```
-    pub fn map_in_place<U>(self, f: impl FnMut(T) -> U) -> MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
-        let MutBumpVec { fixed, bump } = self;
-        let fixed = fixed.map_in_place(f);
-        MutBumpVec { fixed, bump }
+    pub fn map_in_place<U>(self, f: impl FnMut(T) -> U) -> MutBumpVec<U, A> {
+        let MutBumpVec { fixed, allocator } = self;
+        let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().map_in_place(f)) };
+        MutBumpVec { fixed, allocator }
     }
 
     /// Extend the vector by `n` clones of value.
@@ -1331,7 +1289,7 @@ where
     {
         self.generic_reserve(n)?;
         unsafe {
-            self.fixed.extend_with_unchecked(n, value);
+            self.fixed.cook_mut().extend_with_unchecked(n, value);
         }
         Ok(())
     }
@@ -1400,13 +1358,10 @@ where
     ///
     /// `new_capacity` must be greater than the current capacity.
     unsafe fn generic_grow_to<E: ErrorBehavior>(&mut self, new_capacity: usize) -> Result<(), E> {
-        let (ptr, capacity) = self.bump.alloc_greedy::<E, T>(new_capacity)?;
-
-        ptr::copy_nonoverlapping(self.as_ptr(), ptr.as_ptr(), self.len());
-
-        self.fixed.initialized.set_ptr(ptr);
-        self.fixed.capacity = capacity;
-
+        let mut new_vec = RawFixedBumpVec::allocate_greedy(&mut self.allocator, new_capacity)?;
+        ptr::copy_nonoverlapping(self.as_ptr(), new_vec.as_mut_ptr(), self.len());
+        new_vec.set_len(self.len());
+        self.fixed = new_vec;
         Ok(())
     }
 
@@ -1415,48 +1370,23 @@ where
     fn into_slice_ptr(self) -> NonNull<[T]> {
         let mut this = ManuallyDrop::new(self);
 
-        if T::IS_ZST {
-            return nonnull::slice_from_raw_parts(NonNull::dangling(), this.len());
+        unsafe {
+            if T::IS_ZST {
+                return nonnull::slice_from_raw_parts(NonNull::dangling(), this.len());
+            }
+
+            if this.capacity() == 0 {
+                // We didn't touch the allocator, so no need to do anything.
+                debug_assert_eq!(this.as_non_null_ptr(), NonNull::<T>::dangling());
+                return nonnull::slice_from_raw_parts(NonNull::<T>::dangling(), 0);
+            }
+
+            let ptr = this.as_non_null_ptr();
+            let len = this.len();
+            let cap = this.capacity();
+
+            this.allocator.use_reserved_allocation(ptr, len, cap)
         }
-
-        if this.capacity() == 0 {
-            // We didn't touch the bump, so no need to do anything.
-            debug_assert_eq!(this.as_non_null_ptr(), NonNull::<T>::dangling());
-            return nonnull::slice_from_raw_parts(NonNull::<T>::dangling(), 0);
-        }
-
-        let ptr = this.as_non_null_ptr();
-        let len = this.len();
-        let cap = this.capacity();
-
-        unsafe { this.bump.consolidate_greed(ptr, len, cap) }
-    }
-
-    /// Turns this `MutBumpVec<T>` into a `BumpBox<[T]>`.
-    ///
-    /// Unused capacity does not take up space.<br/>
-    /// When [bumping downwards](crate#bumping-upwards-or-downwards) this needs to shift all elements to the other end of the chunk.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_boxed_slice(self) -> BumpBox<'a, [T]> {
-        unsafe { BumpBox::from_raw(self.into_slice_ptr()) }
-    }
-
-    /// Turns this `MutBumpVec<T>` into a `&[T]` that is live for this bump scope.
-    ///
-    /// Unused capacity does not take up space.<br/>
-    /// When [bumping downwards](crate#bumping-upwards-or-downwards) this needs to shift all elements to the other end of the chunk.
-    ///
-    /// This is only available for [`NoDrop`] types so you don't omit dropping a value for which it matters.
-    ///
-    /// `!NoDrop` types can still be turned into slices via <code>BumpBox::[leak](BumpBox::leak)(vec.[into_boxed_slice](Self::into_boxed_slice)())</code>.
-    #[must_use]
-    #[inline(always)]
-    pub fn into_slice(self) -> &'a mut [T]
-    where
-        [T]: NoDrop,
-    {
-        self.into_boxed_slice().into_mut()
     }
 
     /// # Safety
@@ -1510,7 +1440,7 @@ where
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut vec = mut_bump_vec![in bump; 1, 2, 3, 4];
+    /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3, 4];
     ///
     /// vec.retain(|x| if *x <= 3 {
     ///     *x += 1;
@@ -1526,7 +1456,7 @@ where
     where
         F: FnMut(&mut T) -> bool,
     {
-        self.fixed.retain(f)
+        unsafe { self.fixed.cook_mut() }.retain(f)
     }
 
     /// Removes the specified range from the vector in bulk, returning all
@@ -1554,7 +1484,7 @@ where
     /// # let mut bump1: Bump = Bump::new();
     /// # let bump2: Bump = Bump::new();
     /// #
-    /// let mut v = mut_bump_vec![in bump1; 1, 2, 3];
+    /// let mut v = mut_bump_vec![in &mut bump1; 1, 2, 3];
     /// let u = bump2.alloc_iter(v.drain(1..));
     /// assert_eq!(v, [1]);
     /// assert_eq!(u, [2, 3]);
@@ -1567,7 +1497,7 @@ where
     where
         R: RangeBounds<usize>,
     {
-        self.fixed.drain(range)
+        unsafe { self.fixed.cook_mut() }.drain(range)
     }
 
     /// Creates an iterator which uses a closure to determine if an element should be removed.
@@ -1586,7 +1516,7 @@ where
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
     /// # let mut bump: Bump = Bump::new();
-    /// # let mut vec = mut_bump_vec![in bump; 1, 2, 3, 4, 5, 6];
+    /// # let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3, 4, 5, 6];
     /// let mut i = 0;
     /// while i < vec.len() {
     ///     if some_predicate(&mut vec[i]) {
@@ -1614,7 +1544,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
-    /// let mut numbers = mut_bump_vec![in bump; 1, 2, 3, 4, 5, 6, 8, 9, 11, 13, 14, 15];
+    /// let mut numbers = mut_bump_vec![in &mut bump; 1, 2, 3, 4, 5, 6, 8, 9, 11, 13, 14, 15];
     ///
     /// let evens = numbers.extract_if(|x| *x % 2 == 0).collect::<Vec<_>>();
     /// let odds = numbers;
@@ -1628,7 +1558,7 @@ where
     where
         F: FnMut(&mut T) -> bool,
     {
-        self.fixed.extract_if(filter)
+        unsafe { self.fixed.cook_mut() }.extract_if(filter)
     }
 
     /// Removes consecutive repeated elements in the vector according to the
@@ -1641,7 +1571,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
-    /// let mut vec = mut_bump_vec![in bump; 1, 2, 2, 3, 2];
+    /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 2, 3, 2];
     ///
     /// vec.dedup();
     ///
@@ -1652,7 +1582,7 @@ where
     where
         T: PartialEq,
     {
-        self.fixed.dedup();
+        unsafe { self.fixed.cook_mut() }.dedup();
     }
 
     /// Removes all but the first of consecutive elements in the vector that resolve to the same
@@ -1665,7 +1595,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
-    /// let mut vec = mut_bump_vec![in bump; 10, 20, 21, 30, 20];
+    /// let mut vec = mut_bump_vec![in &mut bump; 10, 20, 21, 30, 20];
     ///
     /// vec.dedup_by_key(|i| *i / 10);
     ///
@@ -1677,7 +1607,7 @@ where
         F: FnMut(&mut T) -> K,
         K: PartialEq,
     {
-        self.fixed.dedup_by_key(key);
+        unsafe { self.fixed.cook_mut() }.dedup_by_key(key);
     }
 
     /// Removes all but the first of consecutive elements in the vector satisfying a given equality
@@ -1694,7 +1624,7 @@ where
     /// ```
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
-    /// let mut vec = mut_bump_vec![in bump; "foo", "bar", "Bar", "baz", "bar"];
+    /// let mut vec = mut_bump_vec![in &mut bump; "foo", "bar", "Bar", "baz", "bar"];
     ///
     /// vec.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
     ///
@@ -1704,7 +1634,7 @@ where
     where
         F: FnMut(&mut T, &mut T) -> bool,
     {
-        self.fixed.dedup_by(same_bucket);
+        unsafe { self.fixed.cook_mut() }.dedup_by(same_bucket);
     }
 
     /// Returns the remaining spare capacity of the vector as a slice of
@@ -1794,51 +1724,46 @@ where
         }
     }
 
-    /// Returns a reference to the base allocator.
-    #[must_use]
-    #[inline(always)]
-    pub fn allocator(&self) -> &A {
-        self.bump.allocator()
-    }
-}
-
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     ///
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a> {
-        self.bump.stats()
+    pub fn stats(&self) -> Stats {
+        self.allocator.stats()
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool> MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
-{
-    /// Returns a type which provides statistics about the memory usage of the bump allocator.
+impl<'a, T, A: BumpAllocatorScope<'a>> MutBumpVec<T, A> {
+    /// Turns this `MutBumpVec<T>` into a `BumpBox<[T]>`.
     ///
-    /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
+    /// Unused capacity does not take up space.<br/>
+    /// When [bumping downwards](crate#bumping-upwards-or-downwards) this needs to shift all elements to the other end of the chunk.
     #[must_use]
     #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a> {
-        self.bump.guaranteed_allocated_stats()
+    pub fn into_boxed_slice(self) -> BumpBox<'a, [T]> {
+        unsafe { BumpBox::from_raw(self.into_slice_ptr()) }
+    }
+
+    /// Turns this `MutBumpVec<T>` into a `&[T]` that is live for this bump scope.
+    ///
+    /// Unused capacity does not take up space.<br/>
+    /// When [bumping downwards](crate#bumping-upwards-or-downwards) this needs to shift all elements to the other end of the chunk.
+    ///
+    /// This is only available for [`NoDrop`] types so you don't omit dropping a value for which it matters.
+    ///
+    /// `!NoDrop` types can still be turned into slices via <code>BumpBox::[leak](BumpBox::leak)(vec.[into_boxed_slice](Self::into_boxed_slice)())</code>.
+    #[must_use]
+    #[inline(always)]
+    pub fn into_slice(self) -> &'a mut [T]
+    where
+        [T]: NoDrop,
+    {
+        self.into_boxed_slice().into_mut()
     }
 }
 
-impl<'b, 'a: 'b, T, A, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
-    MutBumpVec<'b, 'a, [T; N], A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
-{
+impl<T, const N: usize, A> MutBumpVec<[T; N], A> {
     /// Takes a `MutBumpVec<[T; N]>` and flattens it into a `MutBumpVec<T>`.
     ///
     /// # Panics
@@ -1855,31 +1780,27 @@ where
     /// # use bump_scope::{ Bump, mut_bump_vec };
     /// # let mut bump: Bump = Bump::new();
     /// #
-    /// let mut vec = mut_bump_vec![in bump; [1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    /// let mut vec = mut_bump_vec![in &mut bump; [1, 2, 3], [4, 5, 6], [7, 8, 9]];
     /// assert_eq!(vec.pop(), Some([7, 8, 9]));
     ///
     /// let mut flattened = vec.into_flattened();
     /// assert_eq!(flattened.pop(), Some(6));
     /// ```
     #[must_use]
-    pub fn into_flattened(self) -> MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED> {
-        let Self { fixed, bump } = self;
-        let fixed = fixed.into_flattened();
-        MutBumpVec { fixed, bump }
+    pub fn into_flattened(self) -> MutBumpVec<T, A> {
+        let Self { fixed, allocator } = self;
+        let fixed = unsafe { RawFixedBumpVec::from_cooked(fixed.cook().into_flattened()) };
+        MutBumpVec { fixed, allocator }
     }
 }
 
-impl<'b, 'a: 'b, T: Debug, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Debug
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T: Debug, A> Debug for MutBumpVec<T, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(self.as_slice(), f)
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, I: SliceIndex<[T]>> Index<I>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A: BumpAllocator, I: SliceIndex<[T]>> Index<I> for MutBumpVec<T, A> {
     type Output = I::Output;
 
     #[inline(always)]
@@ -1888,9 +1809,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, I: SliceIndex<[T]>>
-    IndexMut<I> for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A: BumpAllocator, I: SliceIndex<[T]>> IndexMut<I> for MutBumpVec<T, A> {
     #[inline(always)]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         IndexMut::index_mut(self.as_mut_slice(), index)
@@ -1898,12 +1817,7 @@ impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Extend<T>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + 'a,
-{
+impl<T, A: BumpAllocator> Extend<T> for MutBumpVec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
@@ -1917,13 +1831,7 @@ where
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'b, 'a: 'b, 't, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Extend<&'t T>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + 'a,
-    T: Clone + 't,
-{
+impl<'t, T: Clone + 't, A: BumpAllocator> Extend<&'t T> for MutBumpVec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = &'t T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
@@ -1936,25 +1844,22 @@ where
     }
 }
 
-impl<'b0, 'a0: 'b0, 'b1, 'a1: 'b1, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<MutBumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>>
-    for MutBumpVec<'b0, 'a0, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A> PartialEq<MutBumpVec<U, A>> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &MutBumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &MutBumpVec<'b1, 'a1, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<[U; N]> for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, const N: usize, A> PartialEq<[U; N]> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
@@ -1969,8 +1874,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<&[U; N]> for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, const N: usize, A> PartialEq<&[U; N]> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
@@ -1985,8 +1889,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const N: usize, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<&mut [U; N]> for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, const N: usize, A> PartialEq<&mut [U; N]> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
@@ -2001,8 +1904,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<[U]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A> PartialEq<[U]> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
@@ -2017,8 +1919,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<&[U]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A> PartialEq<&[U]> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
@@ -2033,8 +1934,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> PartialEq<&mut [U]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
+impl<T, U, A> PartialEq<&mut [U]> for MutBumpVec<T, A>
 where
     T: PartialEq<U>,
 {
@@ -2049,61 +1949,54 @@ where
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for [T]
+impl<T, U, A> PartialEq<MutBumpVec<U, A>> for [T]
 where
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for &[T]
+impl<T, U, A> PartialEq<MutBumpVec<U, A>> for &[T]
 where
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, U, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>
-    PartialEq<MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>> for &mut [T]
+impl<T, U, A> PartialEq<MutBumpVec<U, A>> for &mut [T]
 where
     T: PartialEq<U>,
 {
     #[inline(always)]
-    fn eq(&self, other: &MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn eq(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::eq(self, other)
     }
 
     #[inline(always)]
-    fn ne(&self, other: &MutBumpVec<'b, 'a, U, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> bool {
+    fn ne(&self, other: &MutBumpVec<U, A>) -> bool {
         <[T] as PartialEq<[U]>>::ne(self, other)
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-{
+impl<T, A> IntoIterator for MutBumpVec<T, A> {
     type Item = T;
-    type IntoIter = owned_slice::IntoIter<'b, T>;
+    type IntoIter = IntoIter<T, A>;
 
     /// Returns an iterator that borrows the `BumpScope` mutably. So you can't use the `BumpScope` while iterating.
     /// The advantage is that the space the items took up is freed.
@@ -2114,13 +2007,33 @@ where
     /// [`into_boxed_slice`]: Self::into_boxed_slice
     #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
-        self.fixed.into_iter()
+        let Self { fixed, allocator } = self;
+        let slice = fixed.initialized.into_ptr();
+
+        unsafe {
+            if T::IS_ZST {
+                IntoIter {
+                    ptr: NonNull::dangling(),
+                    end: unsafe { nonnull::wrapping_byte_add(NonNull::dangling(), slice.len()) },
+                    allocator,
+                    marker: PhantomData,
+                }
+            } else {
+                let start = nonnull::as_non_null_ptr(slice);
+                let end = nonnull::add(start, slice.len());
+
+                IntoIter {
+                    ptr: start,
+                    end,
+                    allocator,
+                    marker: PhantomData,
+                }
+            }
+        }
     }
 }
 
-impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
-    for &'c MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<'c, T, A> IntoIterator for &'c MutBumpVec<T, A> {
     type Item = &'c T;
     type IntoIter = slice::Iter<'c, T>;
 
@@ -2130,9 +2043,7 @@ impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANT
     }
 }
 
-impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> IntoIterator
-    for &'c mut MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<'c, T, A> IntoIterator for &'c mut MutBumpVec<T, A> {
     type Item = &'c mut T;
     type IntoIter = slice::IterMut<'c, T>;
 
@@ -2142,45 +2053,35 @@ impl<'c, 'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANT
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsRef<[T]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> AsRef<[T]> for MutBumpVec<T, A> {
     #[inline(always)]
     fn as_ref(&self) -> &[T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> AsMut<[T]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> AsMut<[T]> for MutBumpVec<T, A> {
     #[inline(always)]
     fn as_mut(&mut self) -> &mut [T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> Borrow<[T]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> Borrow<[T]> for MutBumpVec<T, A> {
     #[inline(always)]
     fn borrow(&self) -> &[T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool> BorrowMut<[T]>
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T, A> BorrowMut<[T]> for MutBumpVec<T, A> {
     #[inline(always)]
     fn borrow_mut(&mut self) -> &mut [T] {
         self
     }
 }
 
-impl<'b, 'a: 'b, T: Hash, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> Hash
-    for MutBumpVec<'b, 'a, T, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-{
+impl<T: Hash, A> Hash for MutBumpVec<T, A> {
     #[inline(always)]
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.as_slice().hash(state);
@@ -2189,12 +2090,7 @@ impl<'b, 'a: 'b, T: Hash, const MIN_ALIGN: usize, const UP: bool, const GUARANTE
 
 /// Returns [`ErrorKind::OutOfMemory`](std::io::ErrorKind::OutOfMemory) when allocations fail.
 #[cfg(feature = "std")]
-impl<'b, 'a: 'b, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A> std::io::Write
-    for MutBumpVec<'b, 'a, u8, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
-where
-    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED> + 'a,
-{
+impl<A: BumpAllocator> std::io::Write for MutBumpVec<u8, A> {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.try_extend_from_slice_copy(buf).is_err() {

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -629,7 +629,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 1, 2];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1, 2];
         /// vec.push(3);
         /// assert_eq!(vec, [1, 2, 3]);
         /// ```
@@ -639,7 +639,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 1, 2]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1, 2]?;
         /// vec.try_push(3)?;
         /// assert_eq!(vec, [1, 2, 3]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -671,7 +671,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         /// vec.insert(1, 4);
         /// assert_eq!(vec, [1, 4, 2, 3]);
         /// vec.insert(4, 5);
@@ -683,7 +683,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1, 2, 3]?;
         /// vec.try_insert(1, 4)?;
         /// assert_eq!(vec, [1, 4, 2, 3]);
         /// vec.try_insert(4, 5)?;
@@ -799,7 +799,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 0, 1, 2, 3, 4];
+        /// let mut vec = mut_bump_vec![in &mut bump; 0, 1, 2, 3, 4];
         ///
         /// vec.extend_from_within_copy(2..);
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -816,7 +816,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 0, 1, 2, 3, 4]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 0, 1, 2, 3, 4]?;
         ///
         /// vec.try_extend_from_within_copy(2..)?;
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -865,7 +865,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 0, 1, 2, 3, 4];
+        /// let mut vec = mut_bump_vec![in &mut bump; 0, 1, 2, 3, 4];
         ///
         /// vec.extend_from_within_clone(2..);
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -882,7 +882,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 0, 1, 2, 3, 4]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 0, 1, 2, 3, 4]?;
         ///
         /// vec.try_extend_from_within_clone(2..)?;
         /// assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -950,7 +950,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         /// vec.extend_zeroed(2);
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// ```
@@ -960,7 +960,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1, 2, 3]?;
         /// vec.try_extend_zeroed(2)?;
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -996,7 +996,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 1];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1];
         /// vec.reserve(10);
         /// assert!(vec.capacity() >= 11);
         /// ```
@@ -1006,7 +1006,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 1]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1]?;
         /// vec.try_reserve(10)?;
         /// assert!(vec.capacity() >= 11);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1040,7 +1040,7 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 1];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1];
         /// vec.reserve_exact(10);
         /// assert!(vec.capacity() >= 11);
         /// ```
@@ -1050,7 +1050,7 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 1]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1]?;
         /// vec.try_reserve_exact(10)?;
         /// assert!(vec.capacity() >= 11);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1084,12 +1084,12 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; "hello"];
+        /// let mut vec = mut_bump_vec![in &mut bump; "hello"];
         /// vec.resize(3, "world");
         /// assert_eq!(vec, ["hello", "world", "world"]);
         /// drop(vec);
         ///
-        /// let mut vec = mut_bump_vec![in bump; 1, 2, 3, 4];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3, 4];
         /// vec.resize(2, 0);
         /// assert_eq!(vec, [1, 2]);
         /// ```
@@ -1099,12 +1099,12 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; "hello"]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; "hello"]?;
         /// vec.try_resize(3, "world")?;
         /// assert_eq!(vec, ["hello", "world", "world"]);
         /// drop(vec);
         ///
-        /// let mut vec = mut_bump_vec![try in bump; 1, 2, 3, 4]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1, 2, 3, 4]?;
         /// vec.try_resize(2, 0)?;
         /// assert_eq!(vec, [1, 2]);
         /// # Ok::<(), bump_scope::allocator_api2::alloc::AllocError>(())
@@ -1142,12 +1142,12 @@ where
         /// ```
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::new();
-        /// let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        /// let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         /// vec.resize_with(5, Default::default);
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// drop(vec);
         ///
-        /// let mut vec = mut_bump_vec![in bump];
+        /// let mut vec = mut_bump_vec![in &mut bump];
         /// let mut p = 1;
         /// vec.resize_with(4, || { p *= 2; p });
         /// assert_eq!(vec, [2, 4, 8, 16]);
@@ -1158,12 +1158,12 @@ where
         /// # #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api))]
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
-        /// let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump; 1, 2, 3]?;
         /// vec.try_resize_with(5, Default::default)?;
         /// assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// drop(vec);
         ///
-        /// let mut vec = mut_bump_vec![try in bump]?;
+        /// let mut vec = mut_bump_vec![try in &mut bump]?;
         /// let mut p = 1;
         /// vec.try_resize_with(4, || { p *= 2; p })?;
         /// assert_eq!(vec, [2, 4, 8, 16]);
@@ -1214,13 +1214,13 @@ where
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
         /// {
-        ///     let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        ///     let mut vec = mut_bump_vec![try in &bump; 1, 2, 3]?;
         ///     vec.try_resize_zeroed(5)?;
         ///     assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// }
         ///
         /// {
-        ///    let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        ///    let mut vec = mut_bump_vec![try in &bump; 1, 2, 3]?;
         ///    vec.try_resize_zeroed(2)?;
         ///    assert_eq!(vec, [1, 2]);
         /// }

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -1813,7 +1813,7 @@ where
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, UP> {
+    pub fn stats(&self) -> Stats<'a> {
         self.bump.stats()
     }
 }
@@ -1828,7 +1828,7 @@ where
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a, UP> {
+    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a> {
         self.bump.guaranteed_allocated_stats()
     }
 }

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -1214,13 +1214,13 @@ where
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
         /// {
-        ///     let mut vec = mut_bump_vec![try in &bump; 1, 2, 3]?;
+        ///     let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
         ///     vec.try_resize_zeroed(5)?;
         ///     assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// }
         ///
         /// {
-        ///    let mut vec = mut_bump_vec![try in &bump; 1, 2, 3]?;
+        ///    let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
         ///    vec.try_resize_zeroed(2)?;
         ///    assert_eq!(vec, [1, 2]);
         /// }

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -14,7 +14,6 @@ use core::{
     fmt::Debug,
     hash::Hash,
     iter,
-    marker::PhantomData,
     mem::{ManuallyDrop, MaybeUninit},
     ops::{Deref, DerefMut, Index, IndexMut, RangeBounds},
     panic::{RefUnwindSafe, UnwindSafe},
@@ -2009,27 +2008,7 @@ impl<T, A> IntoIterator for MutBumpVec<T, A> {
     fn into_iter(self) -> Self::IntoIter {
         let Self { fixed, allocator } = self;
         let slice = fixed.initialized.into_ptr();
-
-        unsafe {
-            if T::IS_ZST {
-                IntoIter {
-                    ptr: NonNull::dangling(),
-                    end: unsafe { nonnull::wrapping_byte_add(NonNull::dangling(), slice.len()) },
-                    allocator,
-                    marker: PhantomData,
-                }
-            } else {
-                let start = nonnull::as_non_null_ptr(slice);
-                let end = nonnull::add(start, slice.len());
-
-                IntoIter {
-                    ptr: start,
-                    end,
-                    allocator,
-                    marker: PhantomData,
-                }
-            }
-        }
+        unsafe { IntoIter::new(slice, allocator) }
     }
 }
 

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -7,7 +7,7 @@ use crate::{
     polyfill::{nonnull, pointer, slice},
     raw_bump_box::RawBumpBox,
     raw_fixed_bump_vec::RawFixedBumpVec,
-    BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, NoDrop, SetLenOnDropByPtr, SizedTypeProperties, Stats,
+    BumpAllocatorMut, BumpAllocatorScopeMut, BumpBox, ErrorBehavior, NoDrop, SetLenOnDropByPtr, SizedTypeProperties, Stats,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -151,7 +151,7 @@ impl<T, A> DerefMut for MutBumpVec<T, A> {
     }
 }
 
-impl<T, A: BumpAllocator> MutBumpVec<T, A> {
+impl<T, A: BumpAllocatorMut> MutBumpVec<T, A> {
     /// Constructs a new empty `MutBumpVec<T>`.
     ///
     /// The vector will not allocate until elements are pushed onto it.
@@ -579,7 +579,7 @@ impl<T, A> MutBumpVec<T, A> {
     }
 }
 
-impl<T, A: BumpAllocator> MutBumpVec<T, A> {
+impl<T, A: BumpAllocatorMut> MutBumpVec<T, A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Appends an element to the back of a collection.
         impl
@@ -1734,7 +1734,7 @@ impl<T, A: BumpAllocator> MutBumpVec<T, A> {
     }
 }
 
-impl<'a, T, A: BumpAllocatorScope<'a>> MutBumpVec<T, A> {
+impl<'a, T, A: BumpAllocatorScopeMut<'a>> MutBumpVec<T, A> {
     /// Turns this `MutBumpVec<T>` into a `BumpBox<[T]>`.
     ///
     /// Unused capacity does not take up space.<br/>
@@ -1800,7 +1800,7 @@ impl<T: Debug, A> Debug for MutBumpVec<T, A> {
     }
 }
 
-impl<T, A: BumpAllocator, I: SliceIndex<[T]>> Index<I> for MutBumpVec<T, A> {
+impl<T, A: BumpAllocatorMut, I: SliceIndex<[T]>> Index<I> for MutBumpVec<T, A> {
     type Output = I::Output;
 
     #[inline(always)]
@@ -1809,7 +1809,7 @@ impl<T, A: BumpAllocator, I: SliceIndex<[T]>> Index<I> for MutBumpVec<T, A> {
     }
 }
 
-impl<T, A: BumpAllocator, I: SliceIndex<[T]>> IndexMut<I> for MutBumpVec<T, A> {
+impl<T, A: BumpAllocatorMut, I: SliceIndex<[T]>> IndexMut<I> for MutBumpVec<T, A> {
     #[inline(always)]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         IndexMut::index_mut(self.as_mut_slice(), index)
@@ -1817,7 +1817,7 @@ impl<T, A: BumpAllocator, I: SliceIndex<[T]>> IndexMut<I> for MutBumpVec<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<T, A: BumpAllocator> Extend<T> for MutBumpVec<T, A> {
+impl<T, A: BumpAllocatorMut> Extend<T> for MutBumpVec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
@@ -1831,7 +1831,7 @@ impl<T, A: BumpAllocator> Extend<T> for MutBumpVec<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'t, T: Clone + 't, A: BumpAllocator> Extend<&'t T> for MutBumpVec<T, A> {
+impl<'t, T: Clone + 't, A: BumpAllocatorMut> Extend<&'t T> for MutBumpVec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = &'t T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
@@ -2090,7 +2090,7 @@ impl<T: Hash, A> Hash for MutBumpVec<T, A> {
 
 /// Returns [`ErrorKind::OutOfMemory`](std::io::ErrorKind::OutOfMemory) when allocations fail.
 #[cfg(feature = "std")]
-impl<A: BumpAllocator> std::io::Write for MutBumpVec<u8, A> {
+impl<A: BumpAllocatorMut> std::io::Write for MutBumpVec<u8, A> {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.try_extend_from_slice_copy(buf).is_err() {

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -211,7 +211,7 @@ impl<T, A: BumpAllocatorMut> MutBumpVec<T, A> {
             }
 
             Ok(Self {
-                fixed: unsafe { RawFixedBumpVec::allocate_greedy(&mut allocator, capacity)? },
+                fixed: unsafe { RawFixedBumpVec::prepare_allocation(&mut allocator, capacity)? },
                 allocator,
             })
         }
@@ -266,7 +266,7 @@ impl<T, A: BumpAllocatorMut> MutBumpVec<T, A> {
                 });
             }
 
-            let mut fixed = unsafe { RawFixedBumpVec::allocate_greedy(&mut allocator, N)? };
+            let mut fixed = unsafe { RawFixedBumpVec::prepare_allocation(&mut allocator, N)? };
 
             let src = array.as_ptr();
             let dst = fixed.initialized.ptr.cast::<T>().as_ptr();
@@ -1358,7 +1358,7 @@ impl<T, A: BumpAllocatorMut> MutBumpVec<T, A> {
     ///
     /// `new_capacity` must be greater than the current capacity.
     unsafe fn generic_grow_to<E: ErrorBehavior>(&mut self, new_capacity: usize) -> Result<(), E> {
-        let mut new_vec = RawFixedBumpVec::allocate_greedy(&mut self.allocator, new_capacity)?;
+        let mut new_vec = RawFixedBumpVec::prepare_allocation(&mut self.allocator, new_capacity)?;
         ptr::copy_nonoverlapping(self.as_ptr(), new_vec.as_mut_ptr(), self.len());
         new_vec.set_len(self.len());
         self.fixed = new_vec;

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -1172,13 +1172,13 @@ impl<T, A: BumpAllocator> MutBumpVec<T, A> {
         /// # use bump_scope::{ Bump, mut_bump_vec };
         /// # let mut bump: Bump = Bump::try_new()?;
         /// {
-        ///     let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        ///     let mut vec = mut_bump_vec![try in &mut bump; 1, 2, 3]?;
         ///     vec.try_resize_zeroed(5)?;
         ///     assert_eq!(vec, [1, 2, 3, 0, 0]);
         /// }
         ///
         /// {
-        ///    let mut vec = mut_bump_vec![try in bump; 1, 2, 3]?;
+        ///    let mut vec = mut_bump_vec![try in &mut bump; 1, 2, 3]?;
         ///    vec.try_resize_zeroed(2)?;
         ///    assert_eq!(vec, [1, 2]);
         /// }

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -24,7 +24,7 @@ use core::{
 
 /// This is like [`vec!`] but allocates inside a `Bump` or `BumpScope`, returning a [`MutBumpVec`].
 ///
-/// `$bump` can be a mutable [`Bump`](crate::Bump) or [`BumpScope`] (anything where `$bump.as_mut_scope()` returns a `&mut BumpScope`).
+/// `$bump` can be any type that implements [`BumpAllocatorMut`].
 ///
 /// # Panics
 /// If used without `try`, panics on allocation failure.

--- a/src/mut_bump_vec/into_iter.rs
+++ b/src/mut_bump_vec/into_iter.rs
@@ -1,0 +1,179 @@
+use core::{
+    fmt::Debug,
+    iter::FusedIterator,
+    marker::PhantomData,
+    mem,
+    ptr::{self, NonNull},
+    slice,
+};
+
+use crate::{polyfill::nonnull, BumpAllocator, SizedTypeProperties};
+
+/// An iterator that moves out of a vector.
+///
+/// This `struct` is created by the `into_iter` method on
+/// [`MutBumpVec`](crate::MutBumpVec::into_iter),
+/// (provided by the [`IntoIterator`] trait).
+// This is modelled after rust's `alloc/src/vec/into_iter.rs`
+pub struct IntoIter<T, A> {
+    pub(super) ptr: NonNull<T>,
+    pub(super) end: NonNull<T>, // if T is a ZST this is ptr + len
+
+    // Just holding on to it so it doesn't drop.
+    #[allow(dead_code)]
+    pub(super) allocator: A,
+
+    /// First field marks the lifetime in the form of the allocator.
+    /// Second field marks ownership over T. (<https://doc.rust-lang.org/nomicon/phantom-data.html#generic-parameters-and-drop-checking>)
+    pub(super) marker: PhantomData<(A, T)>,
+}
+
+unsafe impl<T: Send, A: Send> Send for IntoIter<T, A> {}
+unsafe impl<T: Sync, A: Sync> Sync for IntoIter<T, A> {}
+
+impl<T: Debug, A: BumpAllocator> Debug for IntoIter<T, A> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("IntoIter").field(&self.as_slice()).finish()
+    }
+}
+
+impl<T, A> IntoIter<T, A> {
+    /// Returns the exact remaining length of the iterator.
+    #[must_use]
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        #![allow(clippy::cast_sign_loss)]
+
+        if T::IS_ZST {
+            nonnull::addr(self.end).get().wrapping_sub(nonnull::addr(self.ptr).get())
+        } else {
+            unsafe { nonnull::sub_ptr(self.end, self.ptr) }
+        }
+    }
+
+    /// Returns true if the iterator is empty.
+    #[must_use]
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.ptr == self.end
+    }
+
+    /// Returns the remaining items of this iterator as a slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, mut_bump_vec };
+    /// # let mut bump: Bump = Bump::new();
+    /// let vec = mut_bump_vec![in &mut bump; 1, 2, 3];
+    /// let mut into_iter = vec.into_iter();
+    /// assert_eq!(into_iter.as_slice(), &[1, 2, 3]);
+    /// assert_eq!(into_iter.next(), Some(1));
+    /// assert_eq!(into_iter.as_slice(), &[2, 3]);
+    /// assert_eq!(into_iter.next_back(), Some(3));
+    /// assert_eq!(into_iter.as_slice(), &[2]);
+    /// ```
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len()) }
+    }
+
+    /// Returns the remaining items of this iterator as a mutable slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::{ Bump, mut_bump_vec };
+    /// # let mut bump: Bump = Bump::new();
+    /// let vec = mut_bump_vec![in &mut bump; 'a', 'b', 'c'];
+    /// let mut into_iter = vec.into_iter();
+    /// assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
+    /// into_iter.as_mut_slice()[2] = 'z';
+    /// assert_eq!(into_iter.next().unwrap(), 'a');
+    /// assert_eq!(into_iter.next().unwrap(), 'b');
+    /// assert_eq!(into_iter.next().unwrap(), 'z');
+    /// ```
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe { &mut *self.as_raw_mut_slice() }
+    }
+
+    fn as_raw_mut_slice(&mut self) -> *mut [T] {
+        ptr::slice_from_raw_parts_mut(self.ptr.as_ptr(), self.len())
+    }
+}
+
+impl<T, A> AsRef<[T]> for IntoIter<T, A> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T, A> Iterator for IntoIter<T, A> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ptr == self.end {
+            None
+        } else if T::IS_ZST {
+            // `ptr` has to stay where it is to remain aligned, so we reduce the length by 1 by
+            // reducing the `end`.
+            self.end = unsafe { nonnull::wrapping_byte_sub(self.end, 1) };
+
+            // Make up a value of this ZST.
+            Some(unsafe { mem::zeroed() })
+        } else {
+            let old = self.ptr;
+            self.ptr = unsafe { nonnull::add(self.ptr, 1) };
+
+            Some(unsafe { old.as_ptr().read() })
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let exact = self.len();
+        (exact, Some(exact))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+}
+
+impl<T, A> DoubleEndedIterator for IntoIter<T, A> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.end == self.ptr {
+            None
+        } else if T::IS_ZST {
+            // See above for why 'ptr.offset' isn't used
+            self.end = unsafe { nonnull::wrapping_byte_sub(self.end, 1) };
+
+            // Make up a value of this ZST.
+            Some(unsafe { mem::zeroed() })
+        } else {
+            self.end = unsafe { nonnull::sub(self.end, 1) };
+
+            Some(unsafe { self.end.as_ptr().read() })
+        }
+    }
+}
+
+impl<T, A> ExactSizeIterator for IntoIter<T, A> {}
+impl<T, A> FusedIterator for IntoIter<T, A> {}
+
+#[cfg(feature = "nightly-trusted-len")]
+unsafe impl<T, A> core::iter::TrustedLen for IntoIter<T, A> {}
+
+impl<T, A> Drop for IntoIter<T, A> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            nonnull::slice_from_raw_parts(self.ptr, self.len()).as_ptr().drop_in_place();
+        }
+    }
+}

--- a/src/mut_bump_vec/into_iter.rs
+++ b/src/mut_bump_vec/into_iter.rs
@@ -11,21 +11,22 @@ use crate::{polyfill::nonnull, BumpAllocator, SizedTypeProperties};
 
 /// An iterator that moves out of a vector.
 ///
-/// This `struct` is created by the `into_iter` method on
-/// [`MutBumpVec`](crate::MutBumpVec::into_iter),
+/// This `struct` is created by the [`into_iter`] method on [`MutBumpVec`],
 /// (provided by the [`IntoIterator`] trait).
-// This is modelled after rust's `alloc/src/vec/into_iter.rs`
+///
+/// [`into_iter`]: crate::MutBumpVec::into_iter
+/// [`MutBumpVec`]: crate::MutBumpVec
 pub struct IntoIter<T, A> {
-    pub(super) ptr: NonNull<T>,
-    pub(super) end: NonNull<T>, // if T is a ZST this is ptr + len
+    ptr: NonNull<T>,
+    end: NonNull<T>, // if T is a ZST this is ptr + len
 
     // Just holding on to it so it doesn't drop.
     #[allow(dead_code)]
-    pub(super) allocator: A,
+    allocator: A,
 
     /// First field marks the lifetime in the form of the allocator.
     /// Second field marks ownership over T. (<https://doc.rust-lang.org/nomicon/phantom-data.html#generic-parameters-and-drop-checking>)
-    pub(super) marker: PhantomData<(A, T)>,
+    marker: PhantomData<(A, T)>,
 }
 
 unsafe impl<T: Send, A: Send> Send for IntoIter<T, A> {}

--- a/src/mut_bump_vec_rev.rs
+++ b/src/mut_bump_vec_rev.rs
@@ -1693,7 +1693,7 @@ where
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, UP> {
+    pub fn stats(&self) -> Stats<'a> {
         self.bump.stats()
     }
 }
@@ -1708,7 +1708,7 @@ where
     /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
     #[must_use]
     #[inline(always)]
-    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a, UP> {
+    pub fn guaranteed_allocated_stats(&self) -> GuaranteedAllocatedStats<'a> {
         self.bump.guaranteed_allocated_stats()
     }
 }

--- a/src/mut_bump_vec_rev.rs
+++ b/src/mut_bump_vec_rev.rs
@@ -3,7 +3,7 @@ use crate::{
     error_behavior_generic_methods_allocation_failure, min_non_zero_cap,
     mut_bump_vec::IntoIter,
     polyfill::{self, nonnull, pointer},
-    BumpAllocatorMut, BumpAllocatorScopeMut, BumpBox, ErrorBehavior, NoDrop, SetLenOnDrop, SizedTypeProperties, Stats,
+    BumpBox, ErrorBehavior, MutBumpAllocator, MutBumpAllocatorScope, NoDrop, SetLenOnDrop, SizedTypeProperties, Stats,
 };
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -20,7 +20,7 @@ use core::{
 
 /// This is like [`vec!`] but allocates inside a `Bump` or `BumpScope`, returning a [`MutBumpVecRev`].
 ///
-/// `$bump` can be any type that implements [`BumpAllocatorMut`].
+/// `$bump` can be any type that implements [`MutBumpAllocator`].
 ///
 /// # Panics
 /// If used without `try`, panics on allocation failure.
@@ -504,7 +504,7 @@ impl<T, A> MutBumpVecRev<T, A> {
     }
 }
 
-impl<T, A: BumpAllocatorMut> MutBumpVecRev<T, A> {
+impl<T, A: MutBumpAllocator> MutBumpVecRev<T, A> {
     error_behavior_generic_methods_allocation_failure! {
         /// Constructs a new empty vector with at least the specified capacity
         /// with the provided `BumpScope`.
@@ -1690,7 +1690,7 @@ impl<T, A: BumpAllocatorMut> MutBumpVecRev<T, A> {
     }
 }
 
-impl<'a, T, A: BumpAllocatorScopeMut<'a>> MutBumpVecRev<T, A> {
+impl<'a, T, A: MutBumpAllocatorScope<'a>> MutBumpVecRev<T, A> {
     /// Turns this `MutBumpVecRev<T>` into a `BumpBox<[T]>`.
     ///
     /// Unused capacity does not take up space.<br/>
@@ -1806,7 +1806,7 @@ impl<T, A, I: SliceIndex<[T]>> IndexMut<I> for MutBumpVecRev<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<U, A: BumpAllocatorMut> Extend<U> for MutBumpVecRev<U, A> {
+impl<U, A: MutBumpAllocator> Extend<U> for MutBumpVecRev<U, A> {
     #[inline]
     fn extend<T: IntoIterator<Item = U>>(&mut self, iter: T) {
         let iter = iter.into_iter();
@@ -1837,7 +1837,7 @@ impl<T, A> Drop for MutBumpVecRev<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<'t, T: Clone + 't, A: BumpAllocatorMut> Extend<&'t T> for MutBumpVecRev<T, A> {
+impl<'t, T: Clone + 't, A: MutBumpAllocator> Extend<&'t T> for MutBumpVecRev<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = &'t T>>(&mut self, iter: I) {
         let iter = iter.into_iter();

--- a/src/owned_slice/drain.rs
+++ b/src/owned_slice/drain.rs
@@ -81,7 +81,7 @@ impl<'a, T> Drain<'a, T> {
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; 'a', 'b', 'c'];
+    /// let mut vec = bump_vec![in &bump; 'a', 'b', 'c'];
     /// let mut drain = vec.drain(..);
     /// assert_eq!(drain.as_slice(), &['a', 'b', 'c']);
     /// let _ = drain.next().unwrap();
@@ -99,7 +99,7 @@ impl<'a, T> Drain<'a, T> {
     /// ```
     /// # use bump_scope::{ Bump, bump_vec };
     /// # let bump: Bump = Bump::new();
-    /// let mut vec = bump_vec![in bump; 'a', 'b', 'c'];
+    /// let mut vec = bump_vec![in &bump; 'a', 'b', 'c'];
     /// let mut drain = vec.drain(..);
     ///
     /// assert_eq!(drain.next().unwrap(), 'a');

--- a/src/polyfill/mod.rs
+++ b/src/polyfill/mod.rs
@@ -66,6 +66,10 @@ macro_rules! cfg_const {
 
 pub(crate) use cfg_const;
 
+pub(crate) unsafe fn transmute_ref<A, B>(a: &A) -> &B {
+    &*(a as *const A).cast::<B>()
+}
+
 pub(crate) unsafe fn transmute_mut<A, B>(a: &mut A) -> &mut B {
     &mut *(a as *mut A).cast::<B>()
 }

--- a/src/polyfill/mod.rs
+++ b/src/polyfill/mod.rs
@@ -46,6 +46,8 @@ mod other {
     }
 }
 
+use core::mem::ManuallyDrop;
+
 pub(crate) use other::*;
 
 macro_rules! cfg_const {
@@ -66,10 +68,17 @@ macro_rules! cfg_const {
 
 pub(crate) use cfg_const;
 
-pub(crate) unsafe fn transmute_ref<A, B>(a: &A) -> &B {
+pub(crate) const unsafe fn transmute_value<A, B>(a: A) -> B {
+    assert!(size_of::<A>() == size_of::<B>());
+    core::mem::transmute_copy(&ManuallyDrop::new(a))
+}
+
+pub(crate) const unsafe fn transmute_ref<A, B>(a: &A) -> &B {
+    assert!(size_of::<A>() == size_of::<B>());
     &*(a as *const A).cast::<B>()
 }
 
 pub(crate) unsafe fn transmute_mut<A, B>(a: &mut A) -> &mut B {
+    assert!(size_of::<A>() == size_of::<B>());
     &mut *(a as *mut A).cast::<B>()
 }

--- a/src/polyfill/mod.rs
+++ b/src/polyfill/mod.rs
@@ -46,7 +46,7 @@ mod other {
     }
 }
 
-use core::mem::ManuallyDrop;
+use core::mem::{size_of, ManuallyDrop};
 
 pub(crate) use other::*;
 
@@ -68,7 +68,7 @@ macro_rules! cfg_const {
 
 pub(crate) use cfg_const;
 
-pub(crate) const unsafe fn transmute_value<A, B>(a: A) -> B {
+pub(crate) unsafe fn transmute_value<A, B>(a: A) -> B {
     assert!(size_of::<A>() == size_of::<B>());
     core::mem::transmute_copy(&ManuallyDrop::new(a))
 }

--- a/src/polyfill/nonnull.rs
+++ b/src/polyfill/nonnull.rs
@@ -249,6 +249,12 @@ pub(crate) fn as_non_null_ptr<T>(ptr: NonNull<[T]>) -> NonNull<T> {
 }
 
 #[inline(always)]
+pub(crate) fn set_ptr<T>(ptr: &mut NonNull<[T]>, new_ptr: NonNull<T>) {
+    let len = ptr.len();
+    *ptr = slice_from_raw_parts(new_ptr, len);
+}
+
+#[inline(always)]
 pub(crate) fn set_len<T>(ptr: &mut NonNull<[T]>, new_len: usize) {
     let elem_ptr = as_non_null_ptr(*ptr);
     *ptr = slice_from_raw_parts(elem_ptr, new_len);

--- a/src/raw_bump_box.rs
+++ b/src/raw_bump_box.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Like [`BumpBox`] but without its lifetime.
 #[repr(transparent)]
 pub struct RawBumpBox<T: ?Sized> {
-    pub(crate) ptr: NonNull<T>,
+    ptr: NonNull<T>,
 
     /// Marks ownership over T. (<https://doc.rust-lang.org/nomicon/phantom-data.html#generic-parameters-and-drop-checking>)
     marker: PhantomData<T>,
@@ -38,5 +38,13 @@ impl<T: ?Sized> RawBumpBox<T> {
     #[inline(always)]
     pub(crate) unsafe fn cook_mut<'a>(&mut self) -> &mut BumpBox<'a, T> {
         transmute_mut(self)
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn new(ptr: NonNull<T>) -> Self {
+        Self {
+            ptr,
+            marker: PhantomData,
+        }
     }
 }

--- a/src/raw_bump_box.rs
+++ b/src/raw_bump_box.rs
@@ -1,14 +1,18 @@
-use core::{marker::PhantomData, mem::transmute, ptr::NonNull};
+use core::{
+    marker::PhantomData,
+    mem::{self, transmute},
+    ptr::{self, NonNull},
+};
 
 use crate::{
-    polyfill::{transmute_mut, transmute_ref},
+    polyfill::{nonnull, transmute_mut, transmute_ref},
     BumpBox,
 };
 
 /// Like [`BumpBox`] but without its lifetime.
 #[repr(transparent)]
 pub struct RawBumpBox<T: ?Sized> {
-    ptr: NonNull<T>,
+    pub(crate) ptr: NonNull<T>,
 
     /// Marks ownership over T. (<https://doc.rust-lang.org/nomicon/phantom-data.html#generic-parameters-and-drop-checking>)
     marker: PhantomData<T>,
@@ -25,26 +29,97 @@ impl<T: ?Sized> Drop for RawBumpBox<T> {
 }
 
 impl<T: ?Sized> RawBumpBox<T> {
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) unsafe fn cook<'a>(self) -> BumpBox<'a, T> {
         transmute(self)
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) unsafe fn cook_ref<'a>(&self) -> &BumpBox<'a, T> {
         transmute_ref(self)
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) unsafe fn cook_mut<'a>(&mut self) -> &mut BumpBox<'a, T> {
         transmute_mut(self)
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn new(ptr: NonNull<T>) -> Self {
+    pub(crate) unsafe fn from_cooked(cooked: BumpBox<'_, T>) -> Self {
+        Self {
+            ptr: cooked.into_raw(),
+            marker: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) const unsafe fn from_ptr(ptr: NonNull<T>) -> Self {
         Self {
             ptr,
             marker: PhantomData,
         }
+    }
+
+    #[inline(always)]
+    pub(crate) const fn into_ptr(self) -> NonNull<T> {
+        let ptr = unsafe { ptr::read(&self.ptr) };
+        mem::forget(self);
+        ptr
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub const fn as_non_null_ptr(&self) -> NonNull<T> {
+        self.ptr
+    }
+}
+
+impl<T> RawBumpBox<[T]> {
+    pub(crate) const EMPTY: Self = Self {
+        ptr: nonnull::slice_from_raw_parts(NonNull::dangling(), 0),
+        marker: PhantomData,
+    };
+
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.ptr.len()
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn set_ptr(&mut self, new_ptr: NonNull<T>) {
+        nonnull::set_ptr(&mut self.ptr, new_ptr);
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn set_len(&mut self, new_len: usize) {
+        nonnull::set_len(&mut self.ptr, new_len);
+    }
+}
+
+impl RawBumpBox<str> {
+    pub(crate) const EMPTY_STR: Self = Self {
+        ptr: nonnull::str_from_utf8(nonnull::slice_from_raw_parts(NonNull::dangling(), 0)),
+        marker: PhantomData,
+    };
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        nonnull::str_bytes(self.ptr).len()
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn set_ptr(&mut self, new_ptr: NonNull<u8>) {
+        let len = self.len();
+        self.ptr = nonnull::str_from_utf8(nonnull::slice_from_raw_parts(new_ptr, len));
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn set_len(&mut self, new_len: usize) {
+        let ptr = self.ptr.cast::<u8>();
+        self.ptr = nonnull::str_from_utf8(nonnull::slice_from_raw_parts(ptr, new_len));
     }
 }

--- a/src/raw_bump_box.rs
+++ b/src/raw_bump_box.rs
@@ -64,7 +64,7 @@ impl<T: ?Sized> RawBumpBox<T> {
     }
 
     #[inline(always)]
-    pub(crate) const fn into_ptr(self) -> NonNull<T> {
+    pub(crate) fn into_ptr(self) -> NonNull<T> {
         let ptr = unsafe { ptr::read(&self.ptr) };
         mem::forget(self);
         ptr

--- a/src/raw_bump_box.rs
+++ b/src/raw_bump_box.rs
@@ -1,0 +1,42 @@
+use core::{marker::PhantomData, mem::transmute, ptr::NonNull};
+
+use crate::{
+    polyfill::{transmute_mut, transmute_ref},
+    BumpBox,
+};
+
+/// Like [`BumpBox`] but without its lifetime.
+#[repr(transparent)]
+pub struct RawBumpBox<T: ?Sized> {
+    pub(crate) ptr: NonNull<T>,
+
+    /// Marks ownership over T. (<https://doc.rust-lang.org/nomicon/phantom-data.html#generic-parameters-and-drop-checking>)
+    marker: PhantomData<T>,
+}
+
+unsafe impl<T: ?Sized + Send> Send for RawBumpBox<T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RawBumpBox<T> {}
+
+impl<T: ?Sized> Drop for RawBumpBox<T> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        unsafe { self.ptr.as_ptr().drop_in_place() }
+    }
+}
+
+impl<T: ?Sized> RawBumpBox<T> {
+    #[inline(always)]
+    pub(crate) unsafe fn cook<'a>(self) -> BumpBox<'a, T> {
+        transmute(self)
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn cook_ref<'a>(&self) -> &BumpBox<'a, T> {
+        transmute_ref(self)
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn cook_mut<'a>(&mut self) -> &mut BumpBox<'a, T> {
+        transmute_mut(self)
+    }
+}

--- a/src/raw_fixed_bump_string.rs
+++ b/src/raw_fixed_bump_string.rs
@@ -4,7 +4,7 @@ use crate::{
     error_behavior::ErrorBehavior,
     polyfill::{nonnull, transmute_mut, transmute_ref},
     raw_bump_box::RawBumpBox,
-    BumpAllocator, BumpAllocatorMut, FixedBumpString,
+    BumpAllocator, FixedBumpString, MutBumpAllocator,
 };
 
 /// Like [`FixedBumpVec`] but without its lifetime.
@@ -55,7 +55,7 @@ impl RawFixedBumpString {
 
     #[inline(always)]
     pub(crate) unsafe fn prepare_allocation<B: ErrorBehavior>(
-        allocator: &mut impl BumpAllocatorMut,
+        allocator: &mut impl MutBumpAllocator,
         len: usize,
     ) -> Result<Self, B> {
         let allocation = B::prepare_slice_allocation::<u8>(allocator, len)?;

--- a/src/raw_fixed_bump_string.rs
+++ b/src/raw_fixed_bump_string.rs
@@ -4,81 +4,78 @@ use crate::{
     error_behavior::ErrorBehavior,
     polyfill::{nonnull, transmute_mut, transmute_ref},
     raw_bump_box::RawBumpBox,
-    BumpAllocator, FixedBumpVec, SizedTypeProperties,
+    BumpAllocator, FixedBumpString,
 };
 
 /// Like [`FixedBumpVec`] but without its lifetime.
 #[repr(C)]
-pub struct RawFixedBumpVec<T> {
-    pub(crate) initialized: RawBumpBox<[T]>,
+pub struct RawFixedBumpString {
+    pub(crate) initialized: RawBumpBox<str>,
     pub(crate) capacity: usize,
 }
 
-impl<T> RawFixedBumpVec<T> {
+impl RawFixedBumpString {
     #[inline(always)]
-    pub(crate) const unsafe fn cook<'a>(self) -> FixedBumpVec<'a, T> {
+    pub(crate) const unsafe fn cook<'a>(self) -> FixedBumpString<'a> {
         transmute(self)
     }
 
     #[inline(always)]
-    pub(crate) const unsafe fn cook_ref<'a>(&self) -> &FixedBumpVec<'a, T> {
+    pub(crate) const unsafe fn cook_ref<'a>(&self) -> &FixedBumpString<'a> {
         transmute_ref(self)
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn cook_mut<'a>(&mut self) -> &mut FixedBumpVec<'a, T> {
+    pub(crate) unsafe fn cook_mut<'a>(&mut self) -> &mut FixedBumpString<'a> {
         transmute_mut(self)
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn from_cooked(cooked: FixedBumpVec<'_, T>) -> Self {
-        let (initialized, capacity) = cooked.into_raw_parts();
+    pub(crate) unsafe fn from_cooked(cooked: FixedBumpString<'_>) -> Self {
+        let capacity = cooked.capacity();
+        let initialized = cooked.into_boxed_str();
         let initialized = RawBumpBox::from_cooked(initialized);
         Self { initialized, capacity }
     }
 
-    pub(crate) const EMPTY: Self = RawFixedBumpVec {
-        initialized: RawBumpBox::EMPTY,
-        capacity: if T::IS_ZST { usize::MAX } else { 0 },
+    pub(crate) const EMPTY: Self = RawFixedBumpString {
+        initialized: RawBumpBox::EMPTY_STR,
+        capacity: 0,
     };
 
     #[inline(always)]
     pub(crate) unsafe fn allocate<B: ErrorBehavior>(allocator: &impl BumpAllocator, len: usize) -> Result<Self, B> {
-        let ptr = B::allocate_slice::<T>(allocator, len)?;
-        let initialized = RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(ptr, 0));
+        let ptr = B::allocate_slice::<u8>(allocator, len)?;
+        let initialized = RawBumpBox::from_ptr(nonnull::str_from_utf8(nonnull::slice_from_raw_parts(ptr, 0)));
         Ok(Self {
             initialized,
             capacity: len,
         })
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
-    pub(crate) fn as_ptr(&self) -> *const T {
+    pub(crate) fn as_ptr(&self) -> *const u8 {
         self.initialized.as_non_null_ptr().as_ptr().cast()
     }
 
     #[inline(always)]
-    pub(crate) fn as_mut_ptr(&mut self) -> *mut T {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut u8 {
         self.initialized.as_non_null_ptr().as_ptr().cast()
-    }
-
-    #[must_use]
-    #[inline(always)]
-    pub fn as_non_null_ptr(&self) -> NonNull<T> {
-        self.initialized.as_non_null_ptr().cast()
     }
 
     #[inline(always)]
     pub(crate) const fn len(&self) -> usize {
-        self.initialized.as_non_null_ptr().len()
+        nonnull::str_bytes(self.initialized.as_non_null_ptr()).len()
     }
 
     #[allow(dead_code)]
     #[inline(always)]
-    pub(crate) unsafe fn set_ptr(&mut self, new_ptr: NonNull<T>) {
+    pub(crate) unsafe fn set_ptr(&mut self, new_ptr: NonNull<u8>) {
         self.initialized.set_ptr(new_ptr);
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) unsafe fn set_len(&mut self, new_len: usize) {
         self.initialized.set_len(new_len);

--- a/src/raw_fixed_bump_string.rs
+++ b/src/raw_fixed_bump_string.rs
@@ -53,6 +53,23 @@ impl RawFixedBumpString {
         })
     }
 
+    #[inline(always)]
+    pub(crate) unsafe fn allocate_greedy<B: ErrorBehavior>(
+        allocator: &mut impl BumpAllocator,
+        len: usize,
+    ) -> Result<Self, B> {
+        let allocation = B::allocate_slice_greedy::<u8>(allocator, len)?;
+        let initialized = RawBumpBox::from_ptr(nonnull::str_from_utf8(nonnull::slice_from_raw_parts(
+            nonnull::as_non_null_ptr(allocation),
+            0,
+        )));
+
+        Ok(Self {
+            initialized,
+            capacity: allocation.len(),
+        })
+    }
+
     #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn as_ptr(&self) -> *const u8 {

--- a/src/raw_fixed_bump_string.rs
+++ b/src/raw_fixed_bump_string.rs
@@ -4,7 +4,7 @@ use crate::{
     error_behavior::ErrorBehavior,
     polyfill::{nonnull, transmute_mut, transmute_ref},
     raw_bump_box::RawBumpBox,
-    BumpAllocator, FixedBumpString,
+    BumpAllocator, BumpAllocatorMut, FixedBumpString,
 };
 
 /// Like [`FixedBumpVec`] but without its lifetime.
@@ -55,7 +55,7 @@ impl RawFixedBumpString {
 
     #[inline(always)]
     pub(crate) unsafe fn allocate_greedy<B: ErrorBehavior>(
-        allocator: &mut impl BumpAllocator,
+        allocator: &mut impl BumpAllocatorMut,
         len: usize,
     ) -> Result<Self, B> {
         let allocation = B::allocate_slice_greedy::<u8>(allocator, len)?;

--- a/src/raw_fixed_bump_string.rs
+++ b/src/raw_fixed_bump_string.rs
@@ -54,11 +54,11 @@ impl RawFixedBumpString {
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn allocate_greedy<B: ErrorBehavior>(
+    pub(crate) unsafe fn prepare_allocation<B: ErrorBehavior>(
         allocator: &mut impl BumpAllocatorMut,
         len: usize,
     ) -> Result<Self, B> {
-        let allocation = B::allocate_slice_greedy::<u8>(allocator, len)?;
+        let allocation = B::prepare_slice_allocation::<u8>(allocator, len)?;
         let initialized = RawBumpBox::from_ptr(nonnull::str_from_utf8(nonnull::slice_from_raw_parts(
             nonnull::as_non_null_ptr(allocation),
             0,

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -4,7 +4,7 @@ use crate::{
     error_behavior::ErrorBehavior,
     polyfill::{nonnull, transmute_mut, transmute_ref},
     raw_bump_box::RawBumpBox,
-    BumpAllocator, BumpAllocatorMut, FixedBumpVec, SizedTypeProperties,
+    BumpAllocator, FixedBumpVec, MutBumpAllocator, SizedTypeProperties,
 };
 
 /// Like [`FixedBumpVec`] but without its lifetime.
@@ -54,7 +54,7 @@ impl<T> RawFixedBumpVec<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn prepare_allocation<B: ErrorBehavior>(
-        allocator: &mut impl BumpAllocatorMut,
+        allocator: &mut impl MutBumpAllocator,
         len: usize,
     ) -> Result<Self, B> {
         let allocation = B::prepare_slice_allocation::<T>(allocator, len)?;

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -64,6 +64,7 @@ impl<T> RawFixedBumpVec<T> {
 
     #[must_use]
     #[inline(always)]
+    #[allow(dead_code)]
     pub fn as_non_null_ptr(&self) -> NonNull<T> {
         self.initialized.as_non_null_ptr().cast()
     }

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -1,4 +1,4 @@
-use core::{marker::PhantomData, mem::transmute};
+use core::mem::transmute;
 
 use crate::{
     error_behavior::ErrorBehavior,
@@ -32,7 +32,7 @@ impl<T> RawFixedBumpVec<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn allocate<B: ErrorBehavior>(allocator: &impl BumpAllocator, len: usize) -> Result<Self, B> {
-        let ptr = B::allocate_slice::<T>(allocator, len)?.cast();
+        let ptr = B::allocate_slice::<T>(allocator, len)?;
         let initialized = RawBumpBox::new(nonnull::slice_from_raw_parts(ptr, 0));
         Ok(Self {
             initialized,

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -62,6 +62,20 @@ impl<T> RawFixedBumpVec<T> {
         }
     }
 
+    // TODO take allocator by immutable
+    #[inline(always)]
+    pub(crate) unsafe fn allocate_greedy<B: ErrorBehavior>(
+        allocator: &mut impl BumpAllocator,
+        len: usize,
+    ) -> Result<Self, B> {
+        let allocation = B::allocate_slice_greedy::<T>(allocator, len)?;
+
+        Ok(Self {
+            initialized: RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(nonnull::as_non_null_ptr(allocation), 0)),
+            capacity: allocation.len(),
+        })
+    }
+
     #[inline(always)]
     pub(crate) fn as_ptr(&self) -> *const T {
         self.initialized.as_non_null_ptr().as_ptr().cast()

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -1,0 +1,31 @@
+use core::mem::transmute;
+
+use crate::{
+    polyfill::{transmute_mut, transmute_ref},
+    raw_bump_box::RawBumpBox,
+    FixedBumpVec,
+};
+
+/// Like [`FixedBumpVec`] but without its lifetime.
+#[repr(C)]
+pub struct RawFixedBumpVec<T> {
+    pub(crate) initialized: RawBumpBox<[T]>,
+    pub(crate) capacity: usize,
+}
+
+impl<T> RawFixedBumpVec<T> {
+    #[inline(always)]
+    pub(crate) unsafe fn cook<'a>(self) -> FixedBumpVec<'a, T> {
+        transmute(self)
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn cook_ref<'a>(&self) -> &FixedBumpVec<'a, T> {
+        transmute_ref(self)
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn cook_mut<'a>(&mut self) -> &mut FixedBumpVec<'a, T> {
+        transmute_mut(self)
+    }
+}

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -42,9 +42,8 @@ impl<T> RawFixedBumpVec<T> {
         capacity: if T::IS_ZST { usize::MAX } else { 0 },
     };
 
-    // TODO take allocator by immutable
     #[inline(always)]
-    pub(crate) unsafe fn allocate<B: ErrorBehavior>(allocator: &mut impl BumpAllocator, len: usize) -> Result<Self, B> {
+    pub(crate) unsafe fn allocate<B: ErrorBehavior>(allocator: &impl BumpAllocator, len: usize) -> Result<Self, B> {
         let ptr = B::allocate_slice::<T>(allocator, len)?;
 
         Ok(Self {
@@ -53,13 +52,12 @@ impl<T> RawFixedBumpVec<T> {
         })
     }
 
-    // TODO take allocator by immutable
     #[inline(always)]
-    pub(crate) unsafe fn allocate_greedy<B: ErrorBehavior>(
+    pub(crate) unsafe fn prepare_allocation<B: ErrorBehavior>(
         allocator: &mut impl BumpAllocatorMut,
         len: usize,
     ) -> Result<Self, B> {
-        let allocation = B::allocate_slice_greedy::<T>(allocator, len)?;
+        let allocation = B::prepare_slice_allocation::<T>(allocator, len)?;
 
         Ok(Self {
             initialized: RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(nonnull::as_non_null_ptr(allocation), 0)),

--- a/src/raw_fixed_bump_vec.rs
+++ b/src/raw_fixed_bump_vec.rs
@@ -45,10 +45,23 @@ impl<T> RawFixedBumpVec<T> {
     #[inline(always)]
     pub(crate) unsafe fn allocate<B: ErrorBehavior>(allocator: &impl BumpAllocator, len: usize) -> Result<Self, B> {
         let ptr = B::allocate_slice::<T>(allocator, len)?;
-        let initialized = RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(ptr, 0));
+
         Ok(Self {
-            initialized,
+            initialized: RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(ptr, 0)),
             capacity: len,
+        })
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn allocate_greedy<B: ErrorBehavior>(
+        allocator: &mut impl BumpAllocator,
+        len: usize,
+    ) -> Result<Self, B> {
+        let allocation = B::allocate_slice_greedy::<T>(allocator, len)?;
+
+        Ok(Self {
+            initialized: RawBumpBox::from_ptr(nonnull::slice_from_raw_parts(nonnull::as_non_null_ptr(allocation), 0)),
+            capacity: allocation.len(),
         })
     }
 

--- a/src/tests/alloc_fmt.rs
+++ b/src/tests/alloc_fmt.rs
@@ -79,12 +79,12 @@ fn trait_panic_mut<const UP: bool>() {
 
 fn format_trait_panic<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
-    bump_format!(in bump, "{ErrorsOnFmt}");
+    bump_format!(in &bump, "{ErrorsOnFmt}");
 }
 
 fn format_trait_panic_mut<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    mut_bump_format!(in bump, "{ErrorsOnFmt}");
+    mut_bump_format!(in &mut bump, "{ErrorsOnFmt}");
 }
 
 either_way! {

--- a/src/tests/bump_allocator.rs
+++ b/src/tests/bump_allocator.rs
@@ -1,0 +1,40 @@
+use crate::{Bump, BumpAllocator, BumpVec, MutBumpAllocator, MutBumpVec};
+
+fn number_strings(numbers: impl IntoIterator<Item = i32>) -> impl Iterator<Item = String> {
+    numbers.into_iter().map(|i| i.to_string())
+}
+
+#[test]
+fn smoke_test() {
+    fn test<A: BumpAllocator>(a: A) {
+        let mut vec = BumpVec::from_iter_in(number_strings(1..=5), a);
+        vec.extend(number_strings(6..=9));
+    }
+
+    fn mut_test<A: MutBumpAllocator>(a: A) {
+        let mut vec = MutBumpVec::from_iter_in(number_strings(1..=5), a);
+        vec.extend(number_strings(6..=9));
+    }
+
+    let mut a: Bump = Bump::new();
+    test(&mut a);
+    test(&a);
+    test(a);
+
+    let mut a: Bump = Bump::new();
+    a.scoped(|mut a| {
+        test(&mut a);
+        test(&a);
+        test(a);
+    });
+
+    let mut a: Bump = Bump::new();
+    mut_test(&mut a);
+    mut_test(a);
+
+    let mut a: Bump = Bump::new();
+    a.scoped(|mut a| {
+        mut_test(&mut a);
+        mut_test(a);
+    });
+}

--- a/src/tests/bump_vec_doc.rs
+++ b/src/tests/bump_vec_doc.rs
@@ -29,13 +29,13 @@ either_way! {
 
 fn new<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
-    let vec: BumpVec<i32, Global, 1, UP> = bump_vec![in bump];
+    let vec: BumpVec<i32, _> = bump_vec![in &bump];
     assert!(vec.is_empty());
 }
 
 fn from_array<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
-    let vec = bump_vec![in bump; 1, 2, 3];
+    let vec = bump_vec![in &bump; 1, 2, 3];
     assert_eq!(vec[0], 1);
     assert_eq!(vec[1], 2);
     assert_eq!(vec[2], 3);
@@ -43,14 +43,14 @@ fn from_array<const UP: bool>() {
 
 fn from_elem<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
-    let vec = bump_vec![in bump; 1; 3];
+    let vec = bump_vec![in &bump; 1; 3];
     assert_eq!(vec, [1, 1, 1]);
 }
 
 fn extend_from_within_copy<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = bump_vec![in bump; 0, 1, 2, 3, 4];
+    let mut vec = bump_vec![in &bump; 0, 1, 2, 3, 4];
 
     vec.extend_from_within_copy(2..);
     assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -65,12 +65,12 @@ fn extend_from_within_copy<const UP: bool>() {
 fn resize<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = bump_vec![in bump; "hello"];
+    let mut vec = bump_vec![in &bump; "hello"];
     vec.resize(3, "world");
     assert_eq!(vec, ["hello", "world", "world"]);
     drop(vec);
 
-    let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+    let mut vec = bump_vec![in &bump; 1, 2, 3, 4];
     vec.resize(2, 0);
     assert_eq!(vec, [1, 2]);
 }
@@ -78,12 +78,12 @@ fn resize<const UP: bool>() {
 fn resize_with<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = bump_vec![in bump; 1, 2, 3];
+    let mut vec = bump_vec![in &bump; 1, 2, 3];
     vec.resize_with(5, Default::default);
     assert_eq!(vec, [1, 2, 3, 0, 0]);
     drop(vec);
 
-    let mut vec = bump_vec![in bump];
+    let mut vec = bump_vec![in &bump];
     let mut p = 1;
     vec.resize_with(4, || {
         p *= 2;
@@ -95,14 +95,14 @@ fn resize_with<const UP: bool>() {
 fn capacity<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let vec: BumpVec<i32, Global, 1, UP> = BumpVec::with_capacity_in(2048, &bump);
+    let vec: BumpVec<i32, _> = BumpVec::with_capacity_in(2048, &bump);
     assert!(vec.capacity() >= 2048);
 }
 
 fn insert<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = bump_vec![in bump; 1, 2, 3];
+    let mut vec = bump_vec![in &bump; 1, 2, 3];
     vec.insert(1, 4);
     assert_eq!(vec, [1, 4, 2, 3]);
     vec.insert(4, 5);
@@ -112,7 +112,7 @@ fn insert<const UP: bool>() {
 fn remove<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut v = bump_vec![in bump; 1, 2, 3];
+    let mut v = bump_vec![in &bump; 1, 2, 3];
     assert_eq!(v.remove(1), 2);
     assert_eq!(v, [1, 3]);
 }
@@ -120,7 +120,7 @@ fn remove<const UP: bool>() {
 fn swap_remove<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut v = bump_vec![in bump; "foo", "bar", "baz", "qux"];
+    let mut v = bump_vec![in &bump; "foo", "bar", "baz", "qux"];
 
     assert_eq!(v.swap_remove(1), "bar");
     assert_eq!(v, ["foo", "qux", "baz"]);
@@ -133,19 +133,19 @@ fn truncate<const UP: bool>() {
     let bump: Bump<Global, 1, UP> = Bump::new();
 
     {
-        let mut vec = bump_vec![in bump; 1, 2, 3, 4, 5];
+        let mut vec = bump_vec![in &bump; 1, 2, 3, 4, 5];
         vec.truncate(2);
         assert_eq!(vec, [1, 2]);
     }
 
     {
-        let mut vec = bump_vec![in bump; 1, 2, 3];
+        let mut vec = bump_vec![in &bump; 1, 2, 3];
         vec.truncate(8);
         assert_eq!(vec, [1, 2, 3]);
     }
 
     {
-        let mut vec = bump_vec![in bump; 1, 2, 3];
+        let mut vec = bump_vec![in &bump; 1, 2, 3];
         vec.truncate(0);
         assert!(vec.is_empty());
     }

--- a/src/tests/fixed_bump_vec.rs
+++ b/src/tests/fixed_bump_vec.rs
@@ -2,7 +2,7 @@
 use core::hint::black_box;
 
 use super::either_way;
-use crate::{bump_vec, Bump, FixedBumpVec};
+use crate::{bump_vec, tests::expect_no_panic, Bump, FixedBumpVec};
 use allocator_api2::alloc::Global;
 
 either_way! {
@@ -36,7 +36,7 @@ fn map_in_place_same_layout<const UP: bool>() {
         });
 
         if panic_on == 0 {
-            result.unwrap();
+            expect_no_panic(result);
         } else {
             assert_eq!(*result.unwrap_err().downcast::<&'static str>().unwrap(), "oh no");
         }
@@ -69,7 +69,7 @@ fn map_in_place_smaller_layout<const UP: bool>() {
         });
 
         if panic_on == 0 {
-            result.unwrap();
+            expect_no_panic(result);
         } else {
             assert_eq!(*result.unwrap_err().downcast::<&'static str>().unwrap(), "oh no");
         }
@@ -101,7 +101,7 @@ fn map_in_place_to_zst<const UP: bool>() {
         });
 
         if panic_on == 0 {
-            result.unwrap();
+            expect_no_panic(result);
         } else {
             assert_eq!(*result.unwrap_err().downcast::<&'static str>().unwrap(), "oh no");
         }
@@ -133,7 +133,7 @@ fn map_in_place_from_zst_to_zst<const UP: bool>() {
         });
 
         if panic_on == 0 {
-            result.unwrap();
+            expect_no_panic(result);
         } else {
             assert_eq!(*result.unwrap_err().downcast::<&'static str>().unwrap(), "oh no");
         }

--- a/src/tests/from_std/bump_string.rs
+++ b/src/tests/from_std/bump_string.rs
@@ -251,7 +251,7 @@ fn test_split_off_empty() {
     let bump: Bump = Bump::new();
     let orig = "Hello, world!";
     let mut split = BumpString::from_str_in(orig, &bump);
-    let empty: BumpString = split.split_off(orig.len());
+    let empty: BumpString<_> = split.split_off(orig.len());
     assert!(empty.is_empty());
 }
 
@@ -450,12 +450,12 @@ fn test_simple_types() {
 #[test]
 fn test_vectors() {
     let bump: Bump = Bump::new();
-    let x: BumpVec<i32> = bump_vec![in bump];
+    let x: BumpVec<i32, _> = bump_vec![in &bump];
     assert_eq!(bump_format!(in bump, "{x:?}"), "[]");
-    assert_eq!(bump_format!(in bump, "{:?}", bump_vec![in bump; 1]), "[1]");
-    assert_eq!(bump_format!(in bump, "{:?}", bump_vec![in bump; 1, 2, 3]), "[1, 2, 3]");
+    assert_eq!(bump_format!(in bump, "{:?}", bump_vec![in &bump; 1]), "[1]");
+    assert_eq!(bump_format!(in bump, "{:?}", bump_vec![in &bump; 1, 2, 3]), "[1, 2, 3]");
     assert!(
-        bump_format!(in bump, "{:?}", bump_vec![in bump; bump_vec![in bump], bump_vec![in bump; 1], bump_vec![in bump; 1, 1]])
+        bump_format!(in bump, "{:?}", bump_vec![in &bump; bump_vec![in &bump], bump_vec![in &bump; 1], bump_vec![in &bump; 1, 1]])
             == "[[], [1], [1, 1]]"
     );
 }

--- a/src/tests/from_std/bump_string.rs
+++ b/src/tests/from_std/bump_string.rs
@@ -438,24 +438,24 @@ fn test_slicing() {
 #[test]
 fn test_simple_types() {
     let bump: Bump = Bump::new();
-    assert_eq!(bump_format!(in bump, "{}", 1), "1");
-    assert_eq!(bump_format!(in bump, "{}", -1), "-1");
-    assert_eq!(bump_format!(in bump, "{}", 200), "200");
-    assert_eq!(bump_format!(in bump, "{}", 2), "2");
-    assert_eq!(bump_format!(in bump, "{}", true), "true");
-    assert_eq!(bump_format!(in bump, "{}", false), "false");
-    assert_eq!(bump_format!(in bump, "{}", BumpString::from_str_in("hi", &bump)), "hi");
+    assert_eq!(bump_format!(in &bump, "{}", 1), "1");
+    assert_eq!(bump_format!(in &bump, "{}", -1), "-1");
+    assert_eq!(bump_format!(in &bump, "{}", 200), "200");
+    assert_eq!(bump_format!(in &bump, "{}", 2), "2");
+    assert_eq!(bump_format!(in &bump, "{}", true), "true");
+    assert_eq!(bump_format!(in &bump, "{}", false), "false");
+    assert_eq!(bump_format!(in &bump, "{}", BumpString::from_str_in("hi", &bump)), "hi");
 }
 
 #[test]
 fn test_vectors() {
     let bump: Bump = Bump::new();
     let x: BumpVec<i32, _> = bump_vec![in &bump];
-    assert_eq!(bump_format!(in bump, "{x:?}"), "[]");
-    assert_eq!(bump_format!(in bump, "{:?}", bump_vec![in &bump; 1]), "[1]");
-    assert_eq!(bump_format!(in bump, "{:?}", bump_vec![in &bump; 1, 2, 3]), "[1, 2, 3]");
+    assert_eq!(bump_format!(in &bump, "{x:?}"), "[]");
+    assert_eq!(bump_format!(in &bump, "{:?}", bump_vec![in &bump; 1]), "[1]");
+    assert_eq!(bump_format!(in &bump, "{:?}", bump_vec![in &bump; 1, 2, 3]), "[1, 2, 3]");
     assert!(
-        bump_format!(in bump, "{:?}", bump_vec![in &bump; bump_vec![in &bump], bump_vec![in &bump; 1], bump_vec![in &bump; 1, 1]])
+        bump_format!(in &bump, "{:?}", bump_vec![in &bump; bump_vec![in &bump], bump_vec![in &bump; 1], bump_vec![in &bump; 1, 1]])
             == "[[], [1], [1, 1]]"
     );
 }
@@ -573,6 +573,6 @@ fn test_str_concat() {
     let bump: Bump = Bump::new();
     let a = BumpString::from_str_in("hello", &bump);
     let b = BumpString::from_str_in("world", &bump);
-    let s = bump_format!(in bump, "{a}{b}");
+    let s = bump_format!(in &bump, "{a}{b}");
     assert_eq!(s.as_bytes()[9], 'd' as u8);
 }

--- a/src/tests/from_std/bump_vec.rs
+++ b/src/tests/from_std/bump_vec.rs
@@ -57,7 +57,7 @@ impl Drop for DropCounterMutex {
 
 #[test]
 fn test_small_vec_struct() {
-    assert_eq!(size_of::<BumpVec<u8>>(), size_of::<usize>() * 4);
+    assert_eq!(size_of::<BumpVec<u8, Bump>>(), size_of::<usize>() * 4);
 }
 
 #[test]
@@ -66,8 +66,8 @@ fn test_double_drop() {
     let bump_y: Bump = Bump::new();
 
     struct TwoVec<'a, T> {
-        x: BumpVec<'a, 'a, T>,
-        y: BumpVec<'a, 'a, T>,
+        x: BumpVec<T, &'a Bump>,
+        y: BumpVec<T, &'a Bump>,
     }
 
     let (mut count_x, mut count_y) = (0, 0);
@@ -119,14 +119,14 @@ fn test_reserve() {
 fn test_zst_capacity() {
     let bump: Bump = Bump::new();
 
-    assert_eq!(BumpVec::<()>::new_in(&bump).capacity(), usize::MAX);
+    assert_eq!(BumpVec::<(), _>::new_in(&bump).capacity(), usize::MAX);
 }
 
 #[test]
 fn test_indexing() {
     let bump: Bump = Bump::new();
 
-    let v: BumpVec<isize> = bump_vec![in bump; 10, 20];
+    let v: BumpVec<isize, _> = bump_vec![in &bump; 10, 20];
     assert_eq!(v[0], 10);
     assert_eq!(v[1], 20);
     let mut x: usize = 0;
@@ -142,10 +142,10 @@ fn test_debug_fmt() {
     let bump1: Bump = Bump::new();
     let bump2: Bump = Bump::new();
 
-    let vec1: BumpVec<isize> = bump_vec![in bump1; ];
+    let vec1: BumpVec<isize, _> = bump_vec![in &bump1; ];
     assert_eq!("[]", format!("{:?}", vec1));
 
-    let vec2 = bump_vec![in bump2; 0, 1];
+    let vec2 = bump_vec![in &bump2; 0, 1];
     assert_eq!("[0, 1]", format!("{:?}", vec2));
 
     let slice: &[isize] = &[4, 5];
@@ -156,7 +156,7 @@ fn test_debug_fmt() {
 fn test_push() {
     let bump: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump; ];
+    let mut v = bump_vec![in &bump; ];
     v.push(1);
     assert_eq!(v, [1]);
     v.push(2);
@@ -170,8 +170,8 @@ fn test_extend() {
     let bump_v: Bump = Bump::new();
     let bump_w: Bump = Bump::new();
 
-    let mut v = BumpVec::<i32>::new_in(&bump_v);
-    let mut w = BumpVec::<i32>::new_in(&bump_w);
+    let mut v = BumpVec::<i32, _>::new_in(&bump_v);
+    let mut w = BumpVec::<i32, _>::new_in(&bump_w);
 
     v.extend(&w);
     assert!(v.is_empty());
@@ -201,7 +201,7 @@ fn test_extend() {
     let bump_b: Bump = Bump::new();
 
     let mut a = BumpVec::new_in(&bump_a);
-    let b = bump_vec![in bump_b; Foo, Foo];
+    let b = bump_vec![in &bump_b; Foo, Foo];
 
     a.extend(b);
     assert_eq!(a, &[Foo, Foo]);
@@ -213,7 +213,7 @@ fn test_extend() {
         let bump_y: Bump = Bump::new();
 
         let mut x = BumpVec::new_in(&bump_x);
-        let y = bump_vec![in bump_y; DropCounter { count: &mut count_x }];
+        let y = bump_vec![in &bump_y; DropCounter { count: &mut count_x }];
         x.extend(y);
     }
     assert_eq!(count_x, 1);
@@ -224,10 +224,10 @@ fn test_extend_from_slice() {
     let bump_a: Bump = Bump::new();
     let bump_b: Bump = Bump::new();
 
-    let a: BumpVec<isize> = bump_vec![in bump_a; 1, 2, 3, 4, 5];
-    let b: BumpVec<isize> = bump_vec![in bump_b; 6, 7, 8, 9, 0];
+    let a: BumpVec<isize, _> = bump_vec![in &bump_a; 1, 2, 3, 4, 5];
+    let b: BumpVec<isize, _> = bump_vec![in &bump_b; 6, 7, 8, 9, 0];
 
-    let mut v: BumpVec<isize> = a;
+    let mut v: BumpVec<isize, _> = a;
 
     v.extend_from_slice_copy(&b);
 
@@ -239,13 +239,13 @@ fn test_extend_ref() {
     let bump_v: Bump = Bump::new();
     let bump_w: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump_v; 1, 2];
+    let mut v = bump_vec![in &bump_v; 1, 2];
     v.extend(&[3, 4, 5]);
 
     assert_eq!(v.len(), 5);
     assert_eq!(v, [1, 2, 3, 4, 5]);
 
-    let w = bump_vec![in bump_w; 6, 7];
+    let w = bump_vec![in &bump_w; 6, 7];
     v.extend(&w);
 
     assert_eq!(v.len(), 7);
@@ -256,7 +256,7 @@ fn test_extend_ref() {
 fn test_slice_from_ref() {
     let bump: Bump = Bump::new();
 
-    let values = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let values = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let slice = &values[1..3];
 
     assert_eq!(slice, [2, 3]);
@@ -266,7 +266,7 @@ fn test_slice_from_ref() {
 fn test_slice_from_mut() {
     let bump: Bump = Bump::new();
 
-    let mut values = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut values = bump_vec![in &bump; 1, 2, 3, 4, 5];
     {
         let slice = &mut values[2..];
         assert!(slice == [3, 4, 5]);
@@ -282,7 +282,7 @@ fn test_slice_from_mut() {
 fn test_slice_to_mut() {
     let bump: Bump = Bump::new();
 
-    let mut values = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut values = bump_vec![in &bump; 1, 2, 3, 4, 5];
     {
         let slice = &mut values[..2];
         assert!(slice == [1, 2]);
@@ -298,7 +298,7 @@ fn test_slice_to_mut() {
 fn test_split_at_mut() {
     let bump: Bump = Bump::new();
 
-    let mut values = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut values = bump_vec![in &bump; 1, 2, 3, 4, 5];
     {
         let (left, right) = values.split_at_mut(2);
         {
@@ -325,7 +325,7 @@ fn test_split_at_mut() {
 fn test_retain() {
     let bump: Bump = Bump::new();
 
-    let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+    let mut vec = bump_vec![in &bump; 1, 2, 3, 4];
     vec.retain(|&mut x| x % 2 == 0);
     assert_eq!(vec, [2, 4]);
 }
@@ -336,7 +336,7 @@ fn test_retain_predicate_order() {
 
     for to_keep in [true, false] {
         let mut number_of_executions = 0;
-        let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+        let mut vec = bump_vec![in &bump; 1, 2, 3, 4];
         let mut next_expected = 1;
         vec.retain(|&mut x| {
             assert_eq!(next_expected, x);
@@ -466,7 +466,7 @@ fn test_retain_maybeuninits() {
 
 #[test]
 fn test_dedup() {
-    fn case(a: BumpVec<i32>, b: BumpVec<i32>) {
+    fn case(a: BumpVec<i32, &Bump>, b: BumpVec<i32, &Bump>) {
         let mut v = a;
         v.dedup();
         assert_eq!(v, b);
@@ -475,19 +475,19 @@ fn test_dedup() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    case(bump_vec![in bump0; ], bump_vec![in bump1; ]);
-    case(bump_vec![in bump0; 1], bump_vec![in bump1; 1]);
-    case(bump_vec![in bump0; 1, 1], bump_vec![in bump1; 1]);
-    case(bump_vec![in bump0; 1, 2, 3], bump_vec![in bump1; 1, 2, 3]);
-    case(bump_vec![in bump0; 1, 1, 2, 3], bump_vec![in bump1; 1, 2, 3]);
-    case(bump_vec![in bump0; 1, 2, 2, 3], bump_vec![in bump1; 1, 2, 3]);
-    case(bump_vec![in bump0; 1, 2, 3, 3], bump_vec![in bump1; 1, 2, 3]);
-    case(bump_vec![in bump0; 1, 1, 2, 2, 2, 3, 3], bump_vec![in bump1; 1, 2, 3]);
+    case(bump_vec![in &bump0; ], bump_vec![in &bump1; ]);
+    case(bump_vec![in &bump0; 1], bump_vec![in &bump1; 1]);
+    case(bump_vec![in &bump0; 1, 1], bump_vec![in &bump1; 1]);
+    case(bump_vec![in &bump0; 1, 2, 3], bump_vec![in &bump1; 1, 2, 3]);
+    case(bump_vec![in &bump0; 1, 1, 2, 3], bump_vec![in &bump1; 1, 2, 3]);
+    case(bump_vec![in &bump0; 1, 2, 2, 3], bump_vec![in &bump1; 1, 2, 3]);
+    case(bump_vec![in &bump0; 1, 2, 3, 3], bump_vec![in &bump1; 1, 2, 3]);
+    case(bump_vec![in &bump0; 1, 1, 2, 2, 2, 3, 3], bump_vec![in &bump1; 1, 2, 3]);
 }
 
 #[test]
 fn test_dedup_by_key() {
-    fn case(a: BumpVec<i32>, b: BumpVec<i32>) {
+    fn case(a: BumpVec<i32, &Bump>, b: BumpVec<i32, &Bump>) {
         let mut v = a;
         v.dedup_by_key(|i| *i / 10);
         assert_eq!(v, b);
@@ -496,16 +496,16 @@ fn test_dedup_by_key() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    case(bump_vec![in bump0; ], bump_vec![in bump1; ]);
-    case(bump_vec![in bump0; 10], bump_vec![in bump1; 10]);
-    case(bump_vec![in bump0; 10, 11], bump_vec![in bump1; 10]);
-    case(bump_vec![in bump0; 10, 20, 30], bump_vec![in bump1; 10, 20, 30]);
-    case(bump_vec![in bump0; 10, 11, 20, 30], bump_vec![in bump1; 10, 20, 30]);
-    case(bump_vec![in bump0; 10, 20, 21, 30], bump_vec![in bump1; 10, 20, 30]);
-    case(bump_vec![in bump0; 10, 20, 30, 31], bump_vec![in bump1; 10, 20, 30]);
+    case(bump_vec![in &bump0; ], bump_vec![in &bump1; ]);
+    case(bump_vec![in &bump0; 10], bump_vec![in &bump1; 10]);
+    case(bump_vec![in &bump0; 10, 11], bump_vec![in &bump1; 10]);
+    case(bump_vec![in &bump0; 10, 20, 30], bump_vec![in &bump1; 10, 20, 30]);
+    case(bump_vec![in &bump0; 10, 11, 20, 30], bump_vec![in &bump1; 10, 20, 30]);
+    case(bump_vec![in &bump0; 10, 20, 21, 30], bump_vec![in &bump1; 10, 20, 30]);
+    case(bump_vec![in &bump0; 10, 20, 30, 31], bump_vec![in &bump1; 10, 20, 30]);
     case(
-        bump_vec![in bump0; 10, 11, 20, 21, 22, 30, 31],
-        bump_vec![in bump1; 10, 20, 30],
+        bump_vec![in &bump0; 10, 11, 20, 21, 22, 30, 31],
+        bump_vec![in &bump1; 10, 20, 30],
     );
 }
 
@@ -513,13 +513,13 @@ fn test_dedup_by_key() {
 fn test_dedup_by() {
     let bump: Bump = Bump::new();
 
-    let mut vec = bump_vec![in bump; "foo", "bar", "Bar", "baz", "bar"];
+    let mut vec = bump_vec![in &bump; "foo", "bar", "Bar", "baz", "bar"];
     vec.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
 
     assert_eq!(vec, ["foo", "bar", "baz", "bar"]);
     drop(vec);
 
-    let mut vec = bump_vec![in bump; ("foo", 1), ("foo", 2), ("bar", 3), ("bar", 4), ("bar", 5)];
+    let mut vec = bump_vec![in &bump; ("foo", 1), ("foo", 2), ("bar", 3), ("bar", 4), ("bar", 5)];
     vec.dedup_by(|a, b| {
         a.0 == b.0 && {
             b.1 += a.1;
@@ -536,11 +536,11 @@ fn test_dedup_unique() {
     let bump1: Bump = Bump::new();
     let bump2: Bump = Bump::new();
 
-    let mut v0: BumpVec<Box<_>> = bump_vec![in bump0; Box::new(1), Box::new(1), Box::new(2), Box::new(3)];
+    let mut v0: BumpVec<Box<_>, _> = bump_vec![in &bump0; Box::new(1), Box::new(1), Box::new(2), Box::new(3)];
     v0.dedup();
-    let mut v1: BumpVec<Box<_>> = bump_vec![in bump1; Box::new(1), Box::new(2), Box::new(2), Box::new(3)];
+    let mut v1: BumpVec<Box<_>, _> = bump_vec![in &bump1; Box::new(1), Box::new(2), Box::new(2), Box::new(3)];
     v1.dedup();
-    let mut v2: BumpVec<Box<_>> = bump_vec![in bump2; Box::new(1), Box::new(2), Box::new(3), Box::new(3)];
+    let mut v2: BumpVec<Box<_>, _> = bump_vec![in &bump2; Box::new(1), Box::new(2), Box::new(3), Box::new(3)];
     v2.dedup();
     // If the boxed pointers were leaked or otherwise misused, valgrind
     // and/or rt should raise errors.
@@ -617,7 +617,7 @@ fn test_cmp() {
     let cmp: &[isize] = &[2, 3, 4];
     assert_eq!(&x[1..4], cmp);
 
-    let x: BumpVec<isize> = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let x: BumpVec<isize, _> = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let cmp: &[isize] = &[1, 2, 3, 4, 5];
     assert_eq!(&x[..], cmp);
     let cmp: &[isize] = &[3, 4, 5];
@@ -642,7 +642,7 @@ fn test_vec_truncate_drop() {
     }
 
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; Elem(1), Elem(2), Elem(3), Elem(4), Elem(5)];
+    let mut v = bump_vec![in &bump; Elem(1), Elem(2), Elem(3), Elem(4), Elem(5)];
     assert_eq!(unsafe { DROPS }, 0);
     v.truncate(3);
     assert_eq!(unsafe { DROPS }, 2);
@@ -664,14 +664,14 @@ fn test_vec_truncate_fail() {
     }
 
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; BadElem(1), BadElem(2), BadElem(0xbadbeef), BadElem(4)];
+    let mut v = bump_vec![in &bump; BadElem(1), BadElem(2), BadElem(0xbadbeef), BadElem(4)];
     v.truncate(0);
 }
 
 #[test]
 fn test_index() {
     let bump: Bump = Bump::new();
-    let vec = bump_vec![in bump; 1, 2, 3];
+    let vec = bump_vec![in &bump; 1, 2, 3];
     assert!(vec[1] == 2);
 }
 
@@ -679,7 +679,7 @@ fn test_index() {
 #[should_panic]
 fn test_index_out_of_bounds() {
     let bump: Bump = Bump::new();
-    let vec = bump_vec![in bump; 1, 2, 3];
+    let vec = bump_vec![in &bump; 1, 2, 3];
     let _ = vec[3];
 }
 
@@ -687,7 +687,7 @@ fn test_index_out_of_bounds() {
 #[should_panic]
 fn test_slice_out_of_bounds_1() {
     let bump: Bump = Bump::new();
-    let x = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let x = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let _ = &x[!0..];
 }
 
@@ -695,7 +695,7 @@ fn test_slice_out_of_bounds_1() {
 #[should_panic]
 fn test_slice_out_of_bounds_2() {
     let bump: Bump = Bump::new();
-    let x = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let x = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let _ = &x[..6];
 }
 
@@ -703,7 +703,7 @@ fn test_slice_out_of_bounds_2() {
 #[should_panic]
 fn test_slice_out_of_bounds_3() {
     let bump: Bump = Bump::new();
-    let x = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let x = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let _ = &x[!0..4];
 }
 
@@ -711,7 +711,7 @@ fn test_slice_out_of_bounds_3() {
 #[should_panic]
 fn test_slice_out_of_bounds_4() {
     let bump: Bump = Bump::new();
-    let x = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let x = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let _ = &x[1..6];
 }
 
@@ -719,7 +719,7 @@ fn test_slice_out_of_bounds_4() {
 #[should_panic]
 fn test_slice_out_of_bounds_5() {
     let bump: Bump = Bump::new();
-    let x = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let x = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let _ = &x[3..2];
 }
 
@@ -727,7 +727,7 @@ fn test_slice_out_of_bounds_5() {
 #[should_panic]
 fn test_swap_remove_empty() {
     let bump: Bump = Bump::new();
-    let mut vec = BumpVec::<i32>::new_in(&bump);
+    let mut vec = BumpVec::<i32, _>::new_in(&bump);
     vec.swap_remove(0);
 }
 
@@ -735,8 +735,8 @@ fn test_swap_remove_empty() {
 fn test_move_items() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let vec = bump_vec![in bump0; 1, 2, 3];
-    let mut vec2 = bump_vec![in bump1; ];
+    let vec = bump_vec![in &bump0; 1, 2, 3];
+    let mut vec2 = bump_vec![in &bump1; ];
     for i in vec {
         vec2.push(i);
     }
@@ -747,8 +747,8 @@ fn test_move_items() {
 fn test_move_items_reverse() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let vec = bump_vec![in bump0; 1, 2, 3];
-    let mut vec2 = bump_vec![in bump1; ];
+    let vec = bump_vec![in &bump0; 1, 2, 3];
+    let mut vec2 = bump_vec![in &bump1; ];
     for i in vec.into_iter().rev() {
         vec2.push(i);
     }
@@ -759,8 +759,8 @@ fn test_move_items_reverse() {
 fn test_move_items_zero_sized() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let vec = bump_vec![in bump0; (), (), ()];
-    let mut vec2 = bump_vec![in bump1; ];
+    let vec = bump_vec![in &bump0; (), (), ()];
+    let mut vec2 = bump_vec![in &bump1; ];
     for i in vec {
         vec2.push(i);
     }
@@ -772,8 +772,8 @@ fn test_drain_empty_vec() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    let mut vec: BumpVec<i32> = bump_vec![in bump0; ];
-    let mut vec2: BumpVec<i32> = bump_vec![in bump1; ];
+    let mut vec: BumpVec<i32, _> = bump_vec![in &bump0; ];
+    let mut vec2: BumpVec<i32, _> = bump_vec![in &bump1; ];
     for i in vec.drain(..) {
         vec2.push(i);
     }
@@ -786,8 +786,8 @@ fn test_drain_items() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    let mut vec = bump_vec![in bump0; 1, 2, 3];
-    let mut vec2 = bump_vec![in bump1; ];
+    let mut vec = bump_vec![in &bump0; 1, 2, 3];
+    let mut vec2 = bump_vec![in &bump1; ];
     for i in vec.drain(..) {
         vec2.push(i);
     }
@@ -800,8 +800,8 @@ fn test_drain_items_reverse() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    let mut vec = bump_vec![in bump0; 1, 2, 3];
-    let mut vec2 = bump_vec![in bump1; ];
+    let mut vec = bump_vec![in &bump0; 1, 2, 3];
+    let mut vec2 = bump_vec![in &bump1; ];
     for i in vec.drain(..).rev() {
         vec2.push(i);
     }
@@ -814,8 +814,8 @@ fn test_drain_items_zero_sized() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    let mut vec = bump_vec![in bump0; (), (), ()];
-    let mut vec2 = bump_vec![in bump1; ];
+    let mut vec = bump_vec![in &bump0; (), (), ()];
+    let mut vec2 = bump_vec![in &bump1; ];
     for i in vec.drain(..) {
         vec2.push(i);
     }
@@ -827,7 +827,7 @@ fn test_drain_items_zero_sized() {
 #[should_panic]
 fn test_drain_out_of_bounds() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     v.drain(5..6);
 }
 
@@ -835,7 +835,7 @@ fn test_drain_out_of_bounds() {
 fn test_drain_range() {
     let bump: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     for _ in v.drain(4..) {}
     assert_eq!(v.as_slice(), &[1, 2, 3, 4]);
     drop(v);
@@ -850,7 +850,7 @@ fn test_drain_range() {
     assert_eq!(v.as_slice(), &[1.to_string(), 5.to_string()]);
     drop(v);
 
-    let mut v: BumpVec<_> = bump_vec![in bump; (); 5];
+    let mut v: BumpVec<_, _> = bump_vec![in &bump; (); 5];
     for _ in v.drain(1..4).rev() {}
     assert_eq!(v, &[(), ()]);
     drop(v);
@@ -860,7 +860,7 @@ fn test_drain_range() {
 fn test_drain_inclusive_range() {
     let bump: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump; 'a', 'b', 'c', 'd', 'e'];
+    let mut v = bump_vec![in &bump; 'a', 'b', 'c', 'd', 'e'];
     for _ in v.drain(1..=3) {}
     assert_eq!(v, &['a', 'e']);
     drop(v);
@@ -890,7 +890,7 @@ fn test_drain_inclusive_range() {
 fn test_drain_max_vec_size() {
     let bump: Bump = Bump::new();
 
-    let mut v = BumpVec::<()>::with_capacity_in(usize::MAX, &bump);
+    let mut v = BumpVec::<(), _>::with_capacity_in(usize::MAX, &bump);
     unsafe {
         v.set_len(usize::MAX);
     }
@@ -898,7 +898,7 @@ fn test_drain_max_vec_size() {
     assert_eq!(v.len(), usize::MAX - 1);
     drop(v);
 
-    let mut v = BumpVec::<()>::with_capacity_in(usize::MAX, &bump);
+    let mut v = BumpVec::<(), _>::with_capacity_in(usize::MAX, &bump);
     unsafe {
         v.set_len(usize::MAX);
     }
@@ -911,7 +911,7 @@ fn test_drain_max_vec_size() {
 #[should_panic]
 fn test_drain_index_overflow() {
     let bump: Bump = Bump::new();
-    let mut v = BumpVec::<()>::with_capacity_in(usize::MAX, &bump);
+    let mut v = BumpVec::<(), _>::with_capacity_in(usize::MAX, &bump);
     unsafe {
         v.set_len(usize::MAX);
     }
@@ -922,7 +922,7 @@ fn test_drain_index_overflow() {
 #[should_panic]
 fn test_drain_inclusive_out_of_bounds() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     v.drain(5..=5);
 }
 
@@ -930,7 +930,7 @@ fn test_drain_inclusive_out_of_bounds() {
 #[should_panic]
 fn test_drain_start_overflow() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3];
+    let mut v = bump_vec![in &bump; 1, 2, 3];
     v.drain((Excluded(usize::MAX), Included(0)));
 }
 
@@ -938,7 +938,7 @@ fn test_drain_start_overflow() {
 #[should_panic]
 fn test_drain_end_overflow() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3];
+    let mut v = bump_vec![in &bump; 1, 2, 3];
     v.drain((Included(0), Included(usize::MAX)));
 }
 
@@ -967,7 +967,7 @@ fn test_drain_leak() {
         }
     }
 
-    let mut v = bump_vec![in bump0;
+    let mut v = bump_vec![in &bump0;
         D(0, false),
         D(1, false),
         D(2, false),
@@ -983,14 +983,14 @@ fn test_drain_leak() {
     .ok();
 
     assert_eq!(unsafe { DROPS }, 4);
-    assert_eq!(v, bump_vec![in bump1; D(0, false), D(1, false), D(6, false),]);
+    assert_eq!(v, bump_vec![in &bump1; D(0, false), D(1, false), D(6, false),]);
 }
 
 #[test]
 fn test_drain_keep_rest() {
     let bump: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump; 0, 1, 2, 3, 4, 5, 6];
+    let mut v = bump_vec![in &bump; 0, 1, 2, 3, 4, 5, 6];
     let mut drain = v.drain(1..6);
     assert_eq!(drain.next(), Some(1));
     assert_eq!(drain.next_back(), Some(5));
@@ -1004,7 +1004,7 @@ fn test_drain_keep_rest() {
 fn test_drain_keep_rest_all() {
     let bump: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump; 0, 1, 2, 3, 4, 5, 6];
+    let mut v = bump_vec![in &bump; 0, 1, 2, 3, 4, 5, 6];
     v.drain(1..6).keep_rest();
     assert_eq!(v, &[0, 1, 2, 3, 4, 5, 6]);
 }
@@ -1013,7 +1013,7 @@ fn test_drain_keep_rest_all() {
 fn test_drain_keep_rest_none() {
     let bump: Bump = Bump::new();
 
-    let mut v = bump_vec![in bump; 0, 1, 2, 3, 4, 5, 6];
+    let mut v = bump_vec![in &bump; 0, 1, 2, 3, 4, 5, 6];
     let mut drain = v.drain(1..6);
 
     drain.by_ref().for_each(drop);
@@ -1025,7 +1025,7 @@ fn test_drain_keep_rest_none() {
 #[test]
 fn test_splice() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let a = [10, 11, 12];
     v.splice(2..4, a);
     assert_eq!(v, &[1, 2, 10, 11, 12, 5]);
@@ -1036,7 +1036,7 @@ fn test_splice() {
 #[test]
 fn test_splice_inclusive_range() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let a = [10, 11, 12];
     let t1: Vec<_> = v.splice(2..=3, a).collect();
     assert_eq!(v, &[1, 2, 10, 11, 12, 5]);
@@ -1050,7 +1050,7 @@ fn test_splice_inclusive_range() {
 #[should_panic]
 fn test_splice_out_of_bounds() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let a = [10, 11, 12];
     v.splice(5..6, a);
 }
@@ -1059,7 +1059,7 @@ fn test_splice_out_of_bounds() {
 #[should_panic]
 fn test_splice_inclusive_out_of_bounds() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let a = [10, 11, 12];
     v.splice(5..=5, a);
 }
@@ -1067,8 +1067,8 @@ fn test_splice_inclusive_out_of_bounds() {
 #[test]
 fn test_splice_items_zero_sized() {
     let bump: Bump = Bump::new();
-    let mut vec = bump_vec![in bump; (), (), ()];
-    let vec2 = bump_vec![in bump; ];
+    let mut vec = bump_vec![in &bump; (), (), ()];
+    let vec2 = bump_vec![in &bump; ];
     let t: Vec<_> = vec.splice(1..2, vec2.iter().cloned()).collect();
     assert_eq!(vec, &[(), ()]);
     assert_eq!(t, &[()]);
@@ -1077,7 +1077,7 @@ fn test_splice_items_zero_sized() {
 #[test]
 fn test_splice_unbounded() {
     let bump: Bump = Bump::new();
-    let mut vec = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut vec = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let t: Vec<_> = vec.splice(.., None).collect();
     assert!(vec.is_empty());
     assert_eq!(t, &[1, 2, 3, 4, 5]);
@@ -1086,7 +1086,7 @@ fn test_splice_unbounded() {
 #[test]
 fn test_splice_forget() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; 1, 2, 3, 4, 5];
+    let mut v = bump_vec![in &bump; 1, 2, 3, 4, 5];
     let a = [10, 11, 12];
     std::mem::forget(v.splice(2..4, a));
     assert_eq!(v, &[1, 2]);
@@ -1095,7 +1095,7 @@ fn test_splice_forget() {
 #[test]
 fn test_into_boxed_slice() {
     let bump: Bump = Bump::new();
-    let xs = bump_vec![in bump; 1, 2, 3];
+    let xs = bump_vec![in &bump; 1, 2, 3];
     let ys = xs.into_boxed_slice();
     assert_eq!(&*ys, [1, 2, 3]);
 }
@@ -1105,7 +1105,7 @@ fn test_append() {
     let bump: Bump = Bump::new();
     let bump = bump.as_scope();
     let mut slice = bump.alloc_slice_copy(&[4, 5, 6]);
-    let mut vec = bump_vec![in bump; 1, 2, 3];
+    let mut vec = bump_vec![in &bump; 1, 2, 3];
     vec.append(&mut slice);
     assert_eq!(vec, [1, 2, 3, 4, 5, 6]);
     assert!(slice.is_empty());
@@ -1114,7 +1114,7 @@ fn test_append() {
 #[test]
 fn test_into_iter_as_slice() {
     let bump: Bump = Bump::new();
-    let vec = bump_vec![in bump; 'a', 'b', 'c'];
+    let vec = bump_vec![in &bump; 'a', 'b', 'c'];
     let mut into_iter = vec.into_iter();
     assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
     let _ = into_iter.next().unwrap();
@@ -1127,7 +1127,7 @@ fn test_into_iter_as_slice() {
 #[test]
 fn test_into_iter_as_mut_slice() {
     let bump: Bump = Bump::new();
-    let vec = bump_vec![in bump; 'a', 'b', 'c'];
+    let vec = bump_vec![in &bump; 'a', 'b', 'c'];
     let mut into_iter = vec.into_iter();
     assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
     into_iter.as_mut_slice()[0] = 'x';
@@ -1139,7 +1139,7 @@ fn test_into_iter_as_mut_slice() {
 #[test]
 fn test_into_iter_debug() {
     let bump: Bump = Bump::new();
-    let vec = bump_vec![in bump; 'a', 'b', 'c'];
+    let vec = bump_vec![in &bump; 'a', 'b', 'c'];
     let into_iter = vec.into_iter();
     let debug = format!("{into_iter:?}");
     assert_eq!(debug, "IntoIter(['a', 'b', 'c'])");
@@ -1166,7 +1166,7 @@ fn test_into_iter_next_chunk() {
 fn test_into_iter_clone() {
     fn iter_equal<I: Iterator<Item = i32>>(it: I, slice: &[i32]) {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump];
+        let mut v = bump_vec![in &bump];
         v.extend(it);
         assert_eq!(&v[..], slice);
     }
@@ -1202,7 +1202,7 @@ fn test_into_iter_leak() {
     }
 
     let bump: Bump = Bump::new();
-    let v = bump_vec![in bump; D(false), D(true), D(false)];
+    let v = bump_vec![in &bump; D(false), D(true), D(false)];
 
     catch_unwind(move || drop(v.into_iter())).ok();
 
@@ -1212,7 +1212,7 @@ fn test_into_iter_leak() {
 #[test]
 fn test_into_iter_advance_by() {
     let bump: Bump = Bump::new();
-    let mut i = bump_vec![in bump; 1, 2, 3, 4, 5].into_iter();
+    let mut i = bump_vec![in &bump; 1, 2, 3, 4, 5].into_iter();
     assert_eq!(i.advance_by(0), Ok(()));
     assert_eq!(i.advance_back_by(0), Ok(()));
     assert_eq!(i.as_slice(), [1, 2, 3, 4, 5]);
@@ -1275,18 +1275,18 @@ fn test_into_iter_zst() {
     const C: AlignedZstWithDrop = AlignedZstWithDrop([0u64; 0]);
 
     let bump: Bump = Bump::new();
-    for _ in bump_vec![in bump; C].into_iter() {}
-    for _ in bump_vec![in bump; C; 5].into_iter().rev() {}
+    for _ in bump_vec![in &bump; C].into_iter() {}
+    for _ in bump_vec![in &bump; C; 5].into_iter().rev() {}
 
-    let mut it = bump_vec![in bump; C, C].into_iter();
+    let mut it = bump_vec![in &bump; C, C].into_iter();
     assert_eq!(it.advance_by(1), Ok(()));
     drop(it);
 
-    let mut it = bump_vec![in bump; C, C].into_iter();
+    let mut it = bump_vec![in &bump; C, C].into_iter();
     it.next_chunk::<1>().unwrap();
     drop(it);
 
-    let mut it = bump_vec![in bump; C, C].into_iter();
+    let mut it = bump_vec![in &bump; C, C].into_iter();
     it.next_chunk::<4>().unwrap_err();
     drop(it);
 }
@@ -1324,7 +1324,7 @@ fn overaligned_allocations() {
 
     #[repr(align(256))]
     struct Foo(usize);
-    let mut v = bump_vec![in bump; Foo(273)];
+    let mut v = bump_vec![in &bump; Foo(273)];
     for i in 0..0x1000 {
         v.reserve_exact(i);
         assert!(v[0].0 == 273);
@@ -1339,7 +1339,7 @@ fn overaligned_allocations() {
 fn extract_if_empty() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let mut vec: BumpVec<i32> = bump_vec![in bump0; ];
+    let mut vec: BumpVec<i32, _> = bump_vec![in &bump0; ];
 
     {
         let mut iter = vec.extract_if(|_| true);
@@ -1351,7 +1351,7 @@ fn extract_if_empty() {
     }
     assert_eq!(vec.len(), 0);
 
-    let empty: BumpVec<i32> = bump_vec![in bump1; ];
+    let empty: BumpVec<i32, _> = bump_vec![in &bump1; ];
     assert_eq!(vec, empty);
 }
 
@@ -1359,7 +1359,7 @@ fn extract_if_empty() {
 fn extract_if_zst() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let mut vec = bump_vec![in bump0; (), (), (), (), ()];
+    let mut vec = bump_vec![in &bump0; (), (), (), (), ()];
     let initial_len = vec.len();
     let mut count = 0;
     {
@@ -1376,14 +1376,14 @@ fn extract_if_zst() {
 
     assert_eq!(count, initial_len);
     assert_eq!(vec.len(), 0);
-    assert_eq!(vec, bump_vec![in bump1; ]);
+    assert_eq!(vec, bump_vec![in &bump1; ]);
 }
 
 #[test]
 fn extract_if_false() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let mut vec = bump_vec![in bump0; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let mut vec = bump_vec![in &bump0; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     let initial_len = vec.len();
     let mut count = 0;
@@ -1400,14 +1400,14 @@ fn extract_if_false() {
 
     assert_eq!(count, 0);
     assert_eq!(vec.len(), initial_len);
-    assert_eq!(vec, bump_vec![in bump1; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assert_eq!(vec, bump_vec![in &bump1; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 }
 
 #[test]
 fn extract_if_true() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
-    let mut vec = bump_vec![in bump0; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let mut vec = bump_vec![in &bump0; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     let initial_len = vec.len();
     let mut count = 0;
@@ -1426,7 +1426,7 @@ fn extract_if_true() {
     assert_eq!(count, initial_len);
     assert_eq!(vec.len(), 0);
 
-    let empty: BumpVec<i32> = bump_vec![in bump1; ];
+    let empty: BumpVec<i32, _> = bump_vec![in &bump1; ];
     assert_eq!(vec, empty);
 }
 
@@ -1436,7 +1436,7 @@ fn extract_if_complex() {
 
     {
         //                [+xxx++++++xxxxx++++x+x++]
-        let mut vec = bump_vec![in bump;
+        let mut vec = bump_vec![in &bump;
             1, 2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37, 39,
         ];
 
@@ -1450,7 +1450,7 @@ fn extract_if_complex() {
 
     {
         //                [xxx++++++xxxxx++++x+x++]
-        let mut vec = bump_vec![in bump;
+        let mut vec = bump_vec![in &bump;
             2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37, 39,
         ];
 
@@ -1464,7 +1464,7 @@ fn extract_if_complex() {
 
     {
         //                [xxx++++++xxxxx++++x+x]
-        let mut vec = bump_vec![in bump; 2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36];
+        let mut vec = bump_vec![in &bump; 2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36];
 
         let removed = vec.extract_if(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -1476,7 +1476,7 @@ fn extract_if_complex() {
 
     {
         //                [xxxxxxxxxx+++++++++++]
-        let mut vec = bump_vec![in bump; 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+        let mut vec = bump_vec![in &bump; 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
 
         let removed = vec.extract_if(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -1488,7 +1488,7 @@ fn extract_if_complex() {
 
     {
         //                [+++++++++++xxxxxxxxxx]
-        let mut vec = bump_vec![in bump; 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+        let mut vec = bump_vec![in &bump; 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
         let removed = vec.extract_if(|x| *x % 2 == 0).collect::<Vec<_>>();
         assert_eq!(removed.len(), 10);
@@ -1507,7 +1507,7 @@ fn extract_if_consumed_panic() {
 
     struct Check<'a> {
         index: usize,
-        drop_counts: Rc<Mutex<BumpVec<'a, 'a, usize>>>,
+        drop_counts: Rc<Mutex<BumpVec<usize, &'a Bump>>>,
     }
 
     impl Drop for Check<'_> {
@@ -1519,8 +1519,8 @@ fn extract_if_consumed_panic() {
 
     let bump: Bump = Bump::new();
     let check_count = 10;
-    let drop_counts = Rc::new(Mutex::new(bump_vec![in bump; 0_usize; check_count]));
-    let mut data: BumpVec<Check> = bump_vec![in bump];
+    let drop_counts = Rc::new(Mutex::new(bump_vec![in &bump; 0_usize; check_count]));
+    let mut data: BumpVec<Check, _> = bump_vec![in &bump];
     data.extend((0..check_count).map(|index| Check {
         index,
         drop_counts: Rc::clone(&drop_counts),
@@ -1561,7 +1561,7 @@ fn extract_if_unconsumed_panic() {
 
     struct Check<'a> {
         index: usize,
-        drop_counts: Rc<Mutex<BumpVec<'a, 'a, usize>>>,
+        drop_counts: Rc<Mutex<BumpVec<usize, &'a Bump>>>,
     }
 
     impl Drop for Check<'_> {
@@ -1573,8 +1573,8 @@ fn extract_if_unconsumed_panic() {
 
     let bump: Bump = Bump::new();
     let check_count = 10;
-    let drop_counts = Rc::new(Mutex::new(bump_vec![in bump; 0_usize; check_count]));
-    let mut data: BumpVec<Check> = bump_vec![in bump];
+    let drop_counts = Rc::new(Mutex::new(bump_vec![in &bump; 0_usize; check_count]));
+    let mut data: BumpVec<Check, _> = bump_vec![in &bump];
     data.extend((0..check_count).map(|index| Check {
         index,
         drop_counts: Rc::clone(&drop_counts),
@@ -1609,7 +1609,7 @@ fn extract_if_unconsumed_panic() {
 #[test]
 fn extract_if_unconsumed() {
     let bump: Bump = Bump::new();
-    let mut vec = bump_vec![in bump; 1, 2, 3, 4];
+    let mut vec = bump_vec![in &bump; 1, 2, 3, 4];
     let drain = vec.extract_if(|&mut x| x % 2 != 0);
     drop(drain);
     assert_eq!(vec, [1, 2, 3, 4]);
@@ -1620,7 +1620,7 @@ fn test_reserve_exact() {
     // This is all the same as test_reserve
 
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump];
+    let mut v = bump_vec![in &bump];
     assert_eq!(v.capacity(), 0);
 
     v.reserve_exact(2);
@@ -1681,13 +1681,13 @@ fn test_stable_pointers() {
     assert_eq!(*v0, 13);
 
     // Appending
-    v.append(&mut bump_vec![in bump1; 27, 19].into_boxed_slice());
+    v.append(&mut bump_vec![in &bump1; 27, 19].into_boxed_slice());
     assert_eq!(*v0, 13);
 
     // Extending
     v.extend_from_slice_copy(&[1, 2]);
     v.extend(&[1, 2]); // `slice::Iter` (with `T: Copy`) specialization
-    v.extend(bump_vec![in bump1; 2, 3]); // `vec::IntoIter` specialization
+    v.extend(bump_vec![in &bump1; 2, 3]); // `vec::IntoIter` specialization
     v.extend(std::iter::once(3)); // `TrustedLen` specialization
     v.extend(std::iter::empty::<i32>()); // `TrustedLen` specialization with empty iterator
     v.extend(std::iter::once(3).filter(|_| true)); // base case
@@ -1716,9 +1716,9 @@ fn test_stable_pointers() {
 
     // Splicing
     v.resize_with(10, || 42);
-    next_then_drop(v.splice(5.., bump_vec![in bump1; 1, 2, 3, 4, 5])); // empty tail after range
+    next_then_drop(v.splice(5.., bump_vec![in &bump1; 1, 2, 3, 4, 5])); // empty tail after range
     assert_eq!(*v0, 13);
-    next_then_drop(v.splice(5..8, bump_vec![in bump1; 1])); // replacement is smaller than original range
+    next_then_drop(v.splice(5..8, bump_vec![in &bump1; 1])); // replacement is smaller than original range
     assert_eq!(*v0, 13);
     next_then_drop(v.splice(5..6, [1; 10].into_iter().filter(|_| true))); // lower bound not exact
     assert_eq!(*v0, 13);
@@ -1734,7 +1734,7 @@ fn test_stable_pointers() {
 
 macro_rules! generate_assert_eq_vec_and_prim {
     ($name:ident<$B:ident>($type:ty)) => {
-        fn $name<A: PartialEq<$B> + Debug, $B: Debug>(a: BumpVec<A>, b: $type) {
+        fn $name<A: PartialEq<$B> + Debug, $B: Debug>(a: BumpVec<A, &Bump>, b: $type) {
             assert!(a == b);
             assert_eq!(a, b);
         }
@@ -1747,8 +1747,8 @@ generate_assert_eq_vec_and_prim! { assert_eq_vec_and_array_3<B>([B; 3]) }
 #[test]
 fn partialeq_vec_and_prim() {
     let bump: Bump = Bump::new();
-    assert_eq_vec_and_slice(bump_vec![in bump; 1, 2, 3], &[1, 2, 3]);
-    assert_eq_vec_and_array_3(bump_vec![in bump; 1, 2, 3], [1, 2, 3]);
+    assert_eq_vec_and_slice(bump_vec![in &bump; 1, 2, 3], &[1, 2, 3]);
+    assert_eq_vec_and_array_3(bump_vec![in &bump; 1, 2, 3], [1, 2, 3]);
 }
 
 macro_rules! assert_partial_eq_valid {
@@ -1768,8 +1768,8 @@ macro_rules! assert_partial_eq_valid {
 fn partialeq_vec_full() {
     let bump2: Bump = Bump::new();
     let bump3: Bump = Bump::new();
-    let vec2: BumpVec<_> = bump_vec![in bump2; 1, 2];
-    let vec3: BumpVec<_> = bump_vec![in bump3; 1, 2, 3];
+    let vec2: BumpVec<_, _> = bump_vec![in &bump2; 1, 2];
+    let vec3: BumpVec<_, _> = bump_vec![in &bump3; 1, 2, 3];
     let slice2: &[_] = &[1, 2];
     let slice3: &[_] = &[1, 2, 3];
     let slicemut2: &[_] = &mut [1, 2];
@@ -1793,7 +1793,7 @@ fn partialeq_vec_full() {
 fn test_zero_sized_capacity() {
     for len in [0, 1, 2, 4, 8, 16, 32, 64, 128, 256] {
         let bump: Bump = Bump::new();
-        let v = BumpVec::<()>::with_capacity_in(len, &bump);
+        let v = BumpVec::<(), _>::with_capacity_in(len, &bump);
         assert_eq!(v.len(), 0);
         assert_eq!(v.capacity(), usize::MAX);
     }
@@ -1822,24 +1822,24 @@ fn test_vec_macro_repeat() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    assert_eq!(bump_vec![in bump0; 1; 3], bump_vec![in bump1; 1, 1, 1]);
-    assert_eq!(bump_vec![in bump0; 1; 2], bump_vec![in bump1; 1, 1]);
-    assert_eq!(bump_vec![in bump0; 1; 1], bump_vec![in bump1; 1]);
-    // assert_eq!(bump_vec![in bump0; 1; 0], bump_vec![in bump1; ]);
+    assert_eq!(bump_vec![in &bump0; 1; 3], bump_vec![in &bump1; 1, 1, 1]);
+    assert_eq!(bump_vec![in &bump0; 1; 2], bump_vec![in &bump1; 1, 1]);
+    assert_eq!(bump_vec![in &bump0; 1; 1], bump_vec![in &bump1; 1]);
+    // assert_eq!(bump_vec![in &bump0; 1; 0], bump_vec![in &bump1; ]);
 
     // from_elem syntax (see RFC 832)
     let el = Box::new(1);
     let n = 3;
     assert_eq!(
-        bump_vec![in bump0; el; n],
-        bump_vec![in bump1; Box::new(1), Box::new(1), Box::new(1)]
+        bump_vec![in &bump0; el; n],
+        bump_vec![in &bump1; Box::new(1), Box::new(1), Box::new(1)]
     );
 }
 
 #[test]
 fn test_vec_swap() {
     let bump: Bump = Bump::new();
-    let mut a: BumpVec<isize> = bump_vec![in bump; 0, 1, 2, 3, 4, 5, 6];
+    let mut a: BumpVec<isize, _> = bump_vec![in &bump; 0, 1, 2, 3, 4, 5, 6];
     a.swap(2, 4);
     assert_eq!(a[2], 4);
     assert_eq!(a[4], 2);
@@ -1861,13 +1861,13 @@ fn test_extend_from_within_spec() {
     }
 
     let bump: Bump = Bump::new();
-    bump_vec![in bump; CopyOnly, CopyOnly].extend_from_within_copy(..);
+    bump_vec![in &bump; CopyOnly, CopyOnly].extend_from_within_copy(..);
 }
 
 #[test]
 fn test_extend_from_within_clone() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; String::from("sssss"), String::from("12334567890"), String::from("c")];
+    let mut v = bump_vec![in &bump; String::from("sssss"), String::from("12334567890"), String::from("c")];
     v.extend_from_within_clone(1..);
     assert_eq!(v, ["sssss", "12334567890", "c", "12334567890", "c"]);
 }
@@ -1876,13 +1876,13 @@ fn test_extend_from_within_clone() {
 fn test_extend_from_within_complete_rande() {
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; 0, 1, 2, 3];
+        let mut v = bump_vec![in &bump; 0, 1, 2, 3];
         v.extend_from_within_copy(..);
         assert_eq!(v, [0, 1, 2, 3, 0, 1, 2, 3]);
     }
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; 0, 1, 2, 3];
+        let mut v = bump_vec![in &bump; 0, 1, 2, 3];
         v.extend_from_within_clone(..);
         assert_eq!(v, [0, 1, 2, 3, 0, 1, 2, 3]);
     }
@@ -1892,13 +1892,13 @@ fn test_extend_from_within_complete_rande() {
 fn test_extend_from_within_empty_rande() {
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; 0, 1, 2, 3];
+        let mut v = bump_vec![in &bump; 0, 1, 2, 3];
         v.extend_from_within_copy(1..1);
         assert_eq!(v, [0, 1, 2, 3]);
     }
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; 0, 1, 2, 3];
+        let mut v = bump_vec![in &bump; 0, 1, 2, 3];
         v.extend_from_within_clone(1..1);
         assert_eq!(v, [0, 1, 2, 3]);
     }
@@ -1909,13 +1909,13 @@ fn test_extend_from_within_empty_rande() {
 fn test_extend_from_within_out_of_rande() {
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; 0, 1];
+        let mut v = bump_vec![in &bump; 0, 1];
         v.extend_from_within_copy(..3);
     }
 
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; 0, 1];
+        let mut v = bump_vec![in &bump; 0, 1];
         v.extend_from_within_clone(..3);
     }
 }
@@ -1924,13 +1924,13 @@ fn test_extend_from_within_out_of_rande() {
 fn test_extend_from_within_zst() {
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; (); 8];
+        let mut v = bump_vec![in &bump; (); 8];
         v.extend_from_within_copy(3..7);
         assert_eq!(v, [(); 12]);
     }
     {
         let bump: Bump = Bump::new();
-        let mut v = bump_vec![in bump; (); 8];
+        let mut v = bump_vec![in &bump; (); 8];
         v.extend_from_within_clone(3..7);
         assert_eq!(v, [(); 12]);
     }
@@ -1940,13 +1940,13 @@ fn test_extend_from_within_zst() {
 fn test_extend_from_within_empty_vec() {
     {
         let bump: Bump = Bump::new();
-        let mut v = BumpVec::<i32>::new_in(&bump);
+        let mut v = BumpVec::<i32, _>::new_in(&bump);
         v.extend_from_within_copy(..);
         assert!(v.is_empty());
     }
     {
         let bump: Bump = Bump::new();
-        let mut v = BumpVec::<i32>::new_in(&bump);
+        let mut v = BumpVec::<i32, _>::new_in(&bump);
         v.extend_from_within_clone(..);
         assert!(v.is_empty());
     }
@@ -1955,7 +1955,7 @@ fn test_extend_from_within_empty_vec() {
 #[test]
 fn test_extend_from_within() {
     let bump: Bump = Bump::new();
-    let mut v = bump_vec![in bump; String::from("a"), String::from("b"), String::from("c")];
+    let mut v = bump_vec![in &bump; String::from("a"), String::from("b"), String::from("c")];
     v.extend_from_within_clone(1..=2);
     v.extend_from_within_clone(..=1);
     assert_eq!(v, ["a", "b", "c", "b", "c", "a", "b"]);
@@ -1964,7 +1964,7 @@ fn test_extend_from_within() {
 #[test]
 fn test_vec_dedup_by() {
     let bump: Bump = Bump::new();
-    let mut vec: BumpVec<i32> = bump_vec![in bump; 1, -1, 2, 3, 1, -5, 5, -2, 2];
+    let mut vec: BumpVec<i32, _> = bump_vec![in &bump; 1, -1, 2, 3, 1, -5, 5, -2, 2];
 
     vec.dedup_by(|a, b| a.abs() == b.abs());
 
@@ -1974,7 +1974,7 @@ fn test_vec_dedup_by() {
 #[test]
 fn test_vec_dedup_empty() {
     let bump: Bump = Bump::new();
-    let mut vec: BumpVec<i32> = BumpVec::new_in(&bump);
+    let mut vec: BumpVec<i32, _> = BumpVec::new_in(&bump);
 
     vec.dedup();
 
@@ -1984,7 +1984,7 @@ fn test_vec_dedup_empty() {
 #[test]
 fn test_vec_dedup_one() {
     let bump: Bump = Bump::new();
-    let mut vec = bump_vec![in bump; 12i32];
+    let mut vec = bump_vec![in &bump; 12i32];
 
     vec.dedup();
 
@@ -1994,7 +1994,7 @@ fn test_vec_dedup_one() {
 #[test]
 fn test_vec_dedup_multiple_ident() {
     let bump: Bump = Bump::new();
-    let mut vec = bump_vec![in bump; 12, 12, 12, 12, 12, 11, 11, 11, 11, 11, 11];
+    let mut vec = bump_vec![in &bump; 12, 12, 12, 12, 12, 11, 11, 11, 11, 11, 11];
 
     vec.dedup();
 
@@ -2014,7 +2014,7 @@ fn test_vec_dedup_partialeq() {
     }
 
     let bump: Bump = Bump::new();
-    let mut vec = bump_vec![in bump; Foo(0, 1), Foo(0, 5), Foo(1, 7), Foo(1, 9)];
+    let mut vec = bump_vec![in &bump; Foo(0, 1), Foo(0, 5), Foo(1, 7), Foo(1, 9)];
 
     vec.dedup();
     assert_eq!(vec, [Foo(0, 1), Foo(1, 7)]);
@@ -2025,7 +2025,7 @@ fn test_vec_dedup() {
     let bump0: Bump = Bump::new();
     let bump1: Bump = Bump::new();
 
-    let mut vec: BumpVec<bool> = BumpVec::with_capacity_in(8, &bump0);
+    let mut vec: BumpVec<bool, _> = BumpVec::with_capacity_in(8, &bump0);
 
     let mut template = BumpVec::new_in(&bump1);
     template.extend(vec.iter());
@@ -2094,7 +2094,7 @@ fn test_vec_dedup_panicking() {
             index: 7,
         },
     ];
-    let mut vec = bump_vec![in bump;
+    let mut vec = bump_vec![in &bump;
         Panic {
             drop_counter,
             value: false,
@@ -2178,7 +2178,7 @@ fn test_extend_from_within_panicking_clone() {
     let count = core::sync::atomic::AtomicU32::new(0);
     let bump: Bump = Bump::new();
 
-    let mut vec = bump_vec![in bump;
+    let mut vec = bump_vec![in &bump;
         Panic {
             drop_count: &count,
             aaaaa: false,
@@ -2207,6 +2207,6 @@ fn test_extend_from_within_panicking_clone() {
 #[should_panic = "vec len overflow"]
 fn test_into_flattened_size_overflow() {
     let bump: Bump = Bump::new();
-    let v = bump_vec![in bump; [(); usize::MAX]; 2];
+    let v = bump_vec![in &bump; [(); usize::MAX]; 2];
     let _ = v.into_flattened();
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1085,6 +1085,16 @@ fn min_non_zero_cap() {
     }
 }
 
+#[test]
+fn unsound_exclusive_allocator() {
+    let mut bump: Bump = Bump::new();
+    let vec = BumpVec::<i32, _>::from_array_in([1], &mut bump);
+    dbg!(vec.stats().capacity());
+    assert!(vec.stats().capacity() > 100);
+    vec.allocator().alloc(5);
+    assert_ne!(vec[0], 5);
+}
+
 // This must fail to compile.
 //
 // Can't have a trybuild (or doc tests) test for this because trybuild just `check`s

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -18,6 +18,7 @@ mod alloc_iter;
 mod alloc_slice;
 mod alloc_try_with;
 mod allocator_api;
+mod bump_allocator;
 mod bump_string;
 mod bump_vec;
 mod bump_vec_doc;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -570,27 +570,27 @@ fn bump_vec_macro() {
 
 #[allow(dead_code)]
 fn bump_vec_rev_macro() {
-    fn new_in(bump: &mut Bump) -> MutBumpVecRev<u32> {
+    fn new_in(bump: &mut Bump) -> MutBumpVecRev<u32, &mut Bump> {
         mut_bump_vec_rev![in bump]
     }
 
-    fn from_array_in(bump: &mut Bump) -> MutBumpVecRev<u32> {
+    fn from_array_in(bump: &mut Bump) -> MutBumpVecRev<u32, &mut Bump> {
         mut_bump_vec_rev![in bump; 1, 2, 3]
     }
 
-    fn from_elem_in(bump: &mut Bump) -> MutBumpVecRev<u32> {
+    fn from_elem_in(bump: &mut Bump) -> MutBumpVecRev<u32, &mut Bump> {
         mut_bump_vec_rev![in bump; 3; 5]
     }
 
-    fn try_new_in(bump: &mut Bump) -> Result<MutBumpVecRev<u32>> {
+    fn try_new_in(bump: &mut Bump) -> Result<MutBumpVecRev<u32, &mut Bump>> {
         mut_bump_vec_rev![try in bump]
     }
 
-    fn try_from_array_in(bump: &mut Bump) -> Result<MutBumpVecRev<u32>> {
+    fn try_from_array_in(bump: &mut Bump) -> Result<MutBumpVecRev<u32, &mut Bump>> {
         mut_bump_vec_rev![try in bump; 1, 2, 3]
     }
 
-    fn try_from_elem_in(bump: &mut Bump) -> Result<MutBumpVecRev<u32>> {
+    fn try_from_elem_in(bump: &mut Bump) -> Result<MutBumpVecRev<u32, &mut Bump>> {
         mut_bump_vec_rev![try in bump; 3; 5]
     }
 }
@@ -1054,7 +1054,7 @@ fn min_non_zero_cap() {
 
         {
             let mut bump = bump_with_remaining_capacity(size_of::<T>() * expected_capacity);
-            let mut vec: MutBumpVecRev<T> = MutBumpVecRev::new_in(&mut bump);
+            let mut vec: MutBumpVecRev<T, _> = MutBumpVecRev::new_in(&mut bump);
             vec.push_with(Default::default);
             assert_eq!(vec.capacity(), expected_capacity, "{}", std::any::type_name::<T>());
             drop(vec);

--- a/src/tests/mut_bump_vec_doc.rs
+++ b/src/tests/mut_bump_vec_doc.rs
@@ -29,13 +29,13 @@ either_way! {
 
 fn new<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    let vec: MutBumpVec<i32, Global, 1, UP> = mut_bump_vec![in bump];
+    let vec: MutBumpVec<i32, _> = mut_bump_vec![in &mut bump];
     assert!(vec.is_empty());
 }
 
 fn from_array<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    let vec = mut_bump_vec![in bump; 1, 2, 3];
+    let vec = mut_bump_vec![in &mut bump; 1, 2, 3];
     assert_eq!(vec[0], 1);
     assert_eq!(vec[1], 2);
     assert_eq!(vec[2], 3);
@@ -43,14 +43,14 @@ fn from_array<const UP: bool>() {
 
 fn from_elem<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    let vec = mut_bump_vec![in bump; 1; 3];
+    let vec = mut_bump_vec![in &mut bump; 1; 3];
     assert_eq!(vec, [1, 1, 1]);
 }
 
 fn extend_from_within_copy<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec![in bump; 0, 1, 2, 3, 4];
+    let mut vec = mut_bump_vec![in &mut bump; 0, 1, 2, 3, 4];
 
     vec.extend_from_within_copy(2..);
     assert_eq!(vec, [0, 1, 2, 3, 4, 2, 3, 4]);
@@ -65,12 +65,12 @@ fn extend_from_within_copy<const UP: bool>() {
 fn resize<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec![in bump; "hello"];
+    let mut vec = mut_bump_vec![in &mut bump; "hello"];
     vec.resize(3, "world");
     assert_eq!(vec, ["hello", "world", "world"]);
     drop(vec);
 
-    let mut vec = mut_bump_vec![in bump; 1, 2, 3, 4];
+    let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3, 4];
     vec.resize(2, 0);
     assert_eq!(vec, [1, 2]);
 }
@@ -78,12 +78,12 @@ fn resize<const UP: bool>() {
 fn resize_with<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+    let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
     vec.resize_with(5, Default::default);
     assert_eq!(vec, [1, 2, 3, 0, 0]);
     drop(vec);
 
-    let mut vec = mut_bump_vec![in bump];
+    let mut vec = mut_bump_vec![in &mut bump];
     let mut p = 1;
     vec.resize_with(4, || {
         p *= 2;
@@ -95,14 +95,14 @@ fn resize_with<const UP: bool>() {
 fn capacity<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let vec: MutBumpVec<i32, Global, 1, UP> = MutBumpVec::with_capacity_in(2048, &mut bump);
+    let vec: MutBumpVec<i32, _> = MutBumpVec::with_capacity_in(2048, &mut bump);
     assert!(vec.capacity() >= 2048);
 }
 
 fn insert<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+    let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
     vec.insert(1, 4);
     assert_eq!(vec, [1, 4, 2, 3]);
     vec.insert(4, 5);
@@ -112,7 +112,7 @@ fn insert<const UP: bool>() {
 fn remove<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut v = mut_bump_vec![in bump; 1, 2, 3];
+    let mut v = mut_bump_vec![in &mut bump; 1, 2, 3];
     assert_eq!(v.remove(1), 2);
     assert_eq!(v, [1, 3]);
 }
@@ -120,7 +120,7 @@ fn remove<const UP: bool>() {
 fn swap_remove<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut v = mut_bump_vec![in bump; "foo", "bar", "baz", "qux"];
+    let mut v = mut_bump_vec![in &mut bump; "foo", "bar", "baz", "qux"];
 
     assert_eq!(v.swap_remove(1), "bar");
     assert_eq!(v, ["foo", "qux", "baz"]);
@@ -133,19 +133,19 @@ fn truncate<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
     {
-        let mut vec = mut_bump_vec![in bump; 1, 2, 3, 4, 5];
+        let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3, 4, 5];
         vec.truncate(2);
         assert_eq!(vec, [1, 2]);
     }
 
     {
-        let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         vec.truncate(8);
         assert_eq!(vec, [1, 2, 3]);
     }
 
     {
-        let mut vec = mut_bump_vec![in bump; 1, 2, 3];
+        let mut vec = mut_bump_vec![in &mut bump; 1, 2, 3];
         vec.truncate(0);
         assert!(vec.is_empty());
     }

--- a/src/tests/mut_bump_vec_rev_doc.rs
+++ b/src/tests/mut_bump_vec_rev_doc.rs
@@ -29,13 +29,13 @@ either_way! {
 
 fn new<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    let vec: MutBumpVecRev<i32, Global, 1, UP> = mut_bump_vec_rev![in bump];
+    let vec: MutBumpVecRev<i32, _> = mut_bump_vec_rev![in &mut bump];
     assert!(vec.is_empty());
 }
 
 fn from_array<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    let vec = mut_bump_vec_rev![in bump; 1, 2, 3];
+    let vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
     assert_eq!(vec[0], 1);
     assert_eq!(vec[1], 2);
     assert_eq!(vec[2], 3);
@@ -43,14 +43,14 @@ fn from_array<const UP: bool>() {
 
 fn from_elem<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
-    let vec = mut_bump_vec_rev![in bump; 1; 3];
+    let vec = mut_bump_vec_rev![in &mut bump; 1; 3];
     assert_eq!(vec, [1, 1, 1]);
 }
 
 fn extend_from_within_copy<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec_rev![in bump; 0, 1, 2, 3, 4];
+    let mut vec = mut_bump_vec_rev![in &mut bump; 0, 1, 2, 3, 4];
 
     vec.extend_from_within_copy(2..);
     assert_eq!(vec, [2, 3, 4, 0, 1, 2, 3, 4]);
@@ -65,12 +65,12 @@ fn extend_from_within_copy<const UP: bool>() {
 fn resize<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec_rev![in bump; "hello"];
+    let mut vec = mut_bump_vec_rev![in &mut bump; "hello"];
     vec.resize(3, "world");
     assert_eq!(vec, ["world", "world", "hello"]);
     drop(vec);
 
-    let mut vec = mut_bump_vec_rev![in bump; 1, 2, 3, 4];
+    let mut vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3, 4];
     vec.resize(2, 0);
     assert_eq!(vec, [3, 4]);
 }
@@ -78,12 +78,12 @@ fn resize<const UP: bool>() {
 fn resize_with<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec_rev![in bump; 1, 2, 3];
+    let mut vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
     vec.resize_with(5, Default::default);
     assert_eq!(vec, [0, 0, 1, 2, 3]);
     drop(vec);
 
-    let mut vec = mut_bump_vec_rev![in bump];
+    let mut vec = mut_bump_vec_rev![in &mut bump];
     let mut p = 1;
     vec.resize_with(4, || {
         p *= 2;
@@ -95,14 +95,14 @@ fn resize_with<const UP: bool>() {
 fn capacity<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let vec: MutBumpVecRev<i32, Global, 1, UP> = MutBumpVecRev::with_capacity_in(2048, &mut bump);
+    let vec: MutBumpVecRev<i32, _> = MutBumpVecRev::with_capacity_in(2048, &mut bump);
     assert!(vec.capacity() >= 2048);
 }
 
 fn insert<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut vec = mut_bump_vec_rev![in bump; 1, 2, 3];
+    let mut vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
     vec.insert(1, 4);
     assert_eq!(vec, [1, 4, 2, 3]);
     vec.insert(4, 5);
@@ -112,7 +112,7 @@ fn insert<const UP: bool>() {
 fn remove<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut v = mut_bump_vec_rev![in bump; 1, 2, 3];
+    let mut v = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
     assert_eq!(v.remove(1), 2);
     assert_eq!(v, [1, 3]);
 }
@@ -120,7 +120,7 @@ fn remove<const UP: bool>() {
 fn swap_remove<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
-    let mut v = mut_bump_vec_rev![in bump; "foo", "bar", "baz", "qux"];
+    let mut v = mut_bump_vec_rev![in &mut bump; "foo", "bar", "baz", "qux"];
 
     assert_eq!(v.swap_remove(1), "bar");
     assert_eq!(v, ["foo", "baz", "qux"]);
@@ -133,19 +133,19 @@ fn truncate<const UP: bool>() {
     let mut bump: Bump<Global, 1, UP> = Bump::new();
 
     {
-        let mut vec = mut_bump_vec_rev![in bump; 1, 2, 3, 4, 5];
+        let mut vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3, 4, 5];
         vec.truncate(2);
         assert_eq!(vec, [4, 5]);
     }
 
     {
-        let mut vec = mut_bump_vec_rev![in bump; 1, 2, 3];
+        let mut vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
         vec.truncate(8);
         assert_eq!(vec, [1, 2, 3]);
     }
 
     {
-        let mut vec = mut_bump_vec_rev![in bump; 1, 2, 3];
+        let mut vec = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
         vec.truncate(0);
         assert!(vec.is_empty());
     }

--- a/src/tests/mut_collections_do_not_waste_space.rs
+++ b/src/tests/mut_collections_do_not_waste_space.rs
@@ -25,7 +25,7 @@ fn vec_rev<const UP: bool>() {
     for size in [0, 100, 200, 300, 400] {
         bump.reset();
 
-        let mut vec: MutBumpVecRev<u8, Global, 1, UP> = MutBumpVecRev::new_in(&mut bump);
+        let mut vec: MutBumpVecRev<u8, _> = MutBumpVecRev::new_in(&mut bump);
         vec.extend(iter::repeat(0).take(size));
         assert_eq!(vec.stats().allocated(), 0); // `Mut*` allocations don't bump the pointer
         _ = vec.into_slice();

--- a/src/tests/mut_collections_do_not_waste_space.rs
+++ b/src/tests/mut_collections_do_not_waste_space.rs
@@ -10,7 +10,7 @@ fn vec<const UP: bool>() {
     for size in [0, 100, 200, 300, 400] {
         bump.reset();
 
-        let mut vec: MutBumpVec<u8, Global, 1, UP> = MutBumpVec::new_in(&mut bump);
+        let mut vec: MutBumpVec<u8, _> = MutBumpVec::new_in(&mut bump);
         vec.extend(iter::repeat(0).take(size));
         assert_eq!(vec.stats().allocated(), 0); // `Mut*` allocations don't bump the pointer
         _ = vec.into_slice();

--- a/src/tests/panic_safety.rs
+++ b/src/tests/panic_safety.rs
@@ -88,7 +88,7 @@ fn mut_bump_vec_from_elem_in<T: Testable>() {
 fn into_iter<T: Testable>() {
     expected_drops(5).expected_msg("whoops").run(|| {
         let mut bump: Bump = Bump::new();
-        let vec = mut_bump_vec![in bump; T::default(); 5];
+        let vec = mut_bump_vec![in &mut bump; T::default(); 5];
 
         #[allow(clippy::manual_assert)]
         for (i, _) in vec.into_iter().enumerate() {
@@ -114,7 +114,7 @@ fn bump_vec_extend_from_slice<T: Testable>() {
 
 fn mut_bump_vec_extend_from_slice<T: Testable>() {
     let mut bump: Bump = Bump::new();
-    let mut vec: MutBumpVec<T> = mut_bump_vec![in bump];
+    let mut vec: MutBumpVec<T, _> = mut_bump_vec![in &mut bump];
     let slice = ManuallyDrop::new(T::array::<5>());
 
     expected_drops(0).panic_on_clone(3).run(|| {
@@ -243,6 +243,7 @@ mod helper {
     fn catch<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R, String> {
         let hook = std::panic::take_hook();
 
+        #[cfg(any())]
         std::panic::set_hook(Box::new(|_| {
             // be quiet
         }));

--- a/src/tests/panic_safety.rs
+++ b/src/tests/panic_safety.rs
@@ -127,7 +127,7 @@ fn mut_bump_vec_extend_from_slice<T: Testable>() {
 
 fn mut_bump_vec_rev_extend_from_slice<T: Testable>() {
     let mut bump: Bump = Bump::new();
-    let mut vec: MutBumpVecRev<T> = mut_bump_vec_rev![in bump];
+    let mut vec: MutBumpVecRev<T, _> = mut_bump_vec_rev![in &mut bump];
     let slice = ManuallyDrop::new(T::array::<5>());
 
     expected_drops(0).panic_on_clone(3).run(|| {

--- a/src/tests/panic_safety.rs
+++ b/src/tests/panic_safety.rs
@@ -101,7 +101,7 @@ fn into_iter<T: Testable>() {
 
 fn bump_vec_extend_from_slice<T: Testable>() {
     let bump: Bump = Bump::new();
-    let mut vec: BumpVec<T> = bump_vec![in bump];
+    let mut vec: BumpVec<T, _> = bump_vec![in &bump];
     let slice = ManuallyDrop::new(T::array::<5>());
 
     expected_drops(0).panic_on_clone(3).run(|| {

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -26,7 +26,7 @@ fn ser() {
     }
 
     {
-        let a = bump_vec![in bump; 1, 2, 3];
+        let a = bump_vec![in &bump; 1, 2, 3];
         let b = vec![1, 2, 3];
         assert_same(&a, &b);
     }
@@ -81,8 +81,8 @@ fn de() {
     }
 
     {
-        let src = bump_vec![in bump_src; 1, 2, 3];
-        let mut dst = bump_vec![in bump_dst];
+        let src = bump_vec![in &bump_src; 1, 2, 3];
+        let mut dst = bump_vec![in &bump_dst];
         roundtrip(&src, &mut dst);
     }
 

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -32,7 +32,7 @@ fn ser() {
     }
 
     {
-        let a = mut_bump_vec![in bump; 1, 2, 3];
+        let a = mut_bump_vec![in &mut bump; 1, 2, 3];
         let b = vec![1, 2, 3];
         assert_same(&a, &b);
     }
@@ -44,13 +44,13 @@ fn ser() {
     }
 
     {
-        let a = bump_format!(in bump, "Hello world!");
+        let a = bump_format!(in &bump, "Hello world!");
         let b = "Hello world!";
         assert_same(&a, &b);
     }
 
     {
-        let a = mut_bump_format!(in bump, "Hello world!");
+        let a = mut_bump_format!(in &mut bump, "Hello world!");
         let b = "Hello world!";
         assert_same(&a, &b);
     }
@@ -87,14 +87,14 @@ fn de() {
     }
 
     {
-        let src = mut_bump_vec![in bump_src; 1, 2, 3];
-        let mut dst = mut_bump_vec![in bump_dst];
+        let src = mut_bump_vec![in &mut bump_src; 1, 2, 3];
+        let mut dst = mut_bump_vec![in &mut bump_dst];
         roundtrip(&src, &mut dst);
     }
 
     {
-        let src = mut_bump_vec_rev![in bump_src; 1, 2, 3];
-        let mut dst: MutBumpVecRev<i32> = mut_bump_vec_rev![in bump_dst];
+        let src = mut_bump_vec_rev![in &mut bump_src; 1, 2, 3];
+        let mut dst: MutBumpVecRev<i32> = mut_bump_vec_rev![in &mut bump_dst];
 
         let json = serde_json::to_string(&src).unwrap();
         let mut deserializer = serde_json::Deserializer::from_str(&json);
@@ -118,8 +118,8 @@ fn de() {
     }
 
     {
-        let src = mut_bump_format!(in bump_src, "Hello World!");
-        let mut dst = mut_bump_format!(in bump_dst);
+        let src = mut_bump_format!(in &mut bump_src, "Hello World!");
+        let mut dst = mut_bump_format!(in &mut bump_dst);
         roundtrip(&src, &mut dst);
     }
 }

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -38,7 +38,7 @@ fn ser() {
     }
 
     {
-        let a = mut_bump_vec_rev![in bump; 1, 2, 3];
+        let a = mut_bump_vec_rev![in &mut bump; 1, 2, 3];
         let b = vec![1, 2, 3];
         assert_same(&a, &b);
     }
@@ -94,7 +94,7 @@ fn de() {
 
     {
         let src = mut_bump_vec_rev![in &mut bump_src; 1, 2, 3];
-        let mut dst: MutBumpVecRev<i32> = mut_bump_vec_rev![in &mut bump_dst];
+        let mut dst: MutBumpVecRev<i32, _> = mut_bump_vec_rev![in &mut bump_dst];
 
         let json = serde_json::to_string(&src).unwrap();
         let mut deserializer = serde_json::Deserializer::from_str(&json);


### PR DESCRIPTION
We reimplement the collections so instead of
```rust
struct BumpVec<'b, 'a, T, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
where
    MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
    A: BaseAllocator<GUARANTEED_ALLOCATED>,
{ /* ... */ }
```
we now have
```rust
struct BumpVec<T, A: BumpAllocator> { /* ... */ }
```

This should clean up the api and implementation nicely but also add complexity in that we now have to account for `A` being anything and not just `&BumpScope`.

`BumpAllocator` will gain new methods for more optimized versions of `allocate` and friends so the generated code does not degrade.

With the new trait `BumpAllocatorScope<'a>` we can dish out objects for the `'a` lifetime from functions like `into_slice`. Most functions don't need to know about the bump scope lifetime so `BumpAllocator` suffices. Some valid `BumpAllocator`s can't implement `BumpAllocatorScope<'a>` like `Bump` (but `&'a Bump` can).

~With this trait based design we should be able to replace `Mut*` collections by implementing the mut optimizations on their non-mut container equivalents whenever the `BumpAllocator` supports this.~

We still need separate `Mut*` collections because in `Mut*` collections we need to protect the allocator and make sure no one can access it.

Todo:
- [x] implement `Bump{Vec,String}` using `BumpAllocator(Scope)`
- [x] implement `MutBump{Vec,String}` using `BumpAllocator(Scope)`
- [x] replace `(GuaranteedAllocated)Stats<'a, UP>` with a new `(GuaranteedAllocated)Stats<'a>`
- [x] ~add migration guide~ no, there are no straightforward migration steps from what i can tell
- [x] rename to use `Mut*` prefix instead to match the collections (the collections themselves match the `Fixed*` prefix)
- [x] review all docs and update where necessary