### PR TITLE
refactor: add `#![no_std]` attribute unconditionally

### DIFF
--- a/src/bump_box.rs
+++ b/src/bump_box.rs
@@ -1,15 +1,5 @@
 mod slice_initializer;
 
-#[cfg(feature = "alloc")]
-use crate::BumpAllocatorScope;
-use crate::{
-    owned_slice, owned_str,
-    polyfill::{self, nonnull, pointer, transmute_mut},
-    BumpAllocator, FromUtf8Error, NoDrop, SizedTypeProperties,
-};
-#[cfg(feature = "alloc")]
-#[allow(unused_imports)]
-use allocator_api2::boxed::Box;
 use core::{
     alloc::Layout,
     any::Any,
@@ -24,6 +14,23 @@ use core::{
     slice::{self, SliceIndex},
     str,
 };
+
+#[cfg(feature = "std")]
+use alloc::{string::String, vec::Vec};
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+use allocator_api2::boxed::Box;
+
+use crate::{
+    owned_slice, owned_str,
+    polyfill::{self, nonnull, pointer, transmute_mut},
+    BumpAllocator, FromUtf8Error, NoDrop, SizedTypeProperties,
+};
+
+#[cfg(feature = "alloc")]
+use crate::BumpAllocatorScope;
+
 pub(crate) use slice_initializer::BumpBoxSliceInitializer;
 
 /// A pointer type that uniquely owns a bump allocation of type `T`. This type is returned whenever a bump allocation is made.

--- a/src/bump_pool.rs
+++ b/src/bump_pool.rs
@@ -1,13 +1,15 @@
-use crate::{
-    error_behavior_generic_methods_allocation_failure, BaseAllocator, Bump, BumpScope, MinimumAlignment,
-    SupportedMinimumAlignment,
-};
+use alloc::vec::Vec;
 use core::{
     alloc::Layout,
     mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut},
 };
 use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use crate::{
+    error_behavior_generic_methods_allocation_failure, BaseAllocator, Bump, BumpScope, MinimumAlignment,
+    SupportedMinimumAlignment,
+};
 
 macro_rules! bump_pool_declaration {
     ($($allocator_parameter:tt)*) => {

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -28,7 +28,7 @@ use core::mem::MaybeUninit;
 #[cfg(feature = "panic-on-alloc")]
 use crate::{panic_on_error, polyfill::nonnull, raw_bump_box::RawBumpBox};
 
-/// This is like [`format!`] but allocates inside a bump allocator, returning a [`BumpString`].
+/// This is like [`format!`](alloc::format) but allocates inside a bump allocator, returning a [`BumpString`].
 ///
 /// If you don't need to push to the string after creation you can also use [`Bump::alloc_fmt`](crate::Bump::alloc_fmt).
 ///
@@ -74,7 +74,7 @@ macro_rules! bump_format {
     }};
 }
 
-/// A bump allocated [`String`].
+/// A bump allocated [`String`](alloc::string::String).
 ///
 /// When you are done building the string, you can turn it into a `&str` with [`into_str`].
 ///

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -38,7 +38,7 @@ pub use into_iter::IntoIter;
 #[cfg(feature = "panic-on-alloc")]
 pub use splice::Splice;
 
-/// This is like [`vec!`] but allocates inside a bump allocator, returning a [`BumpVec`].
+/// This is like [`vec!`](alloc::vec!) but allocates inside a bump allocator, returning a [`BumpVec`].
 ///
 /// `$bump` can be any type that implements [`BumpAllocator`].
 ///

--- a/src/destructure.rs
+++ b/src/destructure.rs
@@ -71,6 +71,8 @@ const fn str_eq(a: &str, b: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::string::String;
+
     use super::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // This crate uses modified code from the rust standard library. <https://github.com/rust-lang/rust/tree/master/library>.
 // Especially `BumpBox` methods, vectors, strings, `polyfill` and `tests/from_std` are based on code from the standard library.
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![no_std]
 #![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api, vec_into_raw_parts))]
 #![cfg_attr(feature = "nightly-coerce-unsized", feature(coerce_unsized, unsize))]
 #![cfg_attr(feature = "nightly-exact-size-is-empty", feature(exact_size_is_empty))]
@@ -263,7 +263,9 @@
 //! The point of this is so `Bump`s can be created without allocating memory and even `const` constructed since rust version 1.83.
 //! At the same time `Bump`s that have already allocated a chunk don't suffer runtime checks for entering scopes and creating checkpoints.
 
-#[doc(hidden)]
+#[cfg(any(feature = "std", test))]
+extern crate std;
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
@@ -1922,6 +1924,8 @@ pub(crate) use mut_collection_method_allocator_stats;
 #[test]
 #[ignore = "this is not a real test, it's just to insert documentation"]
 fn insert_feature_docs() {
+    use alloc::{format, vec::Vec};
+
     let lib_rs = std::fs::read_to_string("src/lib.rs").unwrap();
 
     let start_marker = "//! # Feature Flags";

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -19,7 +19,7 @@ use allocator_api2::alloc::AllocError;
 #[cfg(feature = "panic-on-alloc")]
 use crate::{panic_on_error, PanicsOnAlloc};
 
-/// This is like [`format!`] but allocates inside a *mutable* bump allocator, returning a [`MutBumpString`].
+/// This is like [`format!`](alloc::format) but allocates inside a *mutable* bump allocator, returning a [`MutBumpString`].
 ///
 /// If you don't need to push to the string after creation you can also use [`Bump::alloc_fmt_mut`](crate::Bump::alloc_fmt_mut).
 ///

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -22,7 +22,7 @@ use core::{
     slice::SliceIndex,
 };
 
-/// This is like [`vec!`] but allocates inside a bump allocator, returning a [`MutBumpVec`].
+/// This is like [`vec!`](alloc::vec!) but allocates inside a bump allocator, returning a [`MutBumpVec`].
 ///
 /// `$bump` can be any type that implements [`MutBumpAllocator`].
 ///

--- a/src/mut_bump_vec_rev.rs
+++ b/src/mut_bump_vec_rev.rs
@@ -20,7 +20,7 @@ use core::{
     slice::{self, SliceIndex},
 };
 
-/// This is like [`vec!`] but allocates inside a bump allocator, returning a [`MutBumpVecRev`].
+/// This is like [`vec!`](alloc::vec!) but allocates inside a bump allocator, returning a [`MutBumpVecRev`].
 ///
 /// `$bump` can be any type that implements [`MutBumpAllocator`].
 ///

--- a/src/owned_slice/drain.rs
+++ b/src/owned_slice/drain.rs
@@ -269,6 +269,8 @@ unsafe impl<T> TakeOwnedSlice for Drain<'_, T> {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
+    use std::{string::ToString, vec::Vec};
+
     use crate::{tests::TestWrap, Bump};
 
     #[test]

--- a/src/tests/alloc_slice.rs
+++ b/src/tests/alloc_slice.rs
@@ -1,6 +1,10 @@
-use super::either_way;
-use crate::Bump;
+use std::string::{String, ToString};
+
 use allocator_api2::alloc::Global;
+
+use crate::Bump;
+
+use super::either_way;
 
 fn zst<const UP: bool>() {
     const ZST: [u64; 0] = [0u64; 0];

--- a/src/tests/alloc_try_with.rs
+++ b/src/tests/alloc_try_with.rs
@@ -1,8 +1,12 @@
-use super::either_way;
-use crate::Bump;
-use allocator_api2::alloc::Global;
 use core::mem;
-use std::mem::offset_of;
+
+use std::{dbg, mem::offset_of};
+
+use allocator_api2::alloc::Global;
+
+use crate::Bump;
+
+use super::either_way;
 
 macro_rules! assert_allocated {
     ($bump:ident, $expected:expr) => {

--- a/src/tests/append.rs
+++ b/src/tests/append.rs
@@ -1,7 +1,16 @@
 #![allow(unused_allocation, clippy::unnecessary_to_owned)]
 
-use alloc::vec::{self, Vec};
 use core::{array, ops::Deref};
+
+use alloc::{
+    string,
+    vec::{self, Vec},
+};
+
+use std::{
+    boxed::Box,
+    string::{String, ToString},
+};
 
 use crate::{
     owned_slice::{self, OwnedSlice, TakeOwnedSlice},

--- a/src/tests/bump_allocator.rs
+++ b/src/tests/bump_allocator.rs
@@ -1,3 +1,8 @@
+use std::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use crate::{Bump, BumpAllocator, BumpVec, MutBumpAllocator, MutBumpVec};
 
 fn number_strings(numbers: impl IntoIterator<Item = i32>) -> impl Iterator<Item = String> {

--- a/src/tests/bump_vec.rs
+++ b/src/tests/bump_vec.rs
@@ -1,9 +1,17 @@
 #![allow(clippy::manual_assert)]
-use core::hint::black_box;
+
+use std::{
+    boxed::Box,
+    dbg, format,
+    hint::black_box,
+    string::{String, ToString},
+};
+
+use allocator_api2::alloc::Global;
+
+use crate::{bump_vec, tests::expect_no_panic, Bump, BumpVec};
 
 use super::either_way;
-use crate::{bump_vec, tests::expect_no_panic, Bump, BumpVec};
-use allocator_api2::alloc::Global;
 
 either_way! {
     shrinks

--- a/src/tests/coerce_unsized.rs
+++ b/src/tests/coerce_unsized.rs
@@ -1,5 +1,6 @@
+use std::{dbg, fmt::Debug, future::Future};
+
 use crate::{Bump, BumpBox};
-use core::{fmt::Debug, future::Future};
 
 #[test]
 fn slice() {

--- a/src/tests/fixed_bump_vec.rs
+++ b/src/tests/fixed_bump_vec.rs
@@ -1,9 +1,18 @@
 #![allow(clippy::manual_assert)]
-use core::hint::black_box;
+
+use std::{
+    boxed::Box,
+    dbg, format,
+    hint::black_box,
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use allocator_api2::alloc::Global;
+
+use crate::{bump_vec, tests::expect_no_panic, Bump, FixedBumpVec};
 
 use super::either_way;
-use crate::{bump_vec, tests::expect_no_panic, Bump, FixedBumpVec};
-use allocator_api2::alloc::Global;
 
 either_way! {
     map_in_place_same_layout

--- a/src/tests/from_std/bump_string.rs
+++ b/src/tests/from_std/bump_string.rs
@@ -1,8 +1,14 @@
 use std::{
     assert_matches::assert_matches,
     cell::Cell,
-    ops::{Bound, Bound::*, RangeBounds},
+    ops::{
+        Bound::{self, *},
+        RangeBounds,
+    },
     panic, str,
+    string::String,
+    vec,
+    vec::Vec,
 };
 
 use crate::{bump_format, bump_vec, Bump, BumpString, BumpVec};

--- a/src/tests/from_std/bump_vec.rs
+++ b/src/tests/from_std/bump_vec.rs
@@ -1,29 +1,31 @@
 //! Adapted from rust's `library/alloc/tests/vec.rs` commit f7ca9df69549470541fbf542f87a03eb9ed024b6
 
 use allocator_api2::alloc::{AllocError, Allocator, Layout};
-#[cfg(feature = "std")]
-use std::alloc::System;
-#[cfg(not(feature = "std"))]
-use std::alloc::System;
+
 use std::{
+    alloc::System,
     assert_eq,
     assert_matches::assert_matches,
     borrow::Cow,
+    boxed::Box,
     cell::Cell,
+    dbg,
     fmt::Debug,
-    hint,
+    format, hint,
     iter::{InPlaceIterable, IntoIterator},
     mem::{self, size_of, swap},
     num::NonZeroUsize,
     ops::Bound::*,
     panic::{catch_unwind, AssertUnwindSafe},
+    println,
     ptr::NonNull,
     rc::Rc,
+    string::{String, ToString},
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex, PoisonError,
     },
-    vec::{Drain, IntoIter},
+    vec::{Drain, IntoIter, Vec},
 };
 
 use crate::{bump_vec, Bump, BumpVec};

--- a/src/tests/from_std/mut_bump_vec.rs
+++ b/src/tests/from_std/mut_bump_vec.rs
@@ -1,18 +1,15 @@
 //! Adapted from rust's `library/alloc/tests/vec.rs` commit f7ca9df69549470541fbf542f87a03eb9ed024b6
 
-use crate::{mut_bump_vec, Bump, MutBumpVec};
-use allocator_api2::alloc::{AllocError, Allocator, Layout};
-#[cfg(feature = "std")]
-use std::alloc::System;
-#[cfg(not(feature = "std"))]
-use std::alloc::System;
 use std::{
+    alloc::System,
     assert_eq,
     assert_matches::assert_matches,
     borrow::Cow,
+    boxed::Box,
     cell::Cell,
+    dbg,
     fmt::Debug,
-    hint,
+    format, hint,
     iter::{InPlaceIterable, IntoIterator},
     mem::{self, size_of, swap},
     num::NonZeroUsize,
@@ -20,12 +17,17 @@ use std::{
     panic::{catch_unwind, AssertUnwindSafe},
     ptr::NonNull,
     rc::Rc,
+    string::{String, ToString},
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex, PoisonError,
     },
-    vec::{Drain, IntoIter},
+    vec::{Drain, IntoIter, Vec},
 };
+
+use allocator_api2::alloc::{AllocError, Allocator, Layout};
+
+use crate::{mut_bump_vec, Bump, MutBumpVec};
 
 struct DropCounter<'a> {
     count: &'a mut u32,

--- a/src/tests/from_std/mut_bump_vec_rev.rs
+++ b/src/tests/from_std/mut_bump_vec_rev.rs
@@ -1,18 +1,14 @@
 //! Adapted from rust's `library/alloc/tests/vec.rs` commit f7ca9df69549470541fbf542f87a03eb9ed024b6
 
-use crate::{mut_bump_vec_rev, Bump, MutBumpVecRev};
-use allocator_api2::alloc::{AllocError, Allocator, Layout};
-#[cfg(feature = "std")]
-use std::alloc::System;
-#[cfg(not(feature = "std"))]
-use std::alloc::System;
 use std::{
+    alloc::System,
     assert_eq,
     assert_matches::assert_matches,
     borrow::Cow,
+    boxed::Box,
     cell::Cell,
     fmt::Debug,
-    hint,
+    format, hint,
     iter::{InPlaceIterable, IntoIterator},
     mem::{self, size_of, swap},
     num::NonZeroUsize,
@@ -20,12 +16,17 @@ use std::{
     panic::{catch_unwind, AssertUnwindSafe},
     ptr::NonNull,
     rc::Rc,
+    string::String,
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex, PoisonError,
     },
     vec::{Drain, IntoIter},
 };
+
+use allocator_api2::alloc::{AllocError, Allocator, Layout};
+
+use crate::{mut_bump_vec_rev, Bump, MutBumpVecRev};
 
 struct DropCounter<'a> {
     count: &'a mut u32,

--- a/src/tests/from_std/rc_bump_vec.rs
+++ b/src/tests/from_std/rc_bump_vec.rs
@@ -1,17 +1,15 @@
 //! Adapted from rust's `library/alloc/tests/vec.rs` commit f7ca9df69549470541fbf542f87a03eb9ed024b6
 
-use allocator_api2::alloc::{AllocError, Allocator, Layout};
-#[cfg(feature = "std")]
-use std::alloc::System;
-#[cfg(not(feature = "std"))]
-use std::alloc::System;
 use std::{
+    alloc::System,
     assert_eq,
     assert_matches::assert_matches,
     borrow::Cow,
+    boxed::Box,
     cell::Cell,
+    dbg,
     fmt::Debug,
-    hint,
+    format, hint,
     iter::{InPlaceIterable, IntoIterator},
     mem::{self, size_of, swap},
     num::NonZeroUsize,
@@ -19,12 +17,15 @@ use std::{
     panic::{catch_unwind, AssertUnwindSafe},
     ptr::NonNull,
     rc::Rc,
+    string::{String, ToString},
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex, PoisonError,
     },
-    vec::{Drain, IntoIter},
+    vec::{Drain, IntoIter, Vec},
 };
+
+use allocator_api2::alloc::{AllocError, Allocator, Layout};
 
 use crate::{bump_vec, tests::RcBump, BumpVec};
 
@@ -1519,7 +1520,7 @@ fn extract_if_complex() {
 #[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn extract_if_consumed_panic() {
-    use std::{rc::Rc, sync::Mutex};
+    use std::{println, rc::Rc, sync::Mutex};
 
     struct Check {
         index: usize,
@@ -1573,7 +1574,7 @@ fn extract_if_consumed_panic() {
 #[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn extract_if_unconsumed_panic() {
-    use std::{rc::Rc, sync::Mutex};
+    use std::{println, rc::Rc, sync::Mutex};
 
     struct Check {
         index: usize,

--- a/src/tests/grow_vec.rs
+++ b/src/tests/grow_vec.rs
@@ -1,3 +1,8 @@
+use std::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use crate::{Bump, BumpVec, MutBumpVec, MutBumpVecRev};
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,18 +1,6 @@
 #![allow(unused_imports, clippy::incompatible_msrv)]
 #![cfg(feature = "std")]
 
-use core::{
-    alloc::Layout,
-    any::Any,
-    cell::Cell,
-    fmt::Debug,
-    mem,
-    ops::Index,
-    ptr::NonNull,
-    sync::atomic::{AtomicUsize, Ordering},
-};
-use std::io::IoSlice;
-
 mod alloc_cstr;
 mod alloc_fmt;
 mod alloc_iter;
@@ -44,7 +32,25 @@ mod unaligned_collection;
 mod unallocated;
 mod vec;
 
-extern crate std;
+use core::{
+    alloc::Layout,
+    any::Any,
+    cell::Cell,
+    fmt::Debug,
+    mem,
+    ops::Index,
+    ptr::NonNull,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use std::{
+    boxed::Box,
+    dbg, eprintln,
+    io::IoSlice,
+    string::{String, ToString},
+    thread_local,
+    vec::Vec,
+};
 
 type Result<T = (), E = AllocError> = core::result::Result<T, E>;
 
@@ -88,7 +94,7 @@ macro_rules! either_way {
                 #[test]
                 $(#[$attr])*
                 fn $ident() {
-                    eprintln!("`UP` is `true`");
+                    std::eprintln!("`UP` is `true`");
                     super::$ident::<true>();
                 }
             )*
@@ -99,7 +105,7 @@ macro_rules! either_way {
                 #[test]
                 $(#[$attr])*
                 fn $ident() {
-                    eprintln!("`UP` is `false`");
+                    std::eprintln!("`UP` is `false`");
                     super::$ident::<false>();
                 }
             )*

--- a/src/tests/panic_safety.rs
+++ b/src/tests/panic_safety.rs
@@ -1,14 +1,14 @@
-use crate::{bump_vec, mut_bump_vec, mut_bump_vec_rev, Bump, BumpVec, MutBumpVec, MutBumpVecRev};
-use core::{
-    cell::Cell,
-    mem::ManuallyDrop,
-    panic::{RefUnwindSafe, UnwindSafe},
-};
 use std::{
+    cell::Cell,
     hint::black_box,
-    panic::catch_unwind,
+    mem::ManuallyDrop,
+    panic::{catch_unwind, RefUnwindSafe, UnwindSafe},
+    string::String,
     sync::{Mutex, PoisonError},
+    thread_local,
 };
+
+use crate::{bump_vec, mut_bump_vec, mut_bump_vec_rev, Bump, BumpVec, MutBumpVec, MutBumpVecRev};
 
 macro_rules! zst_or_not {
     (
@@ -141,11 +141,13 @@ fn mut_bump_vec_rev_extend_from_slice<T: Testable>() {
 use helper::{assert_initialized, expected_drops, Testable};
 
 mod helper {
-    use core::{
+    use std::{
         array,
         cell::Cell,
         hint::black_box,
         panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe},
+        string::String,
+        thread_local,
     };
 
     pub fn assert_initialized(iter: impl IntoIterator) {

--- a/src/tests/pool.rs
+++ b/src/tests/pool.rs
@@ -1,7 +1,11 @@
-use super::either_way;
-use crate::BumpPool;
+use std::vec::Vec;
+
 use allocator_api2::alloc::Global;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use crate::BumpPool;
+
+use super::either_way;
 
 either_way! {
     rayon

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -1,6 +1,10 @@
-use super::*;
-use crate::{bump_format, bump_vec};
+use std::vec;
+
 use ::serde::{de::DeserializeSeed, Serialize};
+
+use crate::{bump_format, bump_vec};
+
+use super::*;
 
 fn assert_same<A: Serialize, B: Serialize>(a: &A, b: &B) {
     let a_json = serde_json::to_string(a).unwrap();

--- a/src/tests/split_off.rs
+++ b/src/tests/split_off.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::similar_names)]
 
+use std::{string::String, vec};
+
 use crate::{bump_vec, Bump, BumpString, BumpVec};
 
 use super::TestWrap;

--- a/src/tests/test_wrap.rs
+++ b/src/tests/test_wrap.rs
@@ -1,5 +1,7 @@
 use core::{cell::Cell, convert::Infallible, fmt};
 
+use std::thread_local;
+
 thread_local! {
     static DROPS: Cell<usize> = const { Cell::new(0) };
     static CLONES: Cell<usize> = const { Cell::new(0) };

--- a/src/tests/unaligned_collection.rs
+++ b/src/tests/unaligned_collection.rs
@@ -1,3 +1,5 @@
+use std::dbg;
+
 use super::*;
 
 either_way! {


### PR DESCRIPTION
Instead of
```rust
#![cfg_attr(not(any(test, feature = "std")), no_std)]
```
lets use 
```rust
#![no_std]

#[cfg(any(feature = "std", test))]
extern crate std;
```

This ...
- makes more sense because features should be additive.
- improves consistency between `no_std` and `std` code.
- makes it explicit when and what of `std` is actually used.

See this discussion on reddit: https://www.reddit.com/r/rust/comments/1hs6spy/psa_for_std_feature_in_no_std_libraries/