### PR TITLE
Simpler `Debug::fmt` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **changed:** simpler and shorter `Debug` output for `Bump(Scope(Guard(Root)))` and `Chunk(NextIter, PrevIter)`
+
 ## 0.16.1 (2025-01-22)
 - **fixed:** double-dropping elements when calling `into_flattened`
 - **added:** `(try_)replace_range` and `as_(mut_)ptr` to strings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ use core::convert::Infallible;
 use core::{
     alloc::Layout,
     ffi::CStr,
-    fmt::{self, Debug},
+    fmt,
     mem::{self, MaybeUninit},
     num::NonZeroUsize,
     ptr::NonNull,
@@ -460,19 +460,6 @@ fn bump_down(addr: NonZeroUsize, size: usize, align: usize) -> usize {
 const unsafe fn assume_unchecked(condition: bool) {
     if !condition {
         core::hint::unreachable_unchecked();
-    }
-}
-
-struct FmtFn<F>(F)
-where
-    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result;
-
-impl<F> Debug for FmtFn<F>
-where
-    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0(f)
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -62,8 +62,8 @@ const OVERHEAD: usize = MALLOC_OVERHEAD + size_of::<ChunkHeader<Global>>();
 
 use crate::{
     chunk_size::AssumedMallocOverhead, mut_bump_format, mut_bump_vec, mut_bump_vec_rev, owned_slice, panic_on_error,
-    stats::Chunk, Bump, BumpBox, BumpScope, BumpString, BumpVec, ChunkHeader, ChunkSize, FmtFn, MinimumAlignment,
-    MutBumpString, MutBumpVec, MutBumpVecRev, SizedTypeProperties, SupportedMinimumAlignment,
+    stats::Chunk, Bump, BumpBox, BumpScope, BumpString, BumpVec, ChunkHeader, ChunkSize, MinimumAlignment, MutBumpString,
+    MutBumpVec, MutBumpVecRev, SizedTypeProperties, SupportedMinimumAlignment,
 };
 
 use allocator_api2::alloc::Global as System;
@@ -386,8 +386,7 @@ fn macro_syntax<const UP: bool>() {
 fn debug_sizes<const UP: bool>(bump: &Bump<Global, 1, UP>) {
     let iter = bump.stats().small_to_big();
     let vec = iter.map(Chunk::size).collect::<Vec<_>>();
-    let sizes = FmtFn(|f| write!(f, "{vec:?}"));
-    dbg!(sizes);
+    eprintln!("sizes: {vec:?}");
 }
 
 fn force_alloc_new_chunk<const UP: bool>(bump: &BumpScope<Global, 1, UP>) {


### PR DESCRIPTION
Currently the Debug implementation prints details that are noisy and too opinionated. 

Lets only keep around the "allocated" field for now.