### PR TITLE
Implement `Fn*` traits for `BumpBox`

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -56,6 +56,7 @@
     "haha",
     "hashbrown",
     "Hasher",
+    "impls",
     "inplace",
     "insertable",
     "justfile",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **added:** `BumpBox<T>` now implements the `Fn*` traits if `T` does (just like `Box`). This requires the new `"nightly-fn-traits"` feature.
+
 ## 0.16.3 (2025-02-21)
 - **added:** `capacity` field to the `Debug` representation of `Stats` and `Bump(Scope(Guard(Root)))`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ nightly-exact-size-is-empty = []
 ## Implements `TrustedLen` for some iterators.
 nightly-trusted-len = []
 
+## Implements `Fn*` traits for `BumpBox<T>`. Makes `BumpBox<T: FnOnce>` callable. Requires alloc crate.
+nightly-fn-traits = []
+
 [dev-dependencies]
 trybuild = "1.0.90"
 expect-test = "1.4.1"

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ assert_eq!(bump.stats().allocated(), 4);
   You can unsize a `BumpBox` in stable without this feature using [`unsize_bump_box`].
 * **`nightly-exact-size-is-empty`** —  Implements `is_empty` manually for some iterators.
 * **`nightly-trusted-len`** —  Implements `TrustedLen` for some iterators.
+* **`nightly-fn-traits`** —  Implements `Fn*` traits for `BumpBox<T>`. Makes `BumpBox<T: FnOnce>` callable. Requires alloc crate.
 
 ## Bumping upwards or downwards?
 Bump direction is controlled by the generic parameter `const UP: bool`. By default, `UP` is `true`, so the allocator bumps upwards.

--- a/src/bump_box.rs
+++ b/src/bump_box.rs
@@ -3099,9 +3099,10 @@ impl<Args: Tuple, F: FnOnce<Args> + ?Sized> FnOnce<Args> for BumpBox<'_, F> {
     type Output = <F as FnOnce<Args>>::Output;
 
     extern "rust-call" fn call_once(self, args: Args) -> Self::Output {
-        use alloc::boxed::Box;
-
-        use allocator_api2::alloc::{AllocError, Allocator};
+        use alloc::{
+            alloc::{AllocError, Allocator},
+            boxed::Box,
+        };
 
         struct NoopAllocator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,15 @@
 // Especially `BumpBox` methods, vectors, strings, `polyfill` and `tests/from_std` are based on code from the standard library.
 
 #![no_std]
-#![cfg_attr(feature = "nightly-allocator-api", feature(allocator_api, vec_into_raw_parts))]
+#![cfg_attr(
+    any(feature = "nightly-allocator-api", feature = "nightly-fn-traits"),
+    feature(allocator_api)
+)]
+#![cfg_attr(feature = "nightly-allocator-api", feature(vec_into_raw_parts))]
 #![cfg_attr(feature = "nightly-coerce-unsized", feature(coerce_unsized, unsize))]
 #![cfg_attr(feature = "nightly-exact-size-is-empty", feature(exact_size_is_empty))]
 #![cfg_attr(feature = "nightly-trusted-len", feature(trusted_len))]
+#![cfg_attr(feature = "nightly-fn-traits", feature(fn_traits, tuple_trait, unboxed_closures))]
 #![cfg_attr(
     test,
     feature(
@@ -242,6 +247,7 @@
 //!   You can unsize a `BumpBox` in stable without this feature using [`unsize_bump_box`].
 //! * **`nightly-exact-size-is-empty`** —  Implements `is_empty` manually for some iterators.
 //! * **`nightly-trusted-len`** —  Implements `TrustedLen` for some iterators.
+//! * **`nightly-fn-traits`** —  Implements `Fn*` traits for `BumpBox<T>`. Makes `BumpBox<T: FnOnce>` callable. Requires alloc crate.
 //!
 //! # Bumping upwards or downwards?
 //! Bump direction is controlled by the generic parameter `const UP: bool`. By default, `UP` is `true`, so the allocator bumps upwards.
@@ -275,7 +281,7 @@
 #[cfg(any(feature = "std", test))]
 extern crate std;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "nightly-fn-traits"))]
 extern crate alloc;
 
 mod allocator;

--- a/src/tests/fn_traits.rs
+++ b/src/tests/fn_traits.rs
@@ -1,0 +1,55 @@
+use std::{panic::catch_unwind, string::String};
+
+use crate::{Bump, BumpBox};
+
+#[test]
+fn fn_once() {
+    let bump: Bump = Bump::new();
+
+    let x: BumpBox<dyn FnOnce()> = bump.alloc(|| {});
+    (x)();
+
+    // making sure the string is dropped
+    let string = String::from("hello world");
+    let x: BumpBox<dyn FnOnce()> = bump.alloc(move || drop(string));
+    (x)();
+
+    let string = String::from("hello world");
+    let x: BumpBox<dyn FnOnce()> = bump.alloc(move || drop(string));
+    drop(x);
+
+    #[allow(unused_variables)]
+    catch_unwind(|| {
+        let string = String::from("hello world");
+        let x: BumpBox<dyn FnOnce()> = bump.alloc(move || {
+            panic!("a");
+            #[allow(unreachable_code)]
+            drop(string);
+        });
+        (x)();
+    })
+    .unwrap_err();
+}
+
+#[test]
+fn does_impl() {
+    fn impls_fn_once<T: FnOnce()>(_: &T) {}
+    fn impls_fn_mut<T: FnMut()>(_: &T) {}
+    fn impls_fn<T: Fn()>(_: &T) {}
+
+    let bump: Bump = Bump::new();
+
+    let f = bump.alloc(|| {});
+    impls_fn_once(&f);
+    impls_fn_mut(&f);
+    impls_fn(&f);
+
+    let mut string = String::from("hello");
+    let f = bump.alloc(|| string.push('x'));
+    impls_fn_once(&f);
+    impls_fn_mut(&f);
+
+    let string = String::from("hello");
+    let f = bump.alloc(|| drop(string));
+    impls_fn_once(&f);
+}

--- a/src/tests/fn_traits.rs
+++ b/src/tests/fn_traits.rs
@@ -52,4 +52,18 @@ fn does_impl() {
     let string = String::from("hello");
     let f = bump.alloc(|| drop(string));
     impls_fn_once(&f);
+
+    let f: BumpBox<dyn Fn()> = bump.alloc(|| {});
+    impls_fn_once(&f);
+    impls_fn_mut(&f);
+    impls_fn(&f);
+
+    let mut string = String::from("hello");
+    let f: BumpBox<dyn FnMut()> = bump.alloc(|| string.push('x'));
+    impls_fn_once(&f);
+    impls_fn_mut(&f);
+
+    let string = String::from("hello");
+    let f: BumpBox<dyn FnOnce()> = bump.alloc(|| drop(string));
+    impls_fn_once(&f);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -36,7 +36,7 @@ mod chunk_size;
 #[cfg(feature = "nightly-coerce-unsized")]
 mod coerce_unsized;
 mod fixed_bump_vec;
-#[cfg(feature = "nightly-fn-traits")]
+#[cfg(all(feature = "nightly-fn-traits", feature = "nightly-coerce-unsized"))]
 mod fn_traits;
 mod from_std;
 mod grow_vec;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -36,6 +36,8 @@ mod chunk_size;
 #[cfg(feature = "nightly-coerce-unsized")]
 mod coerce_unsized;
 mod fixed_bump_vec;
+#[cfg(feature = "nightly-fn-traits")]
+mod fn_traits;
 mod from_std;
 mod grow_vec;
 mod into_flattened;


### PR DESCRIPTION
Fixes #43 

With this PR, `BumpBox` implements the `Fn*` traits just like `Box` does. This makes it possible to call `BumpBox<T: FnOnce>`.

This is gated behind the new "nightly-fn-traits" feature as it requires a nightly compiler and pulls in the alloc crate. (We need `Box` to implement `FnOnce` afaict.)
