### PR TITLE
Fix `Stats` reporting wrong values for non-ZST base allocators 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - **breaking:** the `zerocopy` feature has been renamed to `zerocopy-08`. All methods that this feature added are no longer inherent methods but are provided via extension traits from `bump_scope::zerocopy_08`.
 - **breaking:** removed deprecated methods `(try_)extend_from_array`
 - **breaking:** changed `bump_format!` implementation to not call `$bump.as_scope()` but use `$bump` as is. This is what `mut_bump_format!` and the `bump_vec` macros are already doing.
-- **breaking:** added `UP` generic parameter to `Stats`, `Chunk` and associated types
+- **breaking:** added `A` and `UP` generic parameters to `Stats`, `Chunk` and associated types
 - **breaking:** the `stats` method of `BumpAllocator`, strings and vectors return `AnyStats` now instead of `Stats`
 - **deprecated:** `FixedBumpVec::EMPTY`, use `FixedBumpVec::new()` instead
 - **deprecated:** `FixedBumpString::EMPTY`, use `FixedBumpString::new()` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **breaking:** the `zerocopy` feature has been renamed to `zerocopy-08`. All methods that this feature added are no longer inherent methods but are provided via extension traits from `bump_scope::zerocopy_08`.
 - **breaking:** removed deprecated methods `(try_)extend_from_array`
 - **breaking:** changed `bump_format!` implementation to not call `$bump.as_scope()` but use `$bump` as is. This is what `mut_bump_format!` and the `bump_vec` macros are already doing.
+- **breaking:** added `UP` generic parameter to `Stats`, `Chunk` and associated types
+- **breaking:** the `stats` method of `BumpAllocator`, strings and vectors return `AnyStats` now instead of `Stats`
 - **deprecated:** `FixedBumpVec::EMPTY`, use `FixedBumpVec::new()` instead
 - **deprecated:** `FixedBumpString::EMPTY`, use `FixedBumpString::new()` instead
 - **deprecated:** `alloc_fixed_vec`, use `FixedBumpVec::with_capacity_in` instead
@@ -21,7 +23,9 @@
 - **added:** `{BumpVec, MutBumpVec, MutBumpVecRev}::from_owned_slice_in`
 - **added:** `{MutBumpVec, MutBumpVecRev}::from_iter_exact_in`
 - **added:** `as_non_null` to boxed str and string types
-- **fix:** `serde` to compile without `alloc` feature
+- **added:** `AnyStats`, `AnyChunk` and associated types as type erased versions of their non-`Any*` variants
+- **fixed:** `serde` compiles without `alloc` feature
+- **fixed:** `Stats` and `Chunk` not reporting accurate sizes and pointers if the base allocator is not zero sized
 
 ### Migration Guide
 - If you are bump allocating `hashbrown` types you have to enable the `allocator-api2-02` feature unless you are using `hashbrown`'s `nightly` feature then you only need the `nightly-allocator-api` feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **breaking:** changed `bump_format!` implementation to not call `$bump.as_scope()` but use `$bump` as is. This is what `mut_bump_format!` and the `bump_vec` macros are already doing.
 - **breaking:** added `A` and `UP` generic parameters to `Stats`, `Chunk` and associated types
 - **breaking:** the `stats` method of `BumpAllocator`, strings and vectors return `AnyStats` now instead of `Stats`
+- **breaking:** `Stats` is no longer re-exported at the crate level, you can import it from `bump_scope::stats::Stats`
 - **deprecated:** `FixedBumpVec::EMPTY`, use `FixedBumpVec::new()` instead
 - **deprecated:** `FixedBumpString::EMPTY`, use `FixedBumpString::new()` instead
 - **deprecated:** `alloc_fixed_vec`, use `FixedBumpVec::with_capacity_in` instead
@@ -31,6 +32,8 @@
 - If you are bump allocating `hashbrown` types you have to enable the `allocator-api2-02` feature unless you are using `hashbrown`'s `nightly` feature then you only need the `nightly-allocator-api` feature.
 - If you are using the methods `alloc_zeroed(_slice)`, `init_zeroed`, `resize_zeroed` or `extend_zeroed` you now have to enable the `zerocopy-08` feature (instead of `zerocopy`) and import the respective extension traits from `bump_scope::zerocopy_08`.
 - If you were using a custom base allocator you now have to make it implement this crate's `Allocator` trait. You can safely do that using a wrapper type from the `bump_scope::alloc::compat` module.
+- Uses of `bump_format!(in bump, ...` where `bump` is not a reference now have to write `bump_format!(in &bump, ...` for the same behavior
+- There are other less impactful breaking changes that you might encounter. You can read about them above.
 
 ## 0.16.5 (2025-05-09)
 - **added:** `pop_if` method to vector types

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -13,7 +13,7 @@ use crate::{
     bump_common_methods,
     chunk_size::ChunkSize,
     polyfill::{pointer, transmute_mut, transmute_ref},
-    stats::Stats,
+    stats::{AnyStats, Stats},
     unallocated_chunk_header, BaseAllocator, BumpBox, BumpScope, BumpScopeGuardRoot, Checkpoint, ErrorBehavior,
     FixedBumpString, FixedBumpVec, MinimumAlignment, RawChunk, SupportedMinimumAlignment,
 };
@@ -245,7 +245,7 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.stats().debug_format("Bump", f)
+        AnyStats::from(self.stats()).debug_format("Bump", f)
     }
 }
 

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -492,7 +492,7 @@ where
     #[cfg_attr(feature = "nightly-tests", doc = "```")]
     #[cfg_attr(not(feature = "nightly-tests"), doc = "```ignore")]
     /// # #![feature(pointer_is_aligned_to)]
-    /// # use bump_scope::{Bump, Stats};
+    /// # use bump_scope::Bump;
     /// let mut bump: Bump = Bump::new();
     ///
     /// // bump starts off by being aligned to 16

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -13,8 +13,9 @@ use crate::{
     bump_common_methods,
     chunk_size::ChunkSize,
     polyfill::{pointer, transmute_mut, transmute_ref},
+    stats::Stats,
     unallocated_chunk_header, BaseAllocator, BumpBox, BumpScope, BumpScopeGuardRoot, Checkpoint, ErrorBehavior,
-    FixedBumpString, FixedBumpVec, MinimumAlignment, RawChunk, Stats, SupportedMinimumAlignment,
+    FixedBumpString, FixedBumpVec, MinimumAlignment, RawChunk, SupportedMinimumAlignment,
 };
 
 #[cfg(feature = "panic-on-alloc")]

--- a/src/bump_allocator.rs
+++ b/src/bump_allocator.rs
@@ -4,7 +4,8 @@ use crate::{
     alloc::{AllocError, Allocator},
     bump_down,
     polyfill::nonnull,
-    up_align_usize_unchecked, BaseAllocator, Bump, BumpScope, MinimumAlignment, SizedTypeProperties, Stats,
+    stats::AnyStats,
+    up_align_usize_unchecked, BaseAllocator, Bump, BumpScope, MinimumAlignment, SizedTypeProperties,
     SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
 };
 
@@ -41,8 +42,8 @@ use crate::{handle_alloc_error, panic_on_error};
 #[allow(clippy::missing_errors_doc)]
 pub unsafe trait BumpAllocator: Allocator {
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
-    fn stats(&self) -> Stats<'_> {
-        Stats::unallocated()
+    fn stats(&self) -> AnyStats<'_> {
+        AnyStats::default()
     }
 
     /// A specialized version of [`allocate`](Allocator::allocate).
@@ -169,7 +170,7 @@ pub unsafe trait BumpAllocator: Allocator {
 
 unsafe impl<A: BumpAllocator> BumpAllocator for &A {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
+    fn stats(&self) -> AnyStats<'_> {
         A::stats(self)
     }
 
@@ -226,7 +227,7 @@ unsafe impl<A: BumpAllocator> BumpAllocator for &A {
 
 unsafe impl<A: BumpAllocator> BumpAllocator for WithoutDealloc<A> {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
+    fn stats(&self) -> AnyStats<'_> {
         A::stats(&self.0)
     }
 
@@ -283,7 +284,7 @@ unsafe impl<A: BumpAllocator> BumpAllocator for WithoutDealloc<A> {
 
 unsafe impl<A: BumpAllocator> BumpAllocator for WithoutShrink<A> {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
+    fn stats(&self) -> AnyStats<'_> {
         A::stats(&self.0)
     }
 
@@ -345,8 +346,8 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
-        BumpScope::stats(self).not_guaranteed_allocated()
+    fn stats(&self) -> AnyStats<'_> {
+        BumpScope::stats(self).into()
     }
 
     #[inline(always)]
@@ -452,8 +453,8 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
-        Bump::stats(self).not_guaranteed_allocated()
+    fn stats(&self) -> AnyStats<'_> {
+        Bump::stats(self).into()
     }
 
     #[inline(always)]
@@ -517,8 +518,8 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
-        BumpScope::stats(self).not_guaranteed_allocated()
+    fn stats(&self) -> AnyStats<'_> {
+        BumpScope::stats(self).into()
     }
 
     #[inline(always)]
@@ -579,8 +580,8 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
-    fn stats(&self) -> Stats<'_> {
-        Bump::stats(self).not_guaranteed_allocated()
+    fn stats(&self) -> AnyStats<'_> {
+        Bump::stats(self).into()
     }
 
     #[inline(always)]

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -132,7 +132,7 @@ where
     #[cfg_attr(feature = "nightly-tests", doc = "```")]
     #[cfg_attr(not(feature = "nightly-tests"), doc = "```ignore")]
     /// # #![feature(pointer_is_aligned_to)]
-    /// # use bump_scope::{Bump, Stats};
+    /// # use bump_scope::Bump;
     /// let mut bump: Bump = Bump::new();
     ///
     /// // bump starts off by being aligned to 16

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -20,7 +20,7 @@ use crate::{
     const_param_assert, down_align_usize,
     layout::{ArrayLayout, CustomLayout, LayoutProps, SizedLayout},
     polyfill::{nonnull, pointer, transmute_mut, transmute_ref},
-    stats::Stats,
+    stats::{AnyStats, Stats},
     up_align_usize_unchecked, BaseAllocator, BumpBox, BumpScopeGuard, BumpString, BumpVec, Checkpoint, ErrorBehavior,
     FixedBumpString, FixedBumpVec, MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev, NoDrop, RawChunk,
     SizedTypeProperties, SupportedMinimumAlignment,
@@ -93,7 +93,7 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.stats().debug_format("BumpScope", f)
+        AnyStats::from(self.stats()).debug_format("BumpScope", f)
     }
 }
 

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -340,8 +340,7 @@ where
     #[inline]
     pub unsafe fn reset_to(&self, checkpoint: Checkpoint) {
         debug_assert!(self.stats().big_to_small().any(|chunk| {
-            chunk.header == checkpoint.chunk.cast()
-                && crate::stats::raw!(chunk.contains_addr_or_end(checkpoint.address.get()))
+            chunk.header == checkpoint.chunk.cast() && chunk.contains_addr_or_end(checkpoint.address.get())
         }));
 
         checkpoint.reset_within_chunk();

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -20,9 +20,10 @@ use crate::{
     const_param_assert, down_align_usize,
     layout::{ArrayLayout, CustomLayout, LayoutProps, SizedLayout},
     polyfill::{nonnull, pointer, transmute_mut, transmute_ref},
+    stats::Stats,
     up_align_usize_unchecked, BaseAllocator, BumpBox, BumpScopeGuard, BumpString, BumpVec, Checkpoint, ErrorBehavior,
     FixedBumpString, FixedBumpVec, MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev, NoDrop, RawChunk,
-    SizedTypeProperties, Stats, SupportedMinimumAlignment,
+    SizedTypeProperties, SupportedMinimumAlignment,
 };
 
 #[cfg(feature = "panic-on-alloc")]

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -1,8 +1,10 @@
 use core::{fmt::Debug, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 
 use crate::{
-    chunk_header::ChunkHeader, polyfill::nonnull, stats::Stats, BaseAllocator, Bump, BumpScope, MinimumAlignment, RawChunk,
-    SupportedMinimumAlignment,
+    chunk_header::ChunkHeader,
+    polyfill::nonnull,
+    stats::{AnyStats, Stats},
+    BaseAllocator, Bump, BumpScope, MinimumAlignment, RawChunk, SupportedMinimumAlignment,
 };
 
 /// This is returned from [`checkpoint`](Bump::checkpoint) and used for [`reset_to`](Bump::reset_to).
@@ -42,7 +44,7 @@ where
     A: BaseAllocator,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.stats().debug_format("BumpScopeGuard", f)
+        AnyStats::from(self.stats()).debug_format("BumpScopeGuard", f)
     }
 }
 
@@ -130,7 +132,7 @@ where
     A: BaseAllocator,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.stats().debug_format("BumpScopeGuardRoot", f)
+        AnyStats::from(self.stats()).debug_format("BumpScopeGuardRoot", f)
     }
 }
 

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -94,7 +94,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, A, UP, true> {
+    pub fn stats(&self) -> Stats<'a, A, UP> {
         let header = self.chunk.header_ptr().cast();
         // SAFETY: `header` points to a valid chunk header which is guaranteed allocated
         unsafe { Stats::from_header_unchecked(header) }

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -1,7 +1,7 @@
 use core::{fmt::Debug, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 
 use crate::{
-    chunk_header::ChunkHeader, polyfill::nonnull, BaseAllocator, Bump, BumpScope, MinimumAlignment, RawChunk, Stats,
+    chunk_header::ChunkHeader, polyfill::nonnull, stats::Stats, BaseAllocator, Bump, BumpScope, MinimumAlignment, RawChunk,
     SupportedMinimumAlignment,
 };
 

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -94,7 +94,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, A, true> {
+    pub fn stats(&self) -> Stats<'a, A, UP, true> {
         let header = self.chunk.header_ptr().cast();
         // SAFETY: `header` points to a valid chunk header which is guaranteed allocated
         unsafe { Stats::from_header_unchecked(header) }
@@ -179,7 +179,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<A> {
+    pub fn stats(&self) -> Stats<A, UP> {
         let header = self.chunk.header_ptr().cast();
         // SAFETY: `header` points to a valid chunk header which is guaranteed allocated
         unsafe { Stats::from_header_unchecked(header) }

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -94,7 +94,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats<'a, true> {
+    pub fn stats(&self) -> Stats<'a, A, true> {
         let header = self.chunk.header_ptr().cast();
         // SAFETY: `header` points to a valid chunk header which is guaranteed allocated
         unsafe { Stats::from_header_unchecked(header) }
@@ -179,7 +179,7 @@ where
     /// Returns a type which provides statistics about the memory usage of the bump allocator.
     #[must_use]
     #[inline(always)]
-    pub fn stats(&self) -> Stats {
+    pub fn stats(&self) -> Stats<A> {
         let header = self.chunk.header_ptr().cast();
         // SAFETY: `header` points to a valid chunk header which is guaranteed allocated
         unsafe { Stats::from_header_unchecked(header) }

--- a/src/bump_string.rs
+++ b/src/bump_string.rs
@@ -17,7 +17,6 @@ use crate::{
     owned_str,
     polyfill::{self, transmute_mut, transmute_value},
     raw_fixed_bump_string::RawFixedBumpString,
-    stats::Stats,
     BumpAllocator, BumpAllocatorScope, BumpBox, BumpVec, ErrorBehavior, FixedBumpString, FromUtf16Error, FromUtf8Error,
 };
 

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -20,7 +20,7 @@ use crate::{
     owned_slice::{self, OwnedSlice, TakeOwnedSlice},
     polyfill::{nonnull, pointer, slice},
     raw_fixed_bump_vec::RawFixedBumpVec,
-    BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, FixedBumpVec, NoDrop, SizedTypeProperties, Stats,
+    BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, FixedBumpVec, NoDrop, SizedTypeProperties,
 };
 
 #[cfg(feature = "panic-on-alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,6 @@ mod raw_fixed_bump_string;
 mod raw_fixed_bump_vec;
 mod set_len_on_drop;
 mod set_len_on_drop_by_ptr;
-/// Types that provide statistics about the memory usage of the bump allocator.
 pub mod stats;
 mod without_dealloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ macro_rules! bump_common_methods {
                 /// Returns a type which provides statistics about the memory usage of the bump allocator.
                 #[must_use]
                 #[inline(always)]
-                pub fn stats(&self) -> Stats<'a, GUARANTEED_ALLOCATED> {
+                pub fn stats(&self) -> Stats<'a, A, GUARANTEED_ALLOCATED> {
                     let header = self.chunk.get().header_ptr().cast();
                     unsafe { Stats::from_header_unchecked(header) }
                 }
@@ -597,7 +597,7 @@ macro_rules! bump_common_methods {
                 /// Returns a type which provides statistics about the memory usage of the bump allocator.
                 #[must_use]
                 #[inline(always)]
-                pub fn stats(&self) -> Stats<GUARANTEED_ALLOCATED> {
+                pub fn stats(&self) -> Stats<A, GUARANTEED_ALLOCATED> {
                     let header = self.chunk.get().header_ptr().cast();
                     unsafe { Stats::from_header_unchecked(header) }
                 }
@@ -697,7 +697,7 @@ macro_rules! collection_method_allocator_stats {
         /// This merely exists for api parity with `Mut*` collections which can't have a `allocator` method.
         #[must_use]
         #[inline(always)]
-        pub fn allocator_stats(&self) -> Stats {
+        pub fn allocator_stats(&self) -> $crate::stats::AnyStats {
             self.allocator.stats()
         }
     };
@@ -712,7 +712,7 @@ macro_rules! mut_collection_method_allocator_stats {
         /// This collection does not update the bump pointer, so it also doesn't contribute to the `remaining` and `allocated` stats.
         #[must_use]
         #[inline(always)]
-        pub fn allocator_stats(&self) -> Stats {
+        pub fn allocator_stats(&self) -> $crate::stats::AnyStats {
             self.allocator.stats()
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,8 +371,6 @@ pub use no_drop::NoDrop;
 use private::{capacity_overflow, format_trait_error, PanicsOnAlloc};
 use raw_chunk::RawChunk;
 use set_len_on_drop::SetLenOnDrop;
-#[doc(inline)]
-pub use stats::Stats;
 pub use without_dealloc::{WithoutDealloc, WithoutShrink};
 
 #[cfg(feature = "zerocopy-08")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ macro_rules! bump_common_methods {
                 /// Returns a type which provides statistics about the memory usage of the bump allocator.
                 #[must_use]
                 #[inline(always)]
-                pub fn stats(&self) -> Stats<'a, A, GUARANTEED_ALLOCATED> {
+                pub fn stats(&self) -> Stats<'a, A, UP, GUARANTEED_ALLOCATED> {
                     let header = self.chunk.get().header_ptr().cast();
                     unsafe { Stats::from_header_unchecked(header) }
                 }
@@ -597,7 +597,7 @@ macro_rules! bump_common_methods {
                 /// Returns a type which provides statistics about the memory usage of the bump allocator.
                 #[must_use]
                 #[inline(always)]
-                pub fn stats(&self) -> Stats<A, GUARANTEED_ALLOCATED> {
+                pub fn stats(&self) -> Stats<A, UP, GUARANTEED_ALLOCATED> {
                     let header = self.chunk.get().header_ptr().cast();
                     unsafe { Stats::from_header_unchecked(header) }
                 }

--- a/src/mut_bump_string.rs
+++ b/src/mut_bump_string.rs
@@ -14,7 +14,7 @@ use crate::{
     mut_collection_method_allocator_stats, owned_str,
     polyfill::{self, transmute_mut, transmute_value},
     raw_fixed_bump_string::RawFixedBumpString,
-    BumpBox, ErrorBehavior, FromUtf16Error, FromUtf8Error, MutBumpAllocator, MutBumpAllocatorScope, MutBumpVec, Stats,
+    BumpBox, ErrorBehavior, FromUtf16Error, FromUtf8Error, MutBumpAllocator, MutBumpAllocatorScope, MutBumpVec,
 };
 
 #[cfg(feature = "panic-on-alloc")]

--- a/src/mut_bump_vec.rs
+++ b/src/mut_bump_vec.rs
@@ -16,7 +16,7 @@ use crate::{
     owned_slice::{self, OwnedSlice, TakeOwnedSlice},
     polyfill::{nonnull, pointer, slice},
     raw_fixed_bump_vec::RawFixedBumpVec,
-    BumpBox, ErrorBehavior, MutBumpAllocator, MutBumpAllocatorScope, NoDrop, SizedTypeProperties, Stats,
+    BumpBox, ErrorBehavior, MutBumpAllocator, MutBumpAllocatorScope, NoDrop, SizedTypeProperties,
 };
 
 #[cfg(feature = "panic-on-alloc")]

--- a/src/mut_bump_vec_rev.rs
+++ b/src/mut_bump_vec_rev.rs
@@ -19,7 +19,7 @@ use crate::{
     mut_collection_method_allocator_stats,
     owned_slice::{OwnedSlice, TakeOwnedSlice},
     polyfill::{self, nonnull, pointer},
-    BumpBox, ErrorBehavior, MutBumpAllocator, MutBumpAllocatorScope, NoDrop, SetLenOnDrop, SizedTypeProperties, Stats,
+    BumpBox, ErrorBehavior, MutBumpAllocator, MutBumpAllocatorScope, NoDrop, SetLenOnDrop, SizedTypeProperties,
 };
 
 #[cfg(feature = "panic-on-alloc")]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -61,7 +61,7 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> Eq for Stats<'_, A, UP
 
 impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> Debug for Stats<'_, A, UP, GUARANTEED_ALLOCATED> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.debug_format("Stats", f)
+        AnyStats::from(*self).debug_format("Stats", f)
     }
 }
 
@@ -169,13 +169,6 @@ impl<'a, A, const UP: bool, const GUARANTEED_ALLOCATED: bool> Stats<'a, A, UP, G
         }
 
         ChunkPrevIter { chunk: Some(start) }
-    }
-
-    pub(crate) fn debug_format(self, name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct(name)
-            .field("allocated", &self.allocated())
-            .field("capacity", &self.capacity())
-            .finish()
     }
 
     #[inline]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,7 +1,7 @@
 //! Contains types for inspecting memory usage in bump allocators.
 //!
 //! This module defines both generic types like [`Stats`] and type-erased counterparts prefixed
-//! with `Any*` (e.g., [`AnyStats`]). The generic types are slightly more efficient to use.
+//! with `Any*` (like [`AnyStats`]). The generic types are slightly more efficient to use.
 //! You can turn the generic types into their `Any*` variants using `from` and `into`.
 //!
 //! The `Any*` types are returned by the [`BumpAllocator`](crate::BumpAllocator) trait

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,3 +1,12 @@
+//! Contains types for inspecting memory usage in bump allocators.
+//!
+//! This module defines both generic types like [`Stats`] and type-erased counterparts prefixed
+//! with `Any*` (e.g., [`AnyStats`]). The generic types are slightly more efficient to use.
+//! You can turn the generic types into their `Any*` variants using `from` and `into`.
+//!
+//! The `Any*` types are returned by the [`BumpAllocator`](crate::BumpAllocator) trait
+//! and the `allocator_stats` method of collections whereas `Stats` is returned from [`Bump`](crate::Bump) and [`BumpScope`](crate::BumpScope).
+
 use core::{
     fmt::{self, Debug},
     iter::FusedIterator,
@@ -19,7 +28,7 @@ macro_rules! declaration {
     ($($allocator_parameter:tt)*) => {
         /// Provides statistics about the memory usage of the bump allocator.
         ///
-        /// This is returned from the `stats` method of `Bump`, `BumpScope`, `BumpScopeGuard`, `BumpVec`, ...
+        /// This is returned from the `stats` method of [`Bump`](crate::Bump) and [`BumpScope`](crate::BumpScope).
         pub struct Stats<
             'a,
             $($allocator_parameter)*,

--- a/src/stats/any.rs
+++ b/src/stats/any.rs
@@ -415,7 +415,9 @@ impl fmt::Debug for AnyChunkNextIter<'_> {
 
 #[test]
 fn check_from_impls() {
-    use crate::{BaseAllocator, Bump, BumpScope, MinimumAlignment, SupportedMinimumAlignment};
+    #![allow(dead_code, clippy::needless_lifetimes, clippy::elidable_lifetime_names)]
+
+    use crate::{BaseAllocator, BumpScope, MinimumAlignment, SupportedMinimumAlignment};
 
     fn accepting_any_stats(_: AnyStats) {}
     fn accepting_any_chunk(_: AnyChunk) {}
@@ -434,7 +436,4 @@ fn check_from_impls() {
         accepting_any_chunk_next_iter(stats.small_to_big().into());
         accepting_any_chunk_prev_iter(stats.big_to_small().into());
     }
-
-    let bump: Bump = Bump::new();
-    generic_bump(bump.as_scope());
 }

--- a/src/stats/any.rs
+++ b/src/stats/any.rs
@@ -154,7 +154,7 @@ impl<'a> From<AnyChunk<'a>> for AnyStats<'a> {
 
 /// Refers to a chunk of memory that was allocated by the bump allocator.
 ///
-/// See [`Stats`].
+/// See [`AnyStats`].
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct AnyChunk<'a> {
     header: NonNull<ChunkHeader>,
@@ -345,7 +345,7 @@ impl<'a> AnyChunk<'a> {
     }
 }
 
-/// Iterator that iterates over previous chunks by continuously calling [`Chunk::prev`].
+/// Iterator that iterates over previous chunks by continuously calling [`AnyChunk::prev`].
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub struct AnyChunkPrevIter<'a> {
     #[allow(missing_docs)]
@@ -371,7 +371,7 @@ impl fmt::Debug for AnyChunkPrevIter<'_> {
     }
 }
 
-/// Iterator that iterates over next chunks by continuously calling [`Chunk::next`].
+/// Iterator that iterates over next chunks by continuously calling [`AnyChunk::next`].
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub struct AnyChunkNextIter<'a> {
     #[allow(missing_docs)]

--- a/src/stats/any.rs
+++ b/src/stats/any.rs
@@ -1,0 +1,398 @@
+use core::{fmt, iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull};
+
+use crate::{polyfill::nonnull, ChunkHeader};
+
+use super::{Chunk, Stats};
+
+/// Provides statistics about the memory usage of the bump allocator.
+///
+/// This is returned from the `stats` method of [`BumpAllocator`](crate::BumpAllocator), strings and vectors.
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub struct AnyStats<'a> {
+    chunk: Option<AnyChunk<'a>>,
+}
+
+impl<A, const GUARANTEED_ALLOCATED: bool> From<Stats<'_, A, GUARANTEED_ALLOCATED>> for AnyStats<'_> {
+    fn from(value: Stats<'_, A, GUARANTEED_ALLOCATED>) -> Self {
+        Self {
+            chunk: value.get_current_chunk().map(Into::into),
+        }
+    }
+}
+
+impl fmt::Debug for AnyStats<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.debug_format("Stats", f)
+    }
+}
+
+impl<'a> AnyStats<'a> {
+    /// Returns the number of chunks.
+    #[must_use]
+    pub fn count(self) -> usize {
+        let current = match self.chunk {
+            Some(current) => current,
+            None => return 0,
+        };
+
+        let mut sum = 1;
+        current.iter_prev().for_each(|_| sum += 1);
+        current.iter_next().for_each(|_| sum += 1);
+        sum
+    }
+
+    /// Returns the total size of all chunks.
+    #[must_use]
+    pub fn size(self) -> usize {
+        let current = match self.chunk {
+            Some(current) => current,
+            None => return 0,
+        };
+
+        let mut sum = current.size();
+        current.iter_prev().for_each(|chunk| sum += chunk.size());
+        current.iter_next().for_each(|chunk| sum += chunk.size());
+        sum
+    }
+
+    /// Returns the total capacity of all chunks.
+    #[must_use]
+    pub fn capacity(self) -> usize {
+        let current = match self.chunk {
+            Some(current) => current,
+            None => return 0,
+        };
+
+        let mut sum = current.capacity();
+        current.iter_prev().for_each(|chunk| sum += chunk.capacity());
+        current.iter_next().for_each(|chunk| sum += chunk.capacity());
+        sum
+    }
+
+    /// Returns the amount of allocated bytes.
+    /// This includes padding and wasted space due to reallocations.
+    ///
+    /// This is not the same as the sum of the chunks' `allocated` property!
+    /// Instead this is the `allocated` of the current chunk plus the total `capacity` of all previous chunks.
+    #[must_use]
+    pub fn allocated(self) -> usize {
+        let current = match self.chunk {
+            Some(current) => current,
+            None => return 0,
+        };
+
+        let mut sum = current.allocated();
+        current.iter_prev().for_each(|chunk| sum += chunk.capacity());
+        sum
+    }
+
+    /// Returns the remaining capacity in bytes.
+    ///
+    /// This is not the same as the sum of the chunks' `remaining` property!
+    /// Instead this is the `remaining` of the current chunk plus the total `capacity` of all next chunks.
+    #[must_use]
+    pub fn remaining(self) -> usize {
+        let current = match self.chunk {
+            Some(current) => current,
+            None => return 0,
+        };
+
+        let mut sum = current.remaining();
+        current.iter_next().for_each(|chunk| sum += chunk.capacity());
+        sum
+    }
+
+    /// Returns an iterator from smallest to biggest chunk.
+    #[must_use]
+    pub fn small_to_big(self) -> AnyChunkNextIter<'a> {
+        let mut start = match self.chunk {
+            Some(start) => start,
+            None => return AnyChunkNextIter { chunk: None },
+        };
+
+        while let Some(chunk) = start.prev() {
+            start = chunk;
+        }
+
+        AnyChunkNextIter { chunk: Some(start) }
+    }
+
+    /// Returns an iterator from biggest to smallest chunk.
+    #[must_use]
+    pub fn big_to_small(self) -> AnyChunkPrevIter<'a> {
+        let mut start = match self.chunk {
+            Some(start) => start,
+            None => return AnyChunkPrevIter { chunk: None },
+        };
+
+        while let Some(chunk) = start.next() {
+            start = chunk;
+        }
+
+        AnyChunkPrevIter { chunk: Some(start) }
+    }
+
+    /// This is the chunk we are currently allocating on.
+    #[must_use]
+    pub fn current_chunk(self) -> Option<AnyChunk<'a>> {
+        self.chunk
+    }
+
+    pub(crate) fn debug_format(self, name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(name)
+            .field("allocated", &self.allocated())
+            .field("capacity", &self.capacity())
+            .finish()
+    }
+}
+
+impl<'a> From<AnyChunk<'a>> for AnyStats<'a> {
+    fn from(chunk: AnyChunk<'a>) -> Self {
+        Self { chunk: Some(chunk) }
+    }
+}
+
+/// Refers to a chunk of memory that was allocated by the bump allocator.
+///
+/// See [`Stats`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AnyChunk<'a> {
+    header: NonNull<ChunkHeader>,
+    header_size: usize,
+    marker: PhantomData<&'a ()>,
+}
+
+impl<A> From<Chunk<'_, A>> for AnyChunk<'_> {
+    fn from(value: Chunk<'_, A>) -> Self {
+        Self {
+            header: value.header.cast(),
+            header_size: mem::size_of::<ChunkHeader<A>>(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl fmt::Debug for AnyChunk<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Chunk")
+            .field("allocated", &self.allocated())
+            .field("capacity", &self.capacity())
+            .finish()
+    }
+}
+
+impl<'a> AnyChunk<'a> {
+    #[inline]
+    pub(crate) fn is_upwards_allocating(self) -> bool {
+        let header = nonnull::addr(self.header);
+        let end = nonnull::addr(unsafe { self.header.as_ref().end });
+        end > header
+    }
+
+    /// Returns the previous (smaller) chunk.
+    #[must_use]
+    #[inline(always)]
+    pub fn prev(self) -> Option<Self> {
+        unsafe {
+            Some(AnyChunk {
+                header: self.header.as_ref().prev?,
+                header_size: self.header_size,
+                marker: PhantomData,
+            })
+        }
+    }
+
+    /// Returns the next (bigger) chunk.
+    #[must_use]
+    #[inline(always)]
+    pub fn next(self) -> Option<Self> {
+        unsafe {
+            Some(AnyChunk {
+                header: self.header.as_ref().next.get()?,
+                header_size: self.header_size,
+                marker: PhantomData,
+            })
+        }
+    }
+
+    /// Returns an iterator over all previous (smaller) chunks.
+    #[must_use]
+    #[inline(always)]
+    pub fn iter_prev(self) -> AnyChunkPrevIter<'a> {
+        AnyChunkPrevIter { chunk: self.prev() }
+    }
+
+    /// Returns an iterator over all next (bigger) chunks.
+    #[must_use]
+    #[inline(always)]
+    pub fn iter_next(self) -> AnyChunkNextIter<'a> {
+        AnyChunkNextIter { chunk: self.next() }
+    }
+
+    /// Returns the size of this chunk in bytes.
+    #[must_use]
+    #[inline]
+    pub fn size(self) -> usize {
+        let start = self.chunk_start();
+        let end = self.chunk_end();
+        nonnull::addr(end).get() - nonnull::addr(start).get()
+    }
+
+    /// Returns the capacity of this chunk in bytes.
+    #[must_use]
+    #[inline]
+    pub fn capacity(self) -> usize {
+        let start = self.content_start();
+        let end = self.content_end();
+        nonnull::addr(end).get() - nonnull::addr(start).get()
+    }
+
+    /// Returns the amount of allocated bytes.
+    /// This includes padding and wasted space due to reallocations.
+    ///
+    /// This property can be misleading for chunks that come after the current chunk because
+    /// their `bump_position` and consequently the `allocated` property is not reset until
+    /// they become the current chunk again.
+    #[must_use]
+    #[inline]
+    pub fn allocated(self) -> usize {
+        if self.is_upwards_allocating() {
+            let start = self.content_start();
+            let end = self.bump_position();
+            nonnull::addr(end).get() - nonnull::addr(start).get()
+        } else {
+            let start = self.bump_position();
+            let end = self.content_end();
+            nonnull::addr(end).get() - nonnull::addr(start).get()
+        }
+    }
+
+    /// Returns the remaining capacity.
+    ///
+    /// This property can be misleading for chunks that come after the current chunk because
+    /// their `bump_position` and consequently the `remaining` property is not reset until
+    /// they become the current chunk again.
+    #[must_use]
+    #[inline]
+    pub fn remaining(self) -> usize {
+        if self.is_upwards_allocating() {
+            let start = self.bump_position();
+            let end = self.content_end();
+            nonnull::addr(end).get() - nonnull::addr(start).get()
+        } else {
+            let start = self.content_start();
+            let end = self.bump_position();
+            nonnull::addr(end).get() - nonnull::addr(start).get()
+        }
+    }
+
+    /// Returns a pointer to the start of the chunk.
+    #[must_use]
+    #[inline]
+    pub fn chunk_start(self) -> NonNull<u8> {
+        if self.is_upwards_allocating() {
+            self.header.cast()
+        } else {
+            unsafe { self.header.as_ref().end }
+        }
+    }
+
+    /// Returns a pointer to the end of the chunk.
+    #[must_use]
+    #[inline]
+    pub fn chunk_end(self) -> NonNull<u8> {
+        if self.is_upwards_allocating() {
+            unsafe { self.header.as_ref().end }
+        } else {
+            self.after_header()
+        }
+    }
+
+    /// Returns a pointer to the start of the chunk's content.
+    #[must_use]
+    #[inline]
+    pub fn content_start(self) -> NonNull<u8> {
+        if self.is_upwards_allocating() {
+            self.after_header()
+        } else {
+            self.chunk_start()
+        }
+    }
+
+    /// Returns a pointer to the end of the chunk's content.
+    #[must_use]
+    #[inline]
+    pub fn content_end(self) -> NonNull<u8> {
+        if self.is_upwards_allocating() {
+            self.chunk_end()
+        } else {
+            self.header.cast()
+        }
+    }
+
+    /// Returns the bump pointer. It lies within the chunk's content range.
+    ///
+    /// This property can be misleading for chunks that come after the current chunk because
+    /// their `bump_position` is not reset until they become the current chunk again.
+    #[must_use]
+    #[inline]
+    pub fn bump_position(self) -> NonNull<u8> {
+        unsafe { self.header.as_ref().pos.get() }
+    }
+
+    fn after_header(self) -> NonNull<u8> {
+        unsafe { nonnull::byte_add(self.header, self.header_size).cast() }
+    }
+}
+
+/// Iterator that iterates over previous chunks by continuously calling [`Chunk::prev`].
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub struct AnyChunkPrevIter<'a> {
+    #[allow(missing_docs)]
+    pub chunk: Option<AnyChunk<'a>>,
+}
+
+impl<'a> Iterator for AnyChunkPrevIter<'a> {
+    type Item = AnyChunk<'a>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let chunk = self.chunk?;
+        self.chunk = chunk.prev();
+        Some(chunk)
+    }
+}
+
+impl FusedIterator for AnyChunkPrevIter<'_> {}
+
+impl fmt::Debug for AnyChunkPrevIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(*self).finish()
+    }
+}
+
+/// Iterator that iterates over next chunks by continuously calling [`Chunk::next`].
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub struct AnyChunkNextIter<'a> {
+    #[allow(missing_docs)]
+    pub chunk: Option<AnyChunk<'a>>,
+}
+
+impl<'a> Iterator for AnyChunkNextIter<'a> {
+    type Item = AnyChunk<'a>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let chunk = self.chunk?;
+        self.chunk = chunk.next();
+        Some(chunk)
+    }
+}
+
+impl FusedIterator for AnyChunkNextIter<'_> {}
+
+impl fmt::Debug for AnyChunkNextIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.map(AnyChunk::size)).finish()
+    }
+}

--- a/src/stats/any.rs
+++ b/src/stats/any.rs
@@ -12,8 +12,8 @@ pub struct AnyStats<'a> {
     chunk: Option<AnyChunk<'a>>,
 }
 
-impl<A, const GUARANTEED_ALLOCATED: bool> From<Stats<'_, A, GUARANTEED_ALLOCATED>> for AnyStats<'_> {
-    fn from(value: Stats<'_, A, GUARANTEED_ALLOCATED>) -> Self {
+impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> From<Stats<'_, A, UP, GUARANTEED_ALLOCATED>> for AnyStats<'_> {
+    fn from(value: Stats<'_, A, UP, GUARANTEED_ALLOCATED>) -> Self {
         Self {
             chunk: value.get_current_chunk().map(Into::into),
         }
@@ -162,8 +162,8 @@ pub struct AnyChunk<'a> {
     marker: PhantomData<&'a ()>,
 }
 
-impl<A> From<Chunk<'_, A>> for AnyChunk<'_> {
-    fn from(value: Chunk<'_, A>) -> Self {
+impl<A, const UP: bool> From<Chunk<'_, A, UP>> for AnyChunk<'_> {
+    fn from(value: Chunk<'_, A, UP>) -> Self {
         Self {
             header: value.header.cast(),
             header_size: mem::size_of::<ChunkHeader<A>>(),

--- a/src/stats/any.rs
+++ b/src/stats/any.rs
@@ -22,7 +22,7 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> From<Stats<'_, A, UP, 
 
 impl fmt::Debug for AnyStats<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.debug_format("Stats", f)
+        self.debug_format("AnyStats", f)
     }
 }
 

--- a/src/tests/chunk_size.rs
+++ b/src/tests/chunk_size.rs
@@ -6,6 +6,35 @@ use crate::{
     Bump,
 };
 
+use super::either_way;
+
+macro_rules! create_mock_allocator {
+    (
+        $ident:ident $size_and_align:literal
+    ) => {
+        #[allow(dead_code)]
+        #[repr(align($size_and_align))]
+        #[derive(Clone)]
+        struct $ident([u8; $size_and_align]);
+
+        impl $ident {
+            fn new() -> Self {
+                Self([0; $size_and_align])
+            }
+        }
+
+        unsafe impl Allocator for $ident {
+            fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+                Global.allocate(layout)
+            }
+
+            unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+                Global.deallocate(ptr, layout);
+            }
+        }
+    };
+}
+
 #[test]
 fn aligned_allocator_issue_32() {
     #[allow(dead_code)]
@@ -25,4 +54,19 @@ fn aligned_allocator_issue_32() {
     }
 
     let _: Bump<_, 1, false> = Bump::with_size_in(0x2000, BIG_ALLOCATOR);
+}
+
+either_way! {
+    giant_base_allocator
+}
+
+fn giant_base_allocator<const UP: bool>() {
+    create_mock_allocator! {
+        MyAllocator 16
+    }
+
+    let bump: Bump<_, 1, UP> = Bump::with_size_in(0x2000, MyAllocator::new());
+    assert_eq!(bump.stats().allocated(), 0);
+    bump.alloc_str("hey");
+    assert_eq!(bump.stats().allocated(), 3);
 }

--- a/src/tests/chunk_size.rs
+++ b/src/tests/chunk_size.rs
@@ -35,34 +35,22 @@ macro_rules! create_mock_allocator {
     };
 }
 
-#[test]
-fn aligned_allocator_issue_32() {
-    #[allow(dead_code)]
-    #[repr(align(32))]
-    #[derive(Clone)]
-    struct BigAllocator([u8; 32]);
-    const BIG_ALLOCATOR: BigAllocator = BigAllocator([0u8; 32]);
-
-    unsafe impl Allocator for BigAllocator {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-            Global.allocate(layout)
-        }
-
-        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            Global.deallocate(ptr, layout);
-        }
-    }
-
-    let _: Bump<_, 1, false> = Bump::with_size_in(0x2000, BIG_ALLOCATOR);
+either_way! {
+    aligned_allocator_issue_32
+    giant_base_allocator
 }
 
-either_way! {
-    giant_base_allocator
+fn aligned_allocator_issue_32<const UP: bool>() {
+    create_mock_allocator! {
+        BigAllocator 32
+    }
+
+    let _: Bump<_, 1, false> = Bump::with_size_in(0x2000, BigAllocator::new());
 }
 
 fn giant_base_allocator<const UP: bool>() {
     create_mock_allocator! {
-        MyAllocator 16
+        MyAllocator 4096
     }
 
     let bump: Bump<_, 1, UP> = Bump::with_size_in(0x2000, MyAllocator::new());


### PR DESCRIPTION
This PR also does a general refactor of `Stats` and associated types, adds `A` and `UP` generic parameter to `Stats` and `Chunk` and adds `AnyStats`, `AnyChunk` etc as type erased versions.