### PR TITLE
Refactor `BumpBox` deallocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **added:** `AnyStats`, `AnyChunk` and associated types as type erased versions of their non-`Any*` variants
 - **added:** `Bump(Scope)::alloc_slice_move` to allocate `impl OwnedSlice`s (arrays, `Vec<T>`, `Box<[T]>` and so on)
 - **added:** `BumpBox::as_raw`, returns a pointer to its contents
+- **added:** `Bump(Scope)::dealloc` to deallocate `BumpBox`es
 - **fixed:** `serde` compiles without `alloc` feature
 - **fixed:** `Stats` and `Chunk` not reporting accurate sizes and pointers if the base allocator is not zero sized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **breaking:** added `A` and `UP` generic parameters to `Stats`, `Chunk` and associated types
 - **breaking:** the `stats` method of `BumpAllocator`, strings and vectors return `AnyStats` now instead of `Stats`
 - **breaking:** `Stats` is no longer re-exported at the crate level, you can import it from `bump_scope::stats::Stats`
+- **breaking:** removed `BumpBox::deallocate_in`, use `Bump(Scope)::dealloc` instead
 - **deprecated:** `FixedBumpVec::EMPTY`, use `FixedBumpVec::new()` instead
 - **deprecated:** `FixedBumpString::EMPTY`, use `FixedBumpString::new()` instead
 - **deprecated:** `alloc_fixed_vec`, use `FixedBumpVec::with_capacity_in` instead

--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -163,7 +163,7 @@ up_and_down! {
         bump.try_alloc_layout(layout)
     }
 
-    pub fn Bump_try_alloc_slice_move<'a>(bump: &'a Bump, value: &[u32]) -> Result<BumpBox<'a, [u32]>> {
+    pub fn Bump_try_alloc_slice_move<'a>(bump: &'a Bump, value: [u32; 4]) -> Result<BumpBox<'a, [u32]>> {
         bump.try_alloc_slice_move(value)
     }
 

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -2468,6 +2468,24 @@ where
         self.as_scope().try_alloc_layout(layout)
     }
 
+    /// Drops an allocated value and attempts to free its memory.
+    ///
+    /// The memory can only be freed if this is the last allocation.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bump_scope::Bump;
+    /// # let bump: Bump = Bump::new();
+    /// let boxed = bump.alloc(3i32);
+    /// assert_eq!(bump.stats().allocated(), 4);
+    /// bump.dealloc(boxed);
+    /// assert_eq!(bump.stats().allocated(), 0);
+    /// ```
+    #[inline(always)]
+    pub fn dealloc<T: ?Sized>(&self, boxed: BumpBox<T>) {
+        self.as_scope().dealloc(boxed);
+    }
+
     /// Reserves capacity for at least `additional` more bytes to be bump allocated.
     /// The bump allocator may reserve more space to avoid frequent reallocations.
     /// After calling `reserve_bytes`, <code>self.[stats](Self::stats)().[remaining](Stats::remaining)()</code> will be greater than or equal to

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -171,9 +171,9 @@ either_way! {
 
     call_zst_creation_closures
 
-    deallocate_in_ltr
+    dealloc_ltr
 
-    deallocate_in_rtl
+    dealloc_rtl
 
     default_chunk_size
 
@@ -949,7 +949,7 @@ fn call_zst_creation_closures<const UP: bool>() {
     }
 }
 
-fn deallocate_in_ltr<const UP: bool>() {
+fn dealloc_ltr<const UP: bool>() {
     let bump = Bump::<Global, 1, UP>::new();
     let slice = bump.alloc_slice_copy(&[1, 2, 3, 4, 5, 6]);
     let (lhs, rhs) = slice.split_at(3);
@@ -958,7 +958,7 @@ fn deallocate_in_ltr<const UP: bool>() {
     assert_eq!(rhs, [4, 5, 6]);
     assert_eq!(bump.stats().allocated(), 6 * 4);
 
-    lhs.deallocate_in(&bump);
+    bump.dealloc(lhs);
 
     if UP {
         assert_eq!(bump.stats().allocated(), 6 * 4);
@@ -966,7 +966,7 @@ fn deallocate_in_ltr<const UP: bool>() {
         assert_eq!(bump.stats().allocated(), 3 * 4);
     }
 
-    rhs.deallocate_in(&bump);
+    bump.dealloc(rhs);
 
     if UP {
         assert_eq!(bump.stats().allocated(), 3 * 4);
@@ -975,7 +975,7 @@ fn deallocate_in_ltr<const UP: bool>() {
     }
 }
 
-fn deallocate_in_rtl<const UP: bool>() {
+fn dealloc_rtl<const UP: bool>() {
     let bump = Bump::<Global, 1, UP>::new();
     let slice = bump.alloc_slice_copy(&[1, 2, 3, 4, 5, 6]);
     let (lhs, rhs) = slice.split_at(3);
@@ -984,7 +984,7 @@ fn deallocate_in_rtl<const UP: bool>() {
     assert_eq!(rhs, [4, 5, 6]);
     assert_eq!(bump.stats().allocated(), 6 * 4);
 
-    rhs.deallocate_in(&bump);
+    bump.dealloc(rhs);
 
     if UP {
         assert_eq!(bump.stats().allocated(), 3 * 4);
@@ -992,7 +992,7 @@ fn deallocate_in_rtl<const UP: bool>() {
         assert_eq!(bump.stats().allocated(), 6 * 4);
     }
 
-    lhs.deallocate_in(&bump);
+    bump.dealloc(lhs);
 
     if UP {
         assert_eq!(bump.stats().allocated(), 0);


### PR DESCRIPTION
Removes `BumpBox::deallocate_in`, adds `Bump(Scope)::dealloc` and adds more box docs.