### PR TITLE
Improve `extend_from_slice_clone` performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improve performance of `extend_from_slice_clone`. 
 - Improve documentation.
 
 ## [0.17.0] - 2025-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Improve performance of `extend_from_slice_clone`. 
+- Improve performance of `extend_from_slice_clone`. ([#69])
 - Improve documentation.
 
 ## [0.17.0] - 2025-05-25
@@ -658,6 +658,7 @@ _If you are upgrading: please see [`UPGRADING.md#0.17.0`](UPGRADING.md#0.17.0)._
 
 ## [0.0.0] - 2024-03-26
 
+[#69]: https://github.com/bluurryy/bump-scope/pull/69
 [#48]: https://github.com/bluurryy/bump-scope/pull/48
 [#34]: https://github.com/bluurryy/bump-scope/pull/34
 [#32]: https://github.com/bluurryy/bump-scope/issues/32

--- a/src/bump_vec.rs
+++ b/src/bump_vec.rs
@@ -18,7 +18,7 @@ use crate::{
     destructure::destructure,
     min_non_zero_cap,
     owned_slice::{self, OwnedSlice, TakeOwnedSlice},
-    polyfill::{non_null, pointer, slice},
+    polyfill::{hint::likely, non_null, pointer, slice},
     raw_fixed_bump_vec::RawFixedBumpVec,
     BumpAllocator, BumpAllocatorScope, BumpBox, ErrorBehavior, FixedBumpVec, NoDrop, SizedTypeProperties,
 };
@@ -1471,12 +1471,12 @@ impl<T, A: BumpAllocator> BumpVec<T, A> {
         self.generic_reserve(slice.len())?;
 
         unsafe {
-            let mut ptr = self.as_mut_ptr().add(self.len());
+            let mut pos = 0usize;
 
-            for value in slice {
-                pointer::write_with(ptr, || value.clone());
-                ptr = ptr.add(1);
-                self.inc_len(1);
+            while likely(pos != slice.len()) {
+                let elem = slice.get_unchecked(pos);
+                self.push_unchecked(elem.clone());
+                pos += 1;
             }
         }
 


### PR DESCRIPTION
The current implementation iterates through the source slice via incrementing a pointer. This does not optimize as well as incrementing indices. 

When incrementing indices, the compiler can optimize `extend_from_slice_clone` to use a call to `memcpy` for types that qualify. It was unable to do so with types like `u8`, `u16`, `u32`, `u64`.

This has no impact for types like `String`.