### PR TITLE
Add `GUARANTEED_ALLOCATED` param to `RawChunk`, fix issues related to wrong handling of UNALLOCATED chunks

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,7 +96,7 @@ spellcheck:
 
 doc *args:
   cargo fmt
-  cargo insert-docs --all-features --allow-dirty --strict
+  cargo insert-docs --all-features --allow-dirty
   @ just doc-rustdoc {{args}}
 
 doc-rustdoc *args:

--- a/src/allocator_impl.rs
+++ b/src/allocator_impl.rs
@@ -27,10 +27,11 @@ pub(crate) unsafe fn deallocate<const MIN_ALIGN: usize, const UP: bool, const GU
     layout: Layout,
 ) where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     unsafe {
         // free allocated space if this is the last allocation
-        if is_last(bump, ptr, layout) {
+        if is_last_and_allocated(bump, ptr, layout) {
             deallocate_assume_last(bump, ptr, layout);
         }
     }
@@ -43,25 +44,23 @@ unsafe fn deallocate_assume_last<const MIN_ALIGN: usize, const UP: bool, const G
     layout: Layout,
 ) where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
+    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     unsafe {
-        debug_assert!(is_last(bump, ptr, layout));
+        debug_assert!(is_last_and_allocated(bump, ptr, layout));
 
         if UP {
-            bump.chunk.get().set_pos(ptr);
+            bump.set_pos(ptr.addr());
         } else {
             let mut addr = ptr.addr().get();
             addr += layout.size();
-            addr = up_align_usize_unchecked(addr, MIN_ALIGN);
-
-            let pos = ptr.with_addr(NonZeroUsize::new_unchecked(addr));
-            bump.chunk.get().set_pos(pos);
+            bump.set_pos(NonZeroUsize::new_unchecked(addr));
         }
     }
 }
 
 #[inline(always)]
-unsafe fn is_last<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>(
+unsafe fn is_last_and_allocated<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool, A>(
     bump: &BumpScope<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
     ptr: NonNull<u8>,
     layout: Layout,
@@ -69,6 +68,10 @@ unsafe fn is_last<const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOC
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
 {
+    if bump.chunk.get().is_unallocated() {
+        return false;
+    }
+
     unsafe {
         if UP {
             ptr.as_ptr().add(layout.size()) == bump.chunk.get().pos().as_ptr()
@@ -96,7 +99,7 @@ where
 
     unsafe {
         if UP {
-            if is_last(bump, old_ptr, old_layout) & align_fits(old_ptr, old_layout, new_layout) {
+            if is_last_and_allocated(bump, old_ptr, old_layout) & align_fits(old_ptr, old_layout, new_layout) {
                 // We may be able to grow in place! Just need to check if there is enough space.
 
                 let chunk_end = bump.chunk.get().content_end();
@@ -110,7 +113,8 @@ where
                     // Up-aligning a pointer inside a chunks content by `MIN_ALIGN` never overflows.
                     let new_pos = up_align_usize_unchecked(old_addr.get() + new_layout.size(), MIN_ALIGN);
 
-                    bump.chunk.get().set_pos_addr(new_pos);
+                    // `is_last_and_allocated` returned true
+                    bump.chunk.get().guaranteed_allocated_unchecked().set_pos_addr(new_pos);
 
                     Ok(NonNull::slice_from_raw_parts(old_ptr, new_layout.size()))
                 } else {
@@ -126,7 +130,7 @@ where
                 Ok(NonNull::slice_from_raw_parts(new_ptr, new_layout.size()))
             }
         } else {
-            if is_last(bump, old_ptr, old_layout) {
+            if is_last_and_allocated(bump, old_ptr, old_layout) {
                 // We may be able to reuse the currently allocated space. Just need to check if the current chunk has enough space for that.
                 let additional_size = new_layout.size() - old_layout.size();
 
@@ -150,7 +154,9 @@ where
                         old_ptr.copy_to(new_ptr, old_layout.size());
                     }
 
-                    bump.chunk.get().set_pos_addr(new_addr.get());
+                    // `is_last_and_allocated` returned true
+                    bump.chunk.get().guaranteed_allocated_unchecked().set_pos_addr(new_addr.get());
+
                     Ok(NonNull::slice_from_raw_parts(new_ptr, new_layout.size()))
                 } else {
                     // The current chunk doesn't have enough space to allocate this layout. We need to allocate in another chunk.
@@ -218,7 +224,7 @@ where
         A: BaseAllocator<GUARANTEED_ALLOCATED>,
     {
         unsafe {
-            if is_last(bump, old_ptr, old_layout) {
+            if is_last_and_allocated(bump, old_ptr, old_layout) {
                 let old_pos = bump.chunk.get().pos();
                 deallocate_assume_last(bump, old_ptr, old_layout);
 
@@ -239,7 +245,9 @@ where
                         Ok(new_ptr) => new_ptr,
                         Err(error) => {
                             // Need to reset the bump pointer to the old position.
-                            bump.chunk.get().set_pos(old_pos);
+
+                            // `is_last_and_allocated` returned true
+                            bump.chunk.get().guaranteed_allocated_unchecked().set_pos(old_pos);
                             return Err(error);
                         }
                     };
@@ -272,7 +280,7 @@ where
         }
 
         // if that's not the last allocation, there is nothing we can do
-        if !is_last(bump, old_ptr, old_layout) {
+        if !is_last_and_allocated(bump, old_ptr, old_layout) {
             // we return the size of the old layout
             return Ok(NonNull::slice_from_raw_parts(old_ptr, old_layout.size()));
         }
@@ -283,7 +291,9 @@ where
             // Up-aligning a pointer inside a chunk by `MIN_ALIGN` never overflows.
             let new_pos = up_align_usize_unchecked(end, MIN_ALIGN);
 
-            bump.chunk.get().set_pos_addr(new_pos);
+            // `is_last_and_allocated` returned true
+            bump.chunk.get().guaranteed_allocated_unchecked().set_pos_addr(new_pos);
+
             Ok(NonNull::slice_from_raw_parts(old_ptr, new_layout.size()))
         } else {
             let old_addr = old_ptr.addr();
@@ -303,7 +313,9 @@ where
                 old_ptr.copy_to_nonoverlapping(new_ptr, new_layout.size());
             }
 
-            bump.chunk.get().set_pos(new_ptr);
+            // `is_last_and_allocated` returned true
+            bump.chunk.get().guaranteed_allocated_unchecked().set_pos(new_ptr);
+
             Ok(NonNull::slice_from_raw_parts(new_ptr, new_layout.size()))
         }
     }

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -818,7 +818,7 @@ where
     #[inline]
     pub(crate) fn generic_new_in<E: ErrorBehavior>(allocator: A) -> Result<Self, E> {
         Ok(Self {
-            chunk: Cell::new(RawChunk::new_in(ChunkSize::DEFAULT, None, allocator)?),
+            chunk: Cell::new(RawChunk::new_in(ChunkSize::DEFAULT, None, allocator)?.coerce_guaranteed_allocated()),
         })
     }
 
@@ -888,11 +888,10 @@ where
     #[inline]
     pub(crate) fn generic_with_size_in<E: ErrorBehavior>(size: usize, allocator: A) -> Result<Self, E> {
         Ok(Self {
-            chunk: Cell::new(RawChunk::new_in(
-                ChunkSize::from_hint(size).ok_or_else(E::capacity_overflow)?,
-                None,
-                allocator,
-            )?),
+            chunk: Cell::new(
+                RawChunk::new_in(ChunkSize::from_hint(size).ok_or_else(E::capacity_overflow)?, None, allocator)?
+                    .coerce_guaranteed_allocated(),
+            ),
         })
     }
 
@@ -947,11 +946,14 @@ where
     #[inline]
     pub(crate) fn generic_with_capacity_in<E: ErrorBehavior>(layout: Layout, allocator: A) -> Result<Self, E> {
         Ok(Self {
-            chunk: Cell::new(RawChunk::new_in(
-                ChunkSize::from_capacity(layout).ok_or_else(E::capacity_overflow)?,
-                None,
-                allocator,
-            )?),
+            chunk: Cell::new(
+                RawChunk::new_in(
+                    ChunkSize::from_capacity(layout).ok_or_else(E::capacity_overflow)?,
+                    None,
+                    allocator,
+                )?
+                .coerce_guaranteed_allocated(),
+            ),
         })
     }
 

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -984,7 +984,9 @@ where
     /// ```
     #[inline(always)]
     pub fn reset(&mut self) {
-        let mut chunk = self.chunk.get();
+        let Some(mut chunk) = self.chunk.get().guaranteed_allocated() else {
+            return;
+        };
 
         unsafe {
             chunk.for_each_prev(|chunk| chunk.deallocate());
@@ -997,7 +999,7 @@ where
 
         chunk.set_prev(None);
         chunk.reset();
-        self.chunk.set(chunk);
+        self.chunk.set(chunk.coerce_guaranteed_allocated());
     }
 
     /// Returns a type which provides statistics about the memory usage of the bump allocator.

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -232,12 +232,11 @@ where
     A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     fn drop(&mut self) {
-        if self.as_scope().is_unallocated() {
+        let Some(chunk) = self.chunk.get().guaranteed_allocated() else {
             return;
-        }
+        };
 
         unsafe {
-            let chunk = self.chunk.get();
             chunk.for_each_prev(|chunk| chunk.deallocate());
             chunk.for_each_next(|chunk| chunk.deallocate());
             chunk.deallocate();

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -192,7 +192,7 @@ macro_rules! make_type {
             MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
             A: BaseAllocator<GUARANTEED_ALLOCATED>,
         {
-            pub(crate) chunk: Cell<RawChunk<A, UP>>,
+            pub(crate) chunk: Cell<RawChunk<A, UP, GUARANTEED_ALLOCATED>>,
         }
     };
 }

--- a/src/bump_align_guard.rs
+++ b/src/bump_align_guard.rs
@@ -21,9 +21,11 @@ where
 {
     #[inline(always)]
     fn drop(&mut self) {
-        let pos = self.scope.chunk.get().pos().addr();
-        let addr = align_pos::<MIN_ALIGN, UP>(pos);
-        unsafe { self.scope.chunk.get().set_pos_addr(addr) };
+        if let Some(chunk) = self.scope.chunk.get().guaranteed_allocated() {
+            let pos = chunk.pos().addr();
+            let addr = align_pos::<MIN_ALIGN, UP>(pos);
+            unsafe { chunk.set_pos_addr(addr) };
+        }
     }
 }
 

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -494,7 +494,7 @@ where
         let allocator = A::default_or_panic();
         let chunk = RawChunk::new_in(ChunkSize::DEFAULT, None, allocator)?;
 
-        self.chunk.set(chunk);
+        self.chunk.set(chunk.coerce_guaranteed_allocated());
 
         Ok(())
     }
@@ -750,10 +750,24 @@ where
     pub(crate) unsafe fn in_another_chunk<B: ErrorBehavior, R, L: LayoutProps>(
         &self,
         layout: L,
-        mut f: impl FnMut(RawChunk<A, UP>, L) -> Option<R>,
+        mut f: impl FnMut(RawChunk<A, UP, true>, L) -> Option<R>,
     ) -> Result<R, B> {
         unsafe {
-            let new_chunk = if self.is_unallocated() {
+            let new_chunk: RawChunk<A, UP, true> = if let Some(chunk) = self.chunk.get().guaranteed_allocated() {
+                while let Some(chunk) = chunk.next() {
+                    // We don't reset the chunk position when we leave a scope, so we need to do it here.
+                    chunk.reset();
+
+                    self.chunk.set(chunk.coerce_guaranteed_allocated());
+
+                    if let Some(ptr) = f(chunk, layout) {
+                        return Ok(ptr);
+                    }
+                }
+
+                // there is no chunk that fits, we need a new chunk
+                chunk.append_for(*layout)
+            } else {
                 // When this bump allocator is unallocated, `A` is guaranteed to implement `Default`,
                 // `default_or_panic` will not panic.
                 let allocator = A::default_or_panic();
@@ -763,23 +777,9 @@ where
                     None,
                     allocator,
                 )
-            } else {
-                while let Some(chunk) = self.chunk.get().next() {
-                    // We don't reset the chunk position when we leave a scope, so we need to do it here.
-                    chunk.reset();
-
-                    self.chunk.set(chunk);
-
-                    if let Some(ptr) = f(chunk, layout) {
-                        return Ok(ptr);
-                    }
-                }
-
-                // there is no chunk that fits, we need a new chunk
-                self.chunk.get().append_for(*layout)
             }?;
 
-            self.chunk.set(new_chunk);
+            self.chunk.set(new_chunk.coerce_guaranteed_allocated());
 
             match f(new_chunk, layout) {
                 Some(ptr) => Ok(ptr),
@@ -802,7 +802,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn stats(&self) -> Stats<'a, A, UP, GUARANTEED_ALLOCATED> {
-        unsafe { self.chunk.get().stats() }
+        self.chunk.get().stats()
     }
 
     /// Returns `&self` as is. This is useful for macros that support both `Bump` and `BumpScope`.
@@ -2672,35 +2672,34 @@ where
             return Err(B::capacity_overflow());
         };
 
-        if self.is_unallocated() {
+        if let Some(mut chunk) = self.chunk.get().guaranteed_allocated() {
+            let mut additional = additional;
+
+            loop {
+                if let Some(rest) = additional.checked_sub(chunk.remaining()) {
+                    additional = rest;
+                } else {
+                    return Ok(());
+                }
+
+                if let Some(next) = chunk.next() {
+                    chunk = next;
+                } else {
+                    break;
+                }
+            }
+
+            chunk.append_for(layout).map(drop)
+        } else {
             let allocator = A::default_or_panic();
             let new_chunk = RawChunk::new_in(
                 ChunkSize::from_capacity(layout).ok_or_else(B::capacity_overflow)?,
                 None,
                 allocator,
             )?;
-            self.chunk.set(new_chunk);
-            return Ok(());
+            self.chunk.set(new_chunk.coerce_guaranteed_allocated());
+            Ok(())
         }
-
-        let mut additional = additional;
-        let mut chunk = self.chunk.get();
-
-        loop {
-            if let Some(rest) = additional.checked_sub(chunk.remaining()) {
-                additional = rest;
-            } else {
-                return Ok(());
-            }
-
-            if let Some(next) = chunk.next() {
-                chunk = next;
-            } else {
-                break;
-            }
-        }
-
-        chunk.append_for(layout).map(drop)
     }
 }
 

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -64,7 +64,7 @@ macro_rules! make_type {
             const UP: bool = true,
             const GUARANTEED_ALLOCATED: bool = true,
         > {
-            pub(crate) chunk: Cell<RawChunk<A, UP>>,
+            pub(crate) chunk: Cell<RawChunk<A, UP, GUARANTEED_ALLOCATED>>,
 
             /// Marks the lifetime of the mutably borrowed `BumpScopeGuard(Root)`.
             marker: PhantomData<&'a ()>,
@@ -469,7 +469,7 @@ where
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn new_unchecked(chunk: RawChunk<A, UP>) -> Self {
+    pub(crate) unsafe fn new_unchecked(chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>) -> Self {
         Self {
             chunk: Cell::new(chunk),
             marker: PhantomData,
@@ -489,7 +489,7 @@ where
     #[inline(never)]
     fn allocate_first_chunk<B: ErrorBehavior>(&self) -> Result<(), B> {
         // must only be called when we point to the empty chunk
-        debug_assert_eq!(self.chunk.get(), RawChunk::UNALLOCATED);
+        debug_assert!(self.chunk.get().is_unallocated());
 
         let allocator = A::default_or_panic();
         let chunk = RawChunk::new_in(ChunkSize::DEFAULT, None, allocator)?;

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -14,7 +14,9 @@ pub struct Checkpoint {
 }
 
 impl Checkpoint {
-    pub(crate) fn new<A, const UP: bool>(chunk: RawChunk<A, UP>) -> Self {
+    pub(crate) fn new<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
+    ) -> Self {
         let address = chunk.pos().addr();
         let chunk = chunk.header().cast();
         Checkpoint { chunk, address }
@@ -34,7 +36,7 @@ where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator,
 {
-    pub(crate) chunk: RawChunk<A, UP>,
+    pub(crate) chunk: RawChunk<A, UP, true>,
     address: usize,
     marker: PhantomData<&'a mut ()>,
 }
@@ -72,7 +74,7 @@ where
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn new_unchecked(chunk: RawChunk<A, UP>) -> Self {
+    pub(crate) unsafe fn new_unchecked(chunk: RawChunk<A, UP, true>) -> Self {
         Self {
             chunk,
             address: chunk.pos().addr().get(),
@@ -98,8 +100,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn stats(&self) -> Stats<'a, A, UP> {
-        const GUARANTEED_ALLOCATED: bool = true;
-        unsafe { self.chunk.stats::<GUARANTEED_ALLOCATED>() }
+        self.chunk.stats()
     }
 
     /// Returns a reference to the base allocator.
@@ -122,7 +123,7 @@ where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: BaseAllocator,
 {
-    pub(crate) chunk: RawChunk<A, UP>,
+    pub(crate) chunk: RawChunk<A, UP, true>,
     marker: PhantomData<&'b mut ()>,
 }
 
@@ -159,7 +160,7 @@ where
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn new_unchecked(chunk: RawChunk<A, UP>) -> Self {
+    pub(crate) unsafe fn new_unchecked(chunk: RawChunk<A, UP, true>) -> Self {
         Self {
             chunk,
             marker: PhantomData,
@@ -182,8 +183,7 @@ where
     #[must_use]
     #[inline(always)]
     pub fn stats(&self) -> Stats<'a, A, UP> {
-        const GUARANTEED_ALLOCATED: bool = true;
-        unsafe { self.chunk.stats::<GUARANTEED_ALLOCATED>() }
+        self.chunk.stats()
     }
 
     /// Returns a reference to the base allocator.

--- a/src/error_behavior.rs
+++ b/src/error_behavior.rs
@@ -20,16 +20,16 @@ pub(crate) trait ErrorBehavior: Sized {
     fn format_trait_error() -> Self;
 
     /// For the infallible case we want to inline `f` but not for the fallible one. (Because it produces better code)
-    fn alloc_or_else<A, const UP: bool>(
-        chunk: RawChunk<A, UP>,
+    fn alloc_or_else<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
         minimum_alignment: impl SupportedMinimumAlignment,
         layout: impl LayoutProps,
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,
     ) -> Result<NonNull<u8>, Self>;
 
     /// For the infallible case we want to inline `f` but not for the fallible one. (Because it produces better code)
-    fn prepare_allocation_or_else<A, const UP: bool>(
-        chunk: RawChunk<A, UP>,
+    fn prepare_allocation_or_else<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
         minimum_alignment: impl SupportedMinimumAlignment,
         layout: impl LayoutProps,
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,
@@ -77,8 +77,8 @@ impl ErrorBehavior for Infallible {
     }
 
     #[inline(always)]
-    fn alloc_or_else<A, const UP: bool>(
-        chunk: RawChunk<A, UP>,
+    fn alloc_or_else<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
         minimum_alignment: impl SupportedMinimumAlignment,
         layout: impl LayoutProps,
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,
@@ -87,8 +87,8 @@ impl ErrorBehavior for Infallible {
     }
 
     #[inline(always)]
-    fn prepare_allocation_or_else<A, const UP: bool>(
-        chunk: RawChunk<A, UP>,
+    fn prepare_allocation_or_else<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
         minimum_alignment: impl SupportedMinimumAlignment,
         layout: impl LayoutProps,
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,
@@ -151,8 +151,8 @@ impl ErrorBehavior for AllocError {
     }
 
     #[inline(always)]
-    fn alloc_or_else<A, const UP: bool>(
-        chunk: RawChunk<A, UP>,
+    fn alloc_or_else<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
         minimum_alignment: impl SupportedMinimumAlignment,
         layout: impl LayoutProps,
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,
@@ -164,8 +164,8 @@ impl ErrorBehavior for AllocError {
     }
 
     #[inline(always)]
-    fn prepare_allocation_or_else<A, const UP: bool>(
-        chunk: RawChunk<A, UP>,
+    fn prepare_allocation_or_else<A, const UP: bool, const GUARANTEED_ALLOCATED: bool>(
+        chunk: RawChunk<A, UP, GUARANTEED_ALLOCATED>,
         minimum_alignment: impl SupportedMinimumAlignment,
         layout: impl LayoutProps,
         f: impl FnOnce() -> Result<NonNull<u8>, Self>,

--- a/src/polyfill/layout.rs
+++ b/src/polyfill/layout.rs
@@ -1,10 +1,8 @@
-#[cfg(feature = "alloc")]
 use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
 
 /// See [`std::alloc::Layout::dangling`].
 #[must_use]
 #[inline]
-#[cfg(feature = "alloc")]
 pub(crate) const fn dangling(layout: Layout) -> NonNull<u8> {
     unsafe { super::non_null::without_provenance(NonZeroUsize::new_unchecked(layout.align())) }
 }

--- a/src/polyfill/non_null.rs
+++ b/src/polyfill/non_null.rs
@@ -1,10 +1,8 @@
 use core::{
+    num::NonZeroUsize,
     ops::Range,
     ptr::{self, NonNull},
 };
-
-#[cfg(feature = "alloc")]
-use core::num::NonZeroUsize;
 
 use crate::polyfill::pointer;
 
@@ -50,7 +48,6 @@ pub const fn as_mut_ptr<T>(p: NonNull<[T]>) -> *mut T {
 /// See [`std::ptr::NonNull::without_provenance`].
 #[must_use]
 #[inline]
-#[cfg(feature = "alloc")]
 pub(crate) const fn without_provenance<T>(addr: NonZeroUsize) -> NonNull<T> {
     let pointer = ptr::without_provenance_mut(addr.get());
     // SAFETY: we know `addr` is non-zero.

--- a/src/raw_chunk.rs
+++ b/src/raw_chunk.rs
@@ -407,13 +407,15 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARAN
     }
 
     #[inline(always)]
-    pub(crate) fn prev(self) -> Option<Self> {
-        unsafe { Some(Self::from_header(self.header.as_ref().prev.get()?)) }
+    pub(crate) fn prev(self) -> Option<RawChunk<A, UP, true>> {
+        // SAFETY: the `UNALLOCATED` chunk header never has a `prev` so this must be an allocated chunk if some
+        unsafe { Some(RawChunk::from_header(self.header.as_ref().prev.get()?)) }
     }
 
     #[inline(always)]
-    pub(crate) fn next(self) -> Option<Self> {
-        unsafe { Some(Self::from_header(self.header.as_ref().next.get()?)) }
+    pub(crate) fn next(self) -> Option<RawChunk<A, UP, true>> {
+        // SAFETY: the `UNALLOCATED` chunk header never has a `next` so this must be an allocated chunk if some
+        unsafe { Some(RawChunk::from_header(self.header.as_ref().next.get()?)) }
     }
 
     #[inline(always)]
@@ -527,7 +529,7 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARAN
     }
 
     /// This resolves the next chunk before calling `f`. So calling [`deallocate`](RawChunk::deallocate) on the chunk parameter of `f` is fine.
-    pub(crate) fn for_each_prev(self, mut f: impl FnMut(Self)) {
+    pub(crate) fn for_each_prev(self, mut f: impl FnMut(RawChunk<A, UP, true>)) {
         let mut iter = self.prev();
 
         while let Some(chunk) = iter {
@@ -537,7 +539,7 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARAN
     }
 
     /// This resolves the next chunk before calling `f`. So calling [`deallocate`](RawChunk::deallocate) on the chunk parameter of `f` is fine.
-    pub(crate) fn for_each_next(self, mut f: impl FnMut(Self)) {
+    pub(crate) fn for_each_next(self, mut f: impl FnMut(RawChunk<A, UP, true>)) {
         let mut iter = self.next();
 
         while let Some(chunk) = iter {

--- a/src/raw_chunk.rs
+++ b/src/raw_chunk.rs
@@ -179,6 +179,20 @@ impl<A, const UP: bool> RawChunk<A, UP, true> {
     pub(crate) fn allocator<'a>(self) -> &'a A {
         unsafe { &self.header.as_ref().allocator }
     }
+
+    #[inline(always)]
+    pub(crate) fn set_prev(self, value: Option<Self>) {
+        unsafe {
+            self.header.as_ref().prev.set(value.map(|c| c.header));
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_next(self, value: Option<Self>) {
+        unsafe {
+            self.header.as_ref().next.set(value.map(|c| c.header));
+        }
+    }
 }
 
 impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARANTEED_ALLOCATED> {
@@ -536,20 +550,6 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARAN
             let allocator_ptr = &raw const (*self.header.as_ptr()).allocator;
             let allocator = allocator_ptr.read();
             allocator.deallocate(ptr, layout);
-        }
-    }
-
-    #[inline(always)]
-    pub(crate) fn set_prev(self, value: Option<Self>) {
-        unsafe {
-            self.header.as_ref().prev.set(value.map(|c| c.header));
-        }
-    }
-
-    #[inline(always)]
-    pub(crate) fn set_next(self, value: Option<Self>) {
-        unsafe {
-            self.header.as_ref().next.set(value.map(|c| c.header));
         }
     }
 

--- a/src/raw_chunk.rs
+++ b/src/raw_chunk.rs
@@ -174,6 +174,11 @@ impl<A, const UP: bool> RawChunk<A, UP, true> {
             }
         }
     }
+
+    #[inline(always)]
+    pub(crate) fn allocator<'a>(self) -> &'a A {
+        unsafe { &self.header.as_ref().allocator }
+    }
 }
 
 impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARANTEED_ALLOCATED> {
@@ -566,13 +571,6 @@ impl<A, const UP: bool, const GUARANTEED_ALLOCATED: bool> RawChunk<A, UP, GUARAN
             iter = chunk.next();
             f(chunk);
         }
-    }
-
-    /// This is only safe to read when `self` is not `RawChunk::UNALLOCATED`.
-    #[inline(always)]
-    pub(crate) unsafe fn allocator<'a>(self) -> &'a A {
-        debug_assert!(self.is_allocated());
-        unsafe { &self.header.as_ref().allocator }
     }
 
     #[inline(always)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -14,7 +14,10 @@ use core::{
     ptr::NonNull,
 };
 
-use crate::{RawChunk, chunk_header::ChunkHeader, maybe_default_allocator};
+use crate::{RawChunk, maybe_default_allocator};
+
+#[cfg(debug_assertions)]
+use crate::chunk_header::ChunkHeader;
 
 mod any;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -214,7 +214,7 @@ impl<'a, A, const UP: bool, const GUARANTEED_ALLOCATED: bool> From<Chunk<'a, A, 
 {
     fn from(chunk: Chunk<'a, A, UP>) -> Self {
         Stats {
-            chunk: chunk.chunk.change_guaranteed_allocated(),
+            chunk: chunk.chunk.coerce_guaranteed_allocated(),
             marker: PhantomData,
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -382,8 +382,7 @@ impl<'a, A, const UP: bool> Chunk<'a, A, UP> {
     #[must_use]
     #[inline(always)]
     pub fn allocator(&self) -> &'a A {
-        // SAFETY: A `Chunk` is guaranteed not to be `RawChunk::UNALLOCATED`.
-        unsafe { self.chunk.allocator() }
+        self.chunk.allocator()
     }
 
     #[cfg(debug_assertions)]

--- a/src/tests/misalignment_due_to_dealloc.rs
+++ b/src/tests/misalignment_due_to_dealloc.rs
@@ -1,0 +1,97 @@
+use core::alloc::Layout;
+
+use crate::{
+    Bump,
+    alloc::{Allocator, Global},
+    tests::either_way,
+};
+
+either_way! {
+    test_aligned_alloc
+    test_aligned_allocate
+    test_scoped_alloc
+    test_scoped_allocate
+    test_scoped_aligned_alloc
+    test_scoped_aligned_allocate
+}
+
+fn test_aligned_alloc<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP>>::new();
+    let bump = bump.as_mut_scope();
+
+    let _three = bump.alloc([0u8; 3]);
+    let five = bump.alloc([0u8; 5]);
+
+    bump.aligned::<8, ()>(|bump| {
+        bump.dealloc(five);
+        // deallocation succeeds and the bump pointer is unaligned
+        bump.alloc(0u64);
+    });
+}
+
+fn test_aligned_allocate<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP>>::new();
+    let bump = bump.as_mut_scope();
+
+    let _three = bump.allocate(Layout::new::<[u8; 3]>()).unwrap();
+    let five = bump.allocate(Layout::new::<[u8; 5]>()).unwrap();
+
+    bump.aligned::<8, ()>(|bump| {
+        unsafe { bump.deallocate(five.cast(), Layout::new::<[u8; 5]>()) };
+        bump.alloc(0u64);
+    });
+}
+
+fn test_scoped_alloc<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP>>::new();
+    let bump = bump.as_mut_scope();
+
+    let _three = bump.alloc([0u8; 3]);
+    let five = bump.alloc([0u8; 5]);
+
+    bump.scoped::<()>(|bump| {
+        bump.dealloc(five);
+        // deallocation succeeds and the bump pointer is unaligned
+        bump.alloc(0u64);
+    });
+}
+
+fn test_scoped_allocate<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP>>::new();
+    let bump = bump.as_mut_scope();
+
+    let _three = bump.allocate(Layout::new::<[u8; 3]>()).unwrap();
+    let five = bump.allocate(Layout::new::<[u8; 5]>()).unwrap();
+
+    bump.scoped::<()>(|bump| {
+        unsafe { bump.deallocate(five.cast(), Layout::new::<[u8; 5]>()) };
+        bump.alloc(0u64);
+    });
+}
+
+fn test_scoped_aligned_alloc<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP>>::new();
+    let bump = bump.as_mut_scope();
+
+    let _three = bump.alloc([0u8; 3]);
+    let five = bump.alloc([0u8; 5]);
+
+    bump.scoped_aligned::<8, ()>(|bump| {
+        bump.dealloc(five);
+        // deallocation succeeds and the bump pointer is unaligned
+        bump.alloc(0u64);
+    });
+}
+
+fn test_scoped_aligned_allocate<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP>>::new();
+    let bump = bump.as_mut_scope();
+
+    let _three = bump.allocate(Layout::new::<[u8; 3]>()).unwrap();
+    let five = bump.allocate(Layout::new::<[u8; 5]>()).unwrap();
+
+    bump.scoped_aligned::<8, ()>(|bump| {
+        unsafe { bump.deallocate(five.cast(), Layout::new::<[u8; 5]>()) };
+        bump.alloc(0u64);
+    });
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -44,6 +44,7 @@ mod into_flattened;
 mod io_write;
 mod limited_allocator;
 mod may_dangle;
+mod misalignment_due_to_dealloc;
 mod mut_bump_vec_doc;
 mod mut_bump_vec_rev_doc;
 mod mut_collections_do_not_waste_space;

--- a/src/tests/unallocated.rs
+++ b/src/tests/unallocated.rs
@@ -107,10 +107,7 @@ fn checkpoint_multiple_chunks() {
 fn allocate_another_chunk(bump: &Bump, dummy_size: usize) {
     let start_chunks = bump.any_stats().count();
     let remaining = bump.any_stats().remaining();
-    // FIXME: this condition should not be necessary, this is a bug, see #91
-    if remaining != 0 {
-        bump.alloc_layout(Layout::from_size_align(remaining, 1).unwrap());
-    }
+    bump.alloc_layout(Layout::from_size_align(remaining, 1).unwrap());
     assert_eq!(bump.any_stats().count(), start_chunks);
     bump.alloc_layout(Layout::from_size_align(dummy_size, 1).unwrap());
     assert_eq!(bump.any_stats().count(), start_chunks + 1);

--- a/src/tests/unallocated.rs
+++ b/src/tests/unallocated.rs
@@ -1,43 +1,49 @@
 use core::alloc::Layout;
 
-use crate::{BumpAllocator, BumpAllocatorExt, alloc::Global};
+use crate::{Bump, BumpAllocator, BumpAllocatorExt, alloc::Global, tests::either_way};
 
-type Bump = crate::Bump<Global, 1, true, false>;
+either_way! {
+    allocated
+    unallocated
+    unallocated_alloc
+    guaranteed_allocated
+    allocated_reserve_bytes
+    unallocated_reserve_bytes
+    checkpoint
+    checkpoint_multiple_chunks
+    allocate_zero_layout
+    reset
+}
 
-#[test]
-fn allocated() {
-    let bump: Bump = Bump::new();
+fn allocated<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::new();
     drop(bump);
 }
 
-#[test]
-fn unallocated() {
-    let bump: Bump = Bump::unallocated();
+fn unallocated<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
     assert_eq!(bump.stats().count(), 0);
     drop(bump);
 }
 
-#[test]
-fn unallocated_alloc() {
-    let bump: Bump = Bump::unallocated();
+fn unallocated_alloc<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
     assert_eq!(bump.stats().count(), 0);
     bump.alloc_str("Hello, World!");
     assert_eq!(bump.stats().count(), 1);
     drop(bump);
 }
 
-#[test]
-fn guaranteed_allocated() {
-    let bump: Bump = Bump::unallocated();
+fn guaranteed_allocated<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
     assert_eq!(bump.stats().count(), 0);
     let bump = bump.guaranteed_allocated();
     assert_eq!(bump.stats().count(), 1);
     drop(bump);
 }
 
-#[test]
-fn allocated_reserve_bytes() {
-    let bump: Bump = Bump::new();
+fn allocated_reserve_bytes<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::new();
     assert_eq!(bump.stats().count(), 1);
     bump.reserve_bytes(1024);
     assert_eq!(bump.stats().count(), 2);
@@ -45,9 +51,8 @@ fn allocated_reserve_bytes() {
     drop(bump);
 }
 
-#[test]
-fn unallocated_reserve_bytes() {
-    let bump: Bump = Bump::unallocated();
+fn unallocated_reserve_bytes<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
     assert_eq!(bump.stats().count(), 0);
     bump.reserve_bytes(1024);
     assert_eq!(bump.stats().count(), 1);
@@ -55,9 +60,8 @@ fn unallocated_reserve_bytes() {
     drop(bump);
 }
 
-#[test]
-fn checkpoint() {
-    let bump: Bump = Bump::unallocated();
+fn checkpoint<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
 
     let checkpoint_unallocated = bump.checkpoint();
     assert_eq!(bump.stats().count(), 0);
@@ -81,9 +85,8 @@ fn checkpoint() {
     assert_eq!(bump.stats().allocated(), 0);
 }
 
-#[test]
-fn checkpoint_multiple_chunks() {
-    let bump: Bump = Bump::unallocated();
+fn checkpoint_multiple_chunks<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
 
     assert_eq!(bump.stats().count(), 0);
     let c0 = bump.checkpoint();
@@ -104,7 +107,7 @@ fn checkpoint_multiple_chunks() {
     std::dbg!(bump.stats());
 }
 
-fn allocate_another_chunk(bump: &Bump, dummy_size: usize) {
+fn allocate_another_chunk<const UP: bool>(bump: &Bump<Global, 1, UP, false>, dummy_size: usize) {
     let start_chunks = bump.any_stats().count();
     let remaining = bump.any_stats().remaining();
     bump.alloc_layout(Layout::from_size_align(remaining, 1).unwrap());
@@ -114,14 +117,12 @@ fn allocate_another_chunk(bump: &Bump, dummy_size: usize) {
     assert_eq!(bump.any_stats().current_chunk().unwrap().allocated(), dummy_size);
 }
 
-#[test]
-fn allocate_zero_layout() {
-    let bump = Bump::unallocated();
+fn allocate_zero_layout<const UP: bool>() {
+    let bump = <Bump<Global, 1, UP, false>>::unallocated();
     bump.alloc_layout(Layout::new::<()>());
 }
 
-#[test]
-fn reset() {
-    let mut bump = Bump::unallocated();
+fn reset<const UP: bool>() {
+    let mut bump = <Bump<Global, 1, UP, false>>::unallocated();
     bump.reset();
 }

--- a/src/tests/unallocated.rs
+++ b/src/tests/unallocated.rs
@@ -113,3 +113,15 @@ fn allocate_another_chunk(bump: &Bump, dummy_size: usize) {
     assert_eq!(bump.any_stats().count(), start_chunks + 1);
     assert_eq!(bump.any_stats().current_chunk().unwrap().allocated(), dummy_size);
 }
+
+#[test]
+fn allocate_zero_layout() {
+    let bump = Bump::unallocated();
+    bump.alloc_layout(Layout::new::<()>());
+}
+
+#[test]
+fn reset() {
+    let mut bump = Bump::unallocated();
+    bump.reset();
+}

--- a/tests/compile_fail/escape_scope/scope_guard.stderr
+++ b/tests/compile_fail/escape_scope/scope_guard.stderr
@@ -1,9 +1,9 @@
 error[E0597]: `guard` does not live long enough
-  --> tests/compile_fail/escape_scope/scope_guard.rs:9:21
-   |
-8  |         let mut guard = bump.scope_guard();
+ --> tests/compile_fail/escape_scope/scope_guard.rs:9:21
+  |
+ 8 |         let mut guard = bump.scope_guard();
    |             --------- binding `guard` declared here
-9  |         let scope = guard.scope();
+ 9 |         let scope = guard.scope();
    |                     ^^^^^ borrowed value does not live long enough
 ...
 12 |     }

--- a/tests/compile_fail/escape_scope/scope_guard_scope.stderr
+++ b/tests/compile_fail/escape_scope/scope_guard_scope.stderr
@@ -1,9 +1,9 @@
 error[E0597]: `guard` does not live long enough
-  --> tests/compile_fail/escape_scope/scope_guard_scope.rs:9:21
-   |
-8  |         let mut guard = bump.scope_guard();
+ --> tests/compile_fail/escape_scope/scope_guard_scope.rs:9:21
+  |
+ 8 |         let mut guard = bump.scope_guard();
    |             --------- binding `guard` declared here
-9  |         let scope = guard.scope();
+ 9 |         let scope = guard.scope();
    |                     ^^^^^ borrowed value does not live long enough
 ...
 12 |     }


### PR DESCRIPTION
This is a refactor that encodes the allocated-ness of a `RawChunk` in the type system. This way we can define certain methods only for `RawChunks` that are guaranteed to be allocated, so we don't accidentally call methods that would not be safe for the UNALLOCATED chunk.

Not directly related, but this PR also includes a fix for the misalignment on deallocation of #92.

Fixes #91
Fixes #92