### PR TITLE
Relax base allocator trait bounds

### DIFF
--- a/src/bump_align_guard.rs
+++ b/src/bump_align_guard.rs
@@ -1,4 +1,4 @@
-use crate::{BaseAllocator, BumpScope, MinimumAlignment, SupportedMinimumAlignment, align_pos};
+use crate::{BumpScope, MinimumAlignment, SupportedMinimumAlignment, align_pos};
 
 /// Aligns the bump pointer on drop.
 ///
@@ -8,7 +8,6 @@ use crate::{BaseAllocator, BumpScope, MinimumAlignment, SupportedMinimumAlignmen
 pub(crate) struct BumpAlignGuard<'b, 'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     pub(crate) scope: &'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>,
 }
@@ -17,7 +16,6 @@ impl<A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCATED: bool
     for BumpAlignGuard<'_, '_, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     fn drop(&mut self) {
@@ -33,7 +31,6 @@ impl<'b, 'a, A, const MIN_ALIGN: usize, const UP: bool, const GUARANTEED_ALLOCAT
     BumpAlignGuard<'b, 'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator<GUARANTEED_ALLOCATED>,
 {
     #[inline(always)]
     pub(crate) fn new(scope: &'b mut BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>) -> Self {

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -1,7 +1,8 @@
 use core::{fmt::Debug, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 
 use crate::{
-    BaseAllocator, Bump, BumpScope, MinimumAlignment, RawChunk, SupportedMinimumAlignment,
+    Bump, BumpScope, MinimumAlignment, RawChunk, SupportedMinimumAlignment,
+    alloc::Allocator,
     chunk_header::ChunkHeader,
     stats::{AnyStats, Stats},
 };
@@ -34,7 +35,6 @@ impl Checkpoint {
 pub struct BumpScopeGuard<'a, A, const MIN_ALIGN: usize = 1, const UP: bool = true>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
 {
     pub(crate) chunk: RawChunk<A, UP, true>,
     address: usize,
@@ -44,7 +44,6 @@ where
 impl<A, const MIN_ALIGN: usize, const UP: bool> Debug for BumpScopeGuard<'_, A, MIN_ALIGN, UP>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         AnyStats::from(self.stats()).debug_format("BumpScopeGuard", f)
@@ -54,7 +53,6 @@ where
 impl<A, const MIN_ALIGN: usize, const UP: bool> Drop for BumpScopeGuard<'_, A, MIN_ALIGN, UP>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
 {
     #[inline(always)]
     fn drop(&mut self) {
@@ -65,7 +63,6 @@ where
 impl<'a, A, const MIN_ALIGN: usize, const UP: bool> BumpScopeGuard<'a, A, MIN_ALIGN, UP>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
 {
     #[inline(always)]
     #[allow(clippy::needless_pass_by_ref_mut)]
@@ -121,7 +118,7 @@ where
 pub struct BumpScopeGuardRoot<'b, A, const MIN_ALIGN: usize = 1, const UP: bool = true>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
+    A: Allocator,
 {
     pub(crate) chunk: RawChunk<A, UP, true>,
     marker: PhantomData<&'b mut ()>,
@@ -130,7 +127,7 @@ where
 impl<A, const MIN_ALIGN: usize, const UP: bool> Debug for BumpScopeGuardRoot<'_, A, MIN_ALIGN, UP>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
+    A: Allocator,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         AnyStats::from(self.stats()).debug_format("BumpScopeGuardRoot", f)
@@ -140,7 +137,7 @@ where
 impl<A, const MIN_ALIGN: usize, const UP: bool> Drop for BumpScopeGuardRoot<'_, A, MIN_ALIGN, UP>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
+    A: Allocator,
 {
     #[inline(always)]
     fn drop(&mut self) {
@@ -151,7 +148,7 @@ where
 impl<'a, A, const MIN_ALIGN: usize, const UP: bool> BumpScopeGuardRoot<'a, A, MIN_ALIGN, UP>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
-    A: BaseAllocator,
+    A: Allocator,
 {
     #[inline(always)]
     #[allow(clippy::needless_pass_by_ref_mut)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,7 +578,7 @@ mod supported_base_allocator {
     }
 }
 
-/// Trait that any allocator used as a base allocator of a bump allocator needs to implement.
+/// Trait that the base allocator of a `Bump` is required to implement to make allocations.
 ///
 /// Every [`Allocator`] that implements [`Clone`] automatically implements `BaseAllocator` when `GUARANTEED_ALLOCATED`.
 /// When not guaranteed allocated, allocators are additionally required to implement [`Default`].


### PR DESCRIPTION
This PR also reorders a bunch of methods and improves impl block docs.