### PR TITLE
Simplify internal allocation code

### DIFF
--- a/crates/callgrind-benches/README.md
+++ b/crates/callgrind-benches/README.md
@@ -101,7 +101,7 @@ If the layout is not statically known then the compiler can not do as many optim
 | black_box_shrink_smaller_align [^2] | 13 / 2          | 50 / 9            | 48 / 9  | 23 / 3      |
 | black_box_shrink_larger_align [^2]  | 13 / 2          | 47 / 7            | 15 / 2  | 55 / 8      |
 | black_box_deallocate                | 6 / 1           | 6 / 1             | 7 / 1   | 6 / 2       |
-| black_box_deallocate_non_last       | 5 / 1           | 4 / 1             | 5 / 1   | 6 / 2       |
+| black_box_deallocate_non_last       | 5 / 1           | 4 / 1             | 5 / 1   | —           |
 
 <!-- black_box_allocator_api table end -->
 
@@ -114,7 +114,7 @@ If the layout is not statically known then the compiler can not do as many optim
 
 | name    | bump-scope (up) | bump-scope (down) | bumpalo  | blink-alloc |
 |---------|-----------------|-------------------|----------|-------------|
-| warm_up | 224 / 31        | 230 / 32          | 355 / 43 | 284 / 38    |
+| warm_up | 224 / 31        | 230 / 32          | 355 / 43 | 283 / 38    |
 | reset   | 26 / 2          | 25 / 2            | 23 / 2   | 26 / 3      |
 
 <!-- misc table end -->


### PR DESCRIPTION
We had allocation code manually inlined in `generic_alloc_with` and used `alloc_or_else` and `prepare_allocation_or_else` to coerce the best codegen out of the compiler. In rustc `1.89.0` this is no longer necessary. This extra ceremony has no longer any effect on code generation so I'm ripping it out.

Let's hope a new rustc update doesn't require this again. Some of this was added because the compiler started producing worse code at some point. See #25.