### PR TITLE
Refactor to use less implicit generic args

### DIFF
--- a/crates/callgrind-benches/benches-lib/src/lib.rs
+++ b/crates/callgrind-benches/benches-lib/src/lib.rs
@@ -10,7 +10,7 @@ mod wrapper {
         use ::bump_scope::{MinimumAlignment, SupportedMinimumAlignment};
 
         #[repr(transparent)]
-        pub struct Bump<const MIN_ALIGN: usize = 1>(bump_scope::Bump<bump_scope::alloc::Global, MIN_ALIGN, true>)
+        pub struct Bump<const MIN_ALIGN: usize = 1>(bump_scope::Bump<bump_scope::alloc::Global, MIN_ALIGN, true, true>)
         where
             MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment;
 
@@ -71,7 +71,7 @@ mod wrapper {
         use ::bump_scope::{MinimumAlignment, SupportedMinimumAlignment};
 
         #[repr(transparent)]
-        pub struct Bump<const MIN_ALIGN: usize = 1>(bump_scope::Bump<bump_scope::alloc::Global, MIN_ALIGN, false>)
+        pub struct Bump<const MIN_ALIGN: usize = 1>(bump_scope::Bump<bump_scope::alloc::Global, MIN_ALIGN, false, true>)
         where
             MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment;
 

--- a/crates/fuzzing-support/src/alloc_static_layout.rs
+++ b/crates/fuzzing-support/src/alloc_static_layout.rs
@@ -3,9 +3,9 @@
 use std::{alloc::Layout, fmt::Debug, mem};
 
 use arbitrary::Arbitrary;
-use bump_scope::{Bump, MinimumAlignment, SupportedMinimumAlignment, alloc::Global};
+use bump_scope::{MinimumAlignment, SupportedMinimumAlignment, alloc::Global};
 
-use crate::{MinAlign, UpTo};
+use crate::{Bump, MinAlign, UpTo};
 
 #[derive(Debug, Arbitrary)]
 pub struct Fuzz {

--- a/crates/fuzzing-support/src/allocator_api.rs
+++ b/crates/fuzzing-support/src/allocator_api.rs
@@ -2,14 +2,14 @@ use std::{alloc::Layout, ops::Range, ptr::NonNull, rc::Rc};
 
 use arbitrary::{Arbitrary, Unstructured};
 use bump_scope::{
-    Bump, MinimumAlignment, SupportedMinimumAlignment,
+    MinimumAlignment, SupportedMinimumAlignment,
     alloc::{Allocator, Global},
 };
 use core::fmt::Debug;
 use log::debug;
 use rangemap::RangeSet;
 
-use crate::{MaybeFailingAllocator, MinAlign, RcAllocator, debug_dbg};
+use crate::{Bump, MaybeFailingAllocator, MinAlign, RcAllocator, debug_dbg};
 
 #[derive(Debug, Arbitrary)]
 pub struct Fuzz {

--- a/crates/fuzzing-support/src/bump_vec.rs
+++ b/crates/fuzzing-support/src/bump_vec.rs
@@ -1,8 +1,8 @@
 use arbitrary::Arbitrary;
-use bump_scope::{Bump, BumpAllocatorExt, BumpVec, MinimumAlignment, SupportedMinimumAlignment, alloc::Global};
+use bump_scope::{BumpAllocatorExt, BumpVec, MinimumAlignment, SupportedMinimumAlignment, alloc::Global};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::MinAlign;
+use crate::{Bump, MinAlign};
 
 impl Fuzz {
     pub fn run(self) {

--- a/crates/fuzzing-support/src/lib.rs
+++ b/crates/fuzzing-support/src/lib.rs
@@ -4,7 +4,7 @@
 use std::{alloc::Layout, cell::Cell, mem::swap, ops::Deref, ptr::NonNull, rc::Rc};
 
 use arbitrary::{Arbitrary, Unstructured};
-use bump_scope::alloc::{AllocError, Allocator};
+use bump_scope::alloc::{AllocError, Allocator, Global};
 
 pub use arbitrary;
 pub use bump_scope;
@@ -17,6 +17,8 @@ pub mod bump_up;
 pub mod bump_vec;
 pub mod chunk_size;
 mod from_bump_scope;
+
+pub type Bump<A = Global, const MIN_ALIGN: usize = 1, const UP: bool = true> = bump_scope::Bump<A, MIN_ALIGN, UP, true>;
 
 #[derive(Debug, Clone)]
 struct RcAllocator<A> {

--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -16,8 +16,8 @@ type Result<T = (), E = AllocError> = core::result::Result<T, E>;
 
 macro_rules! type_definitions {
     ($up:literal) => {
-        type Bump<const MIN_ALIGN: usize = 1> = bump_scope::Bump<Global, MIN_ALIGN, $up>;
-        type BumpScope<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScope<'a, Global, MIN_ALIGN, $up>;
+        type Bump<const MIN_ALIGN: usize = 1> = bump_scope::Bump<Global, MIN_ALIGN, $up, true>;
+        type BumpScope<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScope<'a, Global, MIN_ALIGN, $up, true>;
         type BumpScopeGuard<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuard<'a, Global, MIN_ALIGN, $up>;
         type BumpScopeGuardRoot<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuardRoot<'a, Global, MIN_ALIGN, $up>;
         type BumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<T, &'a Bump>;

--- a/crates/test-hashbrown/src/lib.rs
+++ b/crates/test-hashbrown/src/lib.rs
@@ -1,12 +1,14 @@
 #![cfg(test)]
 #![allow(clippy::approx_constant)]
 
-use bump_scope::Bump;
+use bump_scope::alloc::Global;
 use hashbrown::HashMap;
+
+type Bump = bump_scope::Bump<Global, 1, true, true>;
 
 #[test]
 fn test() {
-    let bump: Bump = Bump::new();
+    let bump = Bump::new();
     let mut map = HashMap::new_in(&bump);
     map.insert("tau", 6.283);
 }

--- a/crates/tests-from-std/src/bump_string.rs
+++ b/crates/tests-from-std/src/bump_string.rs
@@ -6,8 +6,10 @@ use std::ops::{Bound, RangeBounds};
 use std::string::String as StdString;
 use std::{panic, str};
 
-use bump_scope::{Bump, bump_format, bump_vec};
+use bump_scope::alloc::Global;
+use bump_scope::{bump_format, bump_vec};
 
+type Bump<A = Global> = bump_scope::Bump<A, 1, true, true>;
 type Vec<T, A = Bump> = bump_scope::BumpVec<T, A>;
 type String<A> = bump_scope::BumpString<A>;
 

--- a/crates/tests-from-std/src/bump_vec.rs
+++ b/crates/tests-from-std/src/bump_vec.rs
@@ -13,10 +13,10 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use bump_scope::Bump;
 use bump_scope::alloc::{AllocError, Allocator, Global};
 
-type Vec<T, A = bump_scope::Bump> = bump_scope::BumpVec<T, A>;
+type Bump<A = Global> = bump_scope::Bump<A, 1, true, true>;
+type Vec<T, A = Bump> = bump_scope::BumpVec<T, A>;
 
 trait VecNew: Sized {
     fn new() -> Self;
@@ -55,7 +55,7 @@ macro_rules! vec {
         bump_scope::bump_vec![in $($tt)*]
     };
     ($($tt:tt)*) => {
-        bump_scope::bump_vec![in <bump_scope::Bump>::default(); $($tt)*]
+        bump_scope::bump_vec![in <Bump>::default(); $($tt)*]
     };
 }
 

--- a/crates/tests-from-std/src/mut_bump_vec.rs
+++ b/crates/tests-from-std/src/mut_bump_vec.rs
@@ -13,10 +13,10 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use bump_scope::Bump;
 use bump_scope::alloc::{AllocError, Allocator, Global};
 
-type Vec<T, A = bump_scope::Bump> = bump_scope::MutBumpVec<T, A>;
+type Bump<A = Global> = bump_scope::Bump<A, 1, true, true>;
+type Vec<T, A = Bump> = bump_scope::MutBumpVec<T, A>;
 
 trait VecNew: Sized {
     fn new() -> Self;
@@ -55,7 +55,7 @@ macro_rules! vec {
         bump_scope::mut_bump_vec![in $($tt)*]
     };
     ($($tt:tt)*) => {
-        bump_scope::mut_bump_vec![in <bump_scope::Bump>::default(); $($tt)*]
+        bump_scope::mut_bump_vec![in <Bump>::default(); $($tt)*]
     };
 }
 

--- a/crates/tests-from-std/src/mut_bump_vec_rev.rs
+++ b/crates/tests-from-std/src/mut_bump_vec_rev.rs
@@ -11,10 +11,10 @@ use std::mem::swap;
 use std::panic::catch_unwind;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use bump_scope::Bump;
 use bump_scope::alloc::{AllocError, Allocator, Global};
 
-type Vec<T, A = bump_scope::Bump> = bump_scope::MutBumpVecRev<T, A>;
+type Bump<A = Global> = bump_scope::Bump<A, 1, true, true>;
+type Vec<T, A = Bump> = bump_scope::MutBumpVecRev<T, A>;
 
 trait VecNew: Sized {
     fn new() -> Self;
@@ -41,7 +41,7 @@ macro_rules! vec {
         bump_scope::mut_bump_vec_rev![in $($tt)*]
     };
     ($($tt:tt)*) => {
-        bump_scope::mut_bump_vec_rev![in <bump_scope::Bump>::default(); $($tt)*]
+        bump_scope::mut_bump_vec_rev![in <Bump>::default(); $($tt)*]
     };
 }
 

--- a/fuzz/fuzz_targets/slice_split_off.rs
+++ b/fuzz/fuzz_targets/slice_split_off.rs
@@ -2,7 +2,7 @@
 
 use core::{mem, ops::Range};
 
-use fuzzing_support::bump_scope::Bump;
+use fuzzing_support::Bump;
 use libfuzzer_sys::{
     arbitrary::{Arbitrary, Unstructured},
     fuzz_target,

--- a/fuzz/fuzz_targets/vec_split_off.rs
+++ b/fuzz/fuzz_targets/vec_split_off.rs
@@ -2,7 +2,7 @@
 
 use core::{mem, ops::Range};
 
-use fuzzing_support::bump_scope::{Bump, BumpVec};
+use fuzzing_support::{bump_scope::BumpVec, Bump};
 use libfuzzer_sys::{
     arbitrary::{Arbitrary, Unstructured},
     fuzz_target,

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -457,9 +457,11 @@ where
 }
 
 // Used for static assertions.
+#[cfg(test)]
 #[derive(Clone)]
 pub(crate) struct NoopAllocator;
 
+#[cfg(test)]
 unsafe impl Allocator for NoopAllocator {
     fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         Err(AllocError)

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -479,7 +479,7 @@ where
 }
 
 /// Methods for a [*guaranteed allocated*](crate#what-does-guaranteed-allocated-mean) `Bump`.
-impl<A, const MIN_ALIGN: usize, const UP: bool> Bump<A, MIN_ALIGN, UP>
+impl<A, const MIN_ALIGN: usize, const UP: bool> Bump<A, MIN_ALIGN, UP, true>
 where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: Allocator,
@@ -500,7 +500,7 @@ where
     /// assert_eq!(bump.stats().allocated(), 0);
     /// ```
     #[inline(always)]
-    pub fn scoped<R>(&mut self, f: impl FnOnce(BumpScope<A, MIN_ALIGN, UP>) -> R) -> R {
+    pub fn scoped<R>(&mut self, f: impl FnOnce(BumpScope<A, MIN_ALIGN, UP, true>) -> R) -> R {
         let mut guard = self.scope_guard();
         f(guard.scope())
     }
@@ -549,7 +549,7 @@ where
     #[inline(always)]
     pub fn scoped_aligned<const NEW_MIN_ALIGN: usize, R>(
         &mut self,
-        f: impl FnOnce(BumpScope<A, NEW_MIN_ALIGN, UP>) -> R,
+        f: impl FnOnce(BumpScope<A, NEW_MIN_ALIGN, UP, true>) -> R,
     ) -> R
     where
         MinimumAlignment<NEW_MIN_ALIGN>: SupportedMinimumAlignment,
@@ -632,7 +632,7 @@ where
     #[inline(always)]
     pub fn aligned<'a, const NEW_MIN_ALIGN: usize, R>(
         &'a mut self,
-        f: impl FnOnce(BumpScope<'a, A, NEW_MIN_ALIGN, UP>) -> R,
+        f: impl FnOnce(BumpScope<'a, A, NEW_MIN_ALIGN, UP, true>) -> R,
     ) -> R
     where
         MinimumAlignment<NEW_MIN_ALIGN>: SupportedMinimumAlignment,
@@ -1127,7 +1127,10 @@ where
     /// ```
     #[inline(always)]
     #[cfg(feature = "panic-on-alloc")]
-    pub fn into_guaranteed_allocated(self, f: impl FnOnce() -> Bump<A, MIN_ALIGN, UP>) -> Bump<A, MIN_ALIGN, UP> {
+    pub fn into_guaranteed_allocated(
+        self,
+        f: impl FnOnce() -> Bump<A, MIN_ALIGN, UP, true>,
+    ) -> Bump<A, MIN_ALIGN, UP, true> {
         self.as_scope().ensure_allocated(f);
         unsafe { transmute(self) }
     }
@@ -1188,8 +1191,8 @@ where
     #[inline(always)]
     pub fn try_into_guaranteed_allocated(
         self,
-        f: impl FnOnce() -> Result<Bump<A, MIN_ALIGN, UP>, AllocError>,
-    ) -> Result<Bump<A, MIN_ALIGN, UP>, AllocError> {
+        f: impl FnOnce() -> Result<Bump<A, MIN_ALIGN, UP, true>, AllocError>,
+    ) -> Result<Bump<A, MIN_ALIGN, UP, true>, AllocError> {
         self.as_scope().try_ensure_allocated(f)?;
         Ok(unsafe { transmute(self) })
     }
@@ -1224,7 +1227,10 @@ where
     /// ```
     #[inline(always)]
     #[cfg(feature = "panic-on-alloc")]
-    pub fn as_guaranteed_allocated(&self, f: impl FnOnce() -> Bump<A, MIN_ALIGN, UP>) -> &Bump<A, MIN_ALIGN, UP> {
+    pub fn as_guaranteed_allocated(
+        &self,
+        f: impl FnOnce() -> Bump<A, MIN_ALIGN, UP, true>,
+    ) -> &Bump<A, MIN_ALIGN, UP, true> {
         self.as_scope().ensure_allocated(f);
         unsafe { transmute_ref(self) }
     }
@@ -1262,8 +1268,8 @@ where
     #[inline(always)]
     pub fn try_as_guaranteed_allocated(
         &self,
-        f: impl FnOnce() -> Result<Bump<A, MIN_ALIGN, UP>, AllocError>,
-    ) -> Result<&Bump<A, MIN_ALIGN, UP>, AllocError> {
+        f: impl FnOnce() -> Result<Bump<A, MIN_ALIGN, UP, true>, AllocError>,
+    ) -> Result<&Bump<A, MIN_ALIGN, UP, true>, AllocError> {
         self.as_scope().try_ensure_allocated(f)?;
         Ok(unsafe { transmute_ref(self) })
     }
@@ -1324,8 +1330,8 @@ where
     #[cfg(feature = "panic-on-alloc")]
     pub fn as_mut_guaranteed_allocated(
         &mut self,
-        f: impl FnOnce() -> Bump<A, MIN_ALIGN, UP>,
-    ) -> &mut Bump<A, MIN_ALIGN, UP> {
+        f: impl FnOnce() -> Bump<A, MIN_ALIGN, UP, true>,
+    ) -> &mut Bump<A, MIN_ALIGN, UP, true> {
         self.as_scope().ensure_allocated(f);
         unsafe { transmute_mut(self) }
     }
@@ -1387,8 +1393,8 @@ where
     #[inline(always)]
     pub fn try_as_mut_guaranteed_allocated(
         &mut self,
-        f: impl FnOnce() -> Result<Bump<A, MIN_ALIGN, UP>, AllocError>,
-    ) -> Result<&mut Bump<A, MIN_ALIGN, UP>, AllocError> {
+        f: impl FnOnce() -> Result<Bump<A, MIN_ALIGN, UP, true>, AllocError>,
+    ) -> Result<&mut Bump<A, MIN_ALIGN, UP, true>, AllocError> {
         self.as_scope().try_ensure_allocated(f)?;
         Ok(unsafe { transmute_mut(self) })
     }

--- a/src/bump_pool.rs
+++ b/src/bump_pool.rs
@@ -79,7 +79,7 @@ macro_rules! make_pool {
             MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
             A: Allocator,
         {
-            bumps: Mutex<Vec<Bump<A, MIN_ALIGN, UP>>>,
+            bumps: Mutex<Vec<Bump<A, MIN_ALIGN, UP, true>>>,
             allocator: A,
         }
     };
@@ -136,11 +136,11 @@ where
     }
 
     /// Returns the vector of `Bump`s.
-    pub fn bumps(&mut self) -> &mut Vec<Bump<A, MIN_ALIGN, UP>> {
+    pub fn bumps(&mut self) -> &mut Vec<Bump<A, MIN_ALIGN, UP, true>> {
         self.bumps.get_mut().unwrap_or_else(PoisonError::into_inner)
     }
 
-    fn lock(&self) -> MutexGuard<'_, Vec<Bump<A, MIN_ALIGN, UP>>> {
+    fn lock(&self) -> MutexGuard<'_, Vec<Bump<A, MIN_ALIGN, UP, true>>> {
         self.bumps.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
@@ -300,7 +300,7 @@ macro_rules! make_pool_guard {
             MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
             A: Allocator,
         {
-            bump: ManuallyDrop<Bump<A, MIN_ALIGN, UP>>,
+            bump: ManuallyDrop<Bump<A, MIN_ALIGN, UP, true>>,
 
             #[doc(hidden)]
             #[deprecated = "Swapping the pool can lead to Undefined Behavior due to dangling pointers, use `pool()` instead!"]
@@ -328,7 +328,7 @@ where
     MinimumAlignment<MIN_ALIGN>: SupportedMinimumAlignment,
     A: Allocator,
 {
-    type Target = BumpScope<'a, A, MIN_ALIGN, UP>;
+    type Target = BumpScope<'a, A, MIN_ALIGN, UP, true>;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
@@ -362,15 +362,15 @@ where
 // This exists as a "safer" transmute that only transmutes the `'a` lifetime parameter.
 #[allow(clippy::needless_lifetimes, clippy::elidable_lifetime_names)]
 unsafe fn transmute_lifetime<'from, 'to, 'b, A, const MIN_ALIGN: usize, const UP: bool>(
-    scope: &'b BumpScope<'from, A, MIN_ALIGN, UP>,
-) -> &'b BumpScope<'to, A, MIN_ALIGN, UP> {
+    scope: &'b BumpScope<'from, A, MIN_ALIGN, UP, true>,
+) -> &'b BumpScope<'to, A, MIN_ALIGN, UP, true> {
     unsafe { mem::transmute(scope) }
 }
 
 // This exists as a "safer" transmute that only transmutes the `'a` lifetime parameter.
 #[allow(clippy::needless_lifetimes, clippy::elidable_lifetime_names)]
 unsafe fn transmute_lifetime_mut<'from, 'to, 'b, A, const MIN_ALIGN: usize, const UP: bool>(
-    scope: &'b mut BumpScope<'from, A, MIN_ALIGN, UP>,
-) -> &'b mut BumpScope<'to, A, MIN_ALIGN, UP> {
+    scope: &'b mut BumpScope<'from, A, MIN_ALIGN, UP, true>,
+) -> &'b mut BumpScope<'to, A, MIN_ALIGN, UP, true> {
     unsafe { mem::transmute(scope) }
 }

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -66,7 +66,7 @@ where
 {
     #[inline(always)]
     #[allow(clippy::needless_pass_by_ref_mut)]
-    pub(crate) fn new(bump: &'a mut BumpScope<'_, A, MIN_ALIGN, UP>) -> Self {
+    pub(crate) fn new(bump: &'a mut BumpScope<'_, A, MIN_ALIGN, UP, true>) -> Self {
         unsafe { Self::new_unchecked(bump.chunk.get()) }
     }
 
@@ -81,7 +81,7 @@ where
 
     /// Returns a new `BumpScope`.
     #[inline(always)]
-    pub fn scope(&mut self) -> BumpScope<'_, A, MIN_ALIGN, UP> {
+    pub fn scope(&mut self) -> BumpScope<'_, A, MIN_ALIGN, UP, true> {
         unsafe { BumpScope::new_unchecked(self.chunk) }
     }
 
@@ -152,7 +152,7 @@ where
 {
     #[inline(always)]
     #[allow(clippy::needless_pass_by_ref_mut)]
-    pub(crate) fn new(bump: &'a mut Bump<A, MIN_ALIGN, UP>) -> Self {
+    pub(crate) fn new(bump: &'a mut Bump<A, MIN_ALIGN, UP, true>) -> Self {
         unsafe { Self::new_unchecked(bump.chunk.get()) }
     }
 
@@ -166,7 +166,7 @@ where
 
     /// Returns a new `BumpScope`.
     #[inline(always)]
-    pub fn scope(&mut self) -> BumpScope<'_, A, MIN_ALIGN, UP> {
+    pub fn scope(&mut self) -> BumpScope<'_, A, MIN_ALIGN, UP, true> {
         unsafe { BumpScope::new_unchecked(self.chunk) }
     }
 

--- a/src/owned_slice.rs
+++ b/src/owned_slice.rs
@@ -316,7 +316,7 @@ unsafe impl<T> TakeOwnedSlice for vec::Drain<'_, T> {
 
 #[cfg(all(test, feature = "alloc"))]
 mod tests {
-    use crate::Bump;
+    use crate::tests::Bump;
 
     use super::*;
 

--- a/src/owned_slice/drain.rs
+++ b/src/owned_slice/drain.rs
@@ -274,7 +274,10 @@ unsafe impl<T> TakeOwnedSlice for Drain<'_, T> {
 mod tests {
     use std::{string::ToString, vec::Vec};
 
-    use crate::{Bump, FixedBumpVec, tests::TestWrap};
+    use crate::{
+        FixedBumpVec,
+        tests::{Bump, TestWrap},
+    };
 
     #[test]
     fn owned_slice() {

--- a/src/tests/alloc_clone.rs
+++ b/src/tests/alloc_clone.rs
@@ -5,7 +5,7 @@ use std::{
     vec::Vec,
 };
 
-use crate::Bump;
+use crate::tests::Bump;
 
 #[test]
 fn test_slice() {

--- a/src/tests/alloc_cstr.rs
+++ b/src/tests/alloc_cstr.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{Bump, alloc::Global};
+use crate::{alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/alloc_fmt.rs
+++ b/src/tests/alloc_fmt.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use crate::{
-    Bump,
     alloc::{AllocError, Allocator, Global},
     bump_format, mut_bump_format,
+    tests::Bump,
 };
 
 use super::either_way;

--- a/src/tests/alloc_iter.rs
+++ b/src/tests/alloc_iter.rs
@@ -1,4 +1,4 @@
-use crate::{Bump, alloc::Global};
+use crate::{alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/alloc_slice.rs
+++ b/src/tests/alloc_slice.rs
@@ -1,6 +1,6 @@
 use std::string::{String, ToString};
 
-use crate::{Bump, alloc::Global};
+use crate::{alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/alloc_try_with.rs
+++ b/src/tests/alloc_try_with.rs
@@ -3,7 +3,7 @@ use std::{
     mem::{self, offset_of},
 };
 
-use crate::{Bump, alloc::Global};
+use crate::{alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/allocator_api.rs
+++ b/src/tests/allocator_api.rs
@@ -1,9 +1,9 @@
 use std::{alloc::Layout, ptr::NonNull};
 
 use crate::{
-    Bump,
     alloc::{Allocator, Global},
     polyfill::non_null,
+    tests::Bump,
 };
 
 use super::either_way;

--- a/src/tests/append.rs
+++ b/src/tests/append.rs
@@ -10,8 +10,9 @@ use std::{
 };
 
 use crate::{
-    Bump, BumpAllocatorExt, BumpBox, BumpVec, FixedBumpVec, MutBumpAllocatorExt, MutBumpVec, MutBumpVecRev,
+    BumpAllocatorExt, BumpBox, BumpVec, FixedBumpVec, MutBumpAllocatorExt, MutBumpVec, MutBumpVecRev,
     owned_slice::{self, OwnedSlice, TakeOwnedSlice},
+    tests::Bump,
     unsize_bump_box,
 };
 

--- a/src/tests/bump_allocator.rs
+++ b/src/tests/bump_allocator.rs
@@ -3,7 +3,7 @@ use std::{
     vec::Vec,
 };
 
-use crate::{Bump, BumpAllocatorExt, BumpVec, MutBumpAllocatorExt, MutBumpVec};
+use crate::{BumpAllocatorExt, BumpVec, MutBumpAllocatorExt, MutBumpVec, tests::Bump};
 
 fn number_strings(numbers: impl IntoIterator<Item = i32>) -> impl Iterator<Item = String> {
     numbers.into_iter().map(|i| i.to_string())

--- a/src/tests/bump_string.rs
+++ b/src/tests/bump_string.rs
@@ -1,4 +1,4 @@
-use crate::{Bump, BumpString, BumpVec, alloc::Global};
+use crate::{BumpString, BumpVec, alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/bump_vec.rs
+++ b/src/tests/bump_vec.rs
@@ -9,8 +9,11 @@ use std::{
 };
 
 use crate::{
-    Bump, BumpAllocator, BumpAllocatorExt, BumpAllocatorScope, BumpScope, BumpVec, MutBumpAllocator, MutBumpAllocatorScope,
-    WithoutDealloc, WithoutShrink, alloc::Global, bump_vec, tests::expect_no_panic,
+    BumpAllocator, BumpAllocatorExt, BumpAllocatorScope, BumpVec, MutBumpAllocator, MutBumpAllocatorScope, WithoutDealloc,
+    WithoutShrink,
+    alloc::Global,
+    bump_vec,
+    tests::{Bump, BumpScope, expect_no_panic},
 };
 
 use super::either_way;

--- a/src/tests/bump_vec_doc.rs
+++ b/src/tests/bump_vec_doc.rs
@@ -1,6 +1,6 @@
 //! doc tests but for up and down
 
-use crate::{Bump, BumpVec, alloc::Global, bump_vec};
+use crate::{BumpVec, alloc::Global, bump_vec, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/chunk_size.rs
+++ b/src/tests/chunk_size.rs
@@ -5,9 +5,9 @@ use core::{alloc::Layout, ptr::NonNull};
 use std::convert::Infallible;
 
 use crate::{
-    Bump,
     alloc::{AllocError, Allocator, Global},
     chunk_size::AssumedMallocOverhead,
+    tests::Bump,
 };
 
 use super::either_way;

--- a/src/tests/coerce_unsized.rs
+++ b/src/tests/coerce_unsized.rs
@@ -1,6 +1,6 @@
 use std::{dbg, fmt::Debug, future::Future};
 
-use crate::{Bump, BumpBox};
+use crate::{BumpBox, tests::Bump};
 
 #[test]
 fn slice() {

--- a/src/tests/fixed_bump_vec.rs
+++ b/src/tests/fixed_bump_vec.rs
@@ -8,7 +8,12 @@ use std::{
     vec::Vec,
 };
 
-use crate::{Bump, FixedBumpVec, alloc::Global, bump_vec, tests::expect_no_panic};
+use crate::{
+    FixedBumpVec,
+    alloc::Global,
+    bump_vec,
+    tests::{Bump, expect_no_panic},
+};
 
 use super::either_way;
 

--- a/src/tests/fn_traits.rs
+++ b/src/tests/fn_traits.rs
@@ -1,6 +1,6 @@
 use std::{panic::catch_unwind, string::String};
 
-use crate::{Bump, BumpBox};
+use crate::{BumpBox, tests::Bump};
 
 #[test]
 fn fn_once() {

--- a/src/tests/grow_vec.rs
+++ b/src/tests/grow_vec.rs
@@ -3,7 +3,7 @@ use std::{
     vec::Vec,
 };
 
-use crate::{Bump, BumpVec, MutBumpVec, MutBumpVecRev};
+use crate::{BumpVec, MutBumpVec, MutBumpVecRev, tests::Bump};
 
 #[test]
 fn grow_vec() {

--- a/src/tests/into_flattened.rs
+++ b/src/tests/into_flattened.rs
@@ -4,7 +4,7 @@ use std::{
     vec::Vec,
 };
 
-use crate::{Bump, BumpVec, FixedBumpVec, MutBumpVec, MutBumpVecRev};
+use crate::{BumpVec, FixedBumpVec, MutBumpVec, MutBumpVecRev, tests::Bump};
 
 fn items() -> impl Iterator<Item = [String; 3]> {
     // would use `array_chunks`, but it's not stable

--- a/src/tests/io_write.rs
+++ b/src/tests/io_write.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use crate::{
-    Bump, BumpVec, FixedBumpVec, MutBumpVec,
+    BumpVec, FixedBumpVec, MutBumpVec,
     alloc::{Allocator, Global},
+    tests::Bump,
 };
 
 use super::limited_allocator::Limited;

--- a/src/tests/may_dangle.rs
+++ b/src/tests/may_dangle.rs
@@ -8,7 +8,7 @@
 
 use std::{string::String, vec};
 
-use crate::{Bump, BumpBox, BumpVec, FixedBumpVec, MutBumpVec, MutBumpVecRev, bump_vec};
+use crate::{BumpBox, BumpVec, FixedBumpVec, MutBumpVec, MutBumpVecRev, bump_vec, tests::Bump};
 
 #[test]
 fn test_std() {

--- a/src/tests/misalignment_due_to_dealloc.rs
+++ b/src/tests/misalignment_due_to_dealloc.rs
@@ -1,9 +1,8 @@
 use core::alloc::Layout;
 
 use crate::{
-    Bump,
     alloc::{Allocator, Global},
-    tests::either_way,
+    tests::{Bump, either_way},
 };
 
 either_way! {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -62,13 +62,28 @@ mod unaligned_collection;
 mod unallocated;
 mod vec;
 
+pub(crate) type Bump<
+    A = Global,
+    const MIN_ALIGN: usize = 1,
+    const UP: bool = true,
+    const GUARANTEED_ALLOCATED: bool = true,
+> = crate::Bump<A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>;
+
+pub(crate) type BumpScope<
+    'a,
+    A = Global,
+    const MIN_ALIGN: usize = 1,
+    const UP: bool = true,
+    const GUARANTEED_ALLOCATED: bool = true,
+> = crate::BumpScope<'a, A, MIN_ALIGN, UP, GUARANTEED_ALLOCATED>;
+
 type Result<T = (), E = AllocError> = core::result::Result<T, E>;
 
 const MALLOC_OVERHEAD: usize = size_of::<AssumedMallocOverhead>();
 const OVERHEAD: usize = MALLOC_OVERHEAD + size_of::<ChunkHeader<Global>>();
 
 use crate::{
-    Bump, BumpBox, BumpScope, BumpString, BumpVec, ChunkHeader, MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev,
+    BumpBox, BumpString, BumpVec, ChunkHeader, MinimumAlignment, MutBumpString, MutBumpVec, MutBumpVecRev,
     SizedTypeProperties, SupportedMinimumAlignment,
     alloc::{AllocError, Allocator, Global as System, Global},
     chunk_size::{AssumedMallocOverhead, ChunkSize},

--- a/src/tests/mut_bump_vec_doc.rs
+++ b/src/tests/mut_bump_vec_doc.rs
@@ -1,6 +1,6 @@
 //! doc tests but for up and down
 
-use crate::{Bump, MutBumpVec, alloc::Global, mut_bump_vec};
+use crate::{MutBumpVec, alloc::Global, mut_bump_vec, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/mut_bump_vec_rev_doc.rs
+++ b/src/tests/mut_bump_vec_rev_doc.rs
@@ -1,6 +1,6 @@
 //! doc tests but for up and down
 
-use crate::{Bump, MutBumpVecRev, alloc::Global, mut_bump_vec_rev};
+use crate::{MutBumpVecRev, alloc::Global, mut_bump_vec_rev, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/mut_collections_do_not_waste_space.rs
+++ b/src/tests/mut_collections_do_not_waste_space.rs
@@ -1,6 +1,6 @@
 use core::iter;
 
-use crate::{Bump, MutBumpVec, MutBumpVecRev, alloc::Global};
+use crate::{MutBumpVec, MutBumpVecRev, alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/tests/panic_safety.rs
+++ b/src/tests/panic_safety.rs
@@ -8,7 +8,7 @@ use std::{
     thread_local,
 };
 
-use crate::{Bump, BumpVec, MutBumpVec, MutBumpVecRev, bump_vec, mut_bump_vec, mut_bump_vec_rev};
+use crate::{BumpVec, MutBumpVec, MutBumpVecRev, bump_vec, mut_bump_vec, mut_bump_vec_rev, tests::Bump};
 
 macro_rules! zst_or_not {
     (

--- a/src/tests/split_off.rs
+++ b/src/tests/split_off.rs
@@ -2,7 +2,7 @@
 
 use std::{string::String, vec};
 
-use crate::{Bump, BumpString, BumpVec, bump_vec};
+use crate::{BumpString, BumpVec, bump_vec, tests::Bump};
 
 use super::TestWrap;
 

--- a/src/tests/test_mut_bump_vec.rs
+++ b/src/tests/test_mut_bump_vec.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use crate::{
-    Bump, BumpScope, MutBumpAllocator, MutBumpAllocatorExt, MutBumpAllocatorScope, MutBumpAllocatorScopeExt, MutBumpVec,
+    MutBumpAllocator, MutBumpAllocatorExt, MutBumpAllocatorScope, MutBumpAllocatorScopeExt, MutBumpVec,
     alloc::{Allocator, Global},
-    tests::either_way,
+    tests::{Bump, BumpScope, either_way},
 };
 
 either_way! {

--- a/src/tests/test_mut_bump_vec_rev.rs
+++ b/src/tests/test_mut_bump_vec_rev.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use crate::{
-    Bump, BumpScope, MutBumpAllocator, MutBumpAllocatorExt, MutBumpAllocatorScope, MutBumpAllocatorScopeExt, MutBumpVecRev,
+    MutBumpAllocator, MutBumpAllocatorExt, MutBumpAllocatorScope, MutBumpAllocatorScopeExt, MutBumpVecRev,
     alloc::{Allocator, Global},
-    tests::either_way,
+    tests::{Bump, BumpScope, either_way},
 };
 
 either_way! {

--- a/src/tests/vec.rs
+++ b/src/tests/vec.rs
@@ -2,7 +2,7 @@
 
 use allocator_api2_02::{boxed::Box, vec::Vec};
 
-use crate::{Bump, alloc::Global};
+use crate::{alloc::Global, tests::Bump};
 
 use super::either_way;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,3 @@
-use crate::alloc::Allocator;
-
 mod bump_allocator;
 pub(crate) mod bump_allocator_ext;
 mod bump_allocator_scope;
@@ -31,13 +29,24 @@ pub(crate) use assert_dyn_compatible;
 
 macro_rules! assert_implements {
     ([$($what:tt)*] $($ty:ty)*) => {
+        #[cfg(test)]
         const _: () = {
+            #[allow(unused_imports)]
+            use crate::{
+                alloc::Allocator,
+                traits::{
+                    BumpAllocatorScope,
+                    MutBumpAllocator,
+                    MutBumpAllocatorScope,
+                }
+            };
+
             #[allow(dead_code)]
             type A = crate::alloc::NoopAllocator;
             #[allow(dead_code)]
-            type Bump = crate::Bump<A>;
+            type Bump = crate::Bump<A, 1, true, true>;
             #[allow(dead_code)]
-            type BumpScope<'a> = crate::BumpScope<'a, A>;
+            type BumpScope<'a> = crate::BumpScope<'a, A, 1, true, true>;
             #[allow(clippy::extra_unused_lifetimes)]
             const fn implements<'a, What: $($what)*>() {}
             $(

--- a/src/traits/bump_allocator.rs
+++ b/src/traits/bump_allocator.rs
@@ -1,8 +1,7 @@
 use core::{alloc::Layout, ops::Range, ptr::NonNull};
 
 use crate::{
-    BaseAllocator, Bump, BumpAllocatorScope, BumpScope, Checkpoint, MinimumAlignment, MutBumpAllocator,
-    MutBumpAllocatorScope, SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
+    BaseAllocator, Bump, BumpScope, Checkpoint, MinimumAlignment, SupportedMinimumAlignment, WithoutDealloc, WithoutShrink,
     alloc::{AllocError, Allocator},
     layout::CustomLayout,
     stats::AnyStats,

--- a/src/traits/bump_allocator_scope.rs
+++ b/src/traits/bump_allocator_scope.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BaseAllocator, Bump, BumpAllocator, BumpScope, MinimumAlignment, MutBumpAllocatorScope, SupportedMinimumAlignment,
-    WithoutDealloc, WithoutShrink,
+    BaseAllocator, Bump, BumpAllocator, BumpScope, MinimumAlignment, SupportedMinimumAlignment, WithoutDealloc,
+    WithoutShrink,
     traits::{assert_dyn_compatible, assert_implements},
 };
 

--- a/src/traits/bump_allocator_scope_ext.rs
+++ b/src/traits/bump_allocator_scope_ext.rs
@@ -1,4 +1,4 @@
-use crate::{BumpAllocatorExt, BumpAllocatorScope, MutBumpAllocatorScope, traits::assert_implements};
+use crate::{BumpAllocatorExt, BumpAllocatorScope, traits::assert_implements};
 
 /// A shorthand for <code>[BumpAllocatorScope]<'a> + [BumpAllocatorExt]</code>
 pub trait BumpAllocatorScopeExt<'a>: BumpAllocatorScope<'a> + BumpAllocatorExt {}

--- a/tests/limit_memory_usage.rs
+++ b/tests/limit_memory_usage.rs
@@ -3,10 +3,7 @@
 
 use std::{alloc::Layout, cell::Cell, ptr::NonNull};
 
-use bump_scope::{
-    Bump,
-    alloc::{AllocError, Allocator, Global},
-};
+use bump_scope::alloc::{AllocError, Allocator, Global};
 
 struct Limited<A> {
     current: Cell<usize>,
@@ -98,11 +95,13 @@ where
     }
 }
 
+type Bump<A> = bump_scope::Bump<A, 1, true, true>;
+
 #[test]
 fn main() {
     let allocator = Limited::new_in(1024, Global);
 
-    let bump = Bump::<_, 1, true>::with_size_in(1024, &allocator);
+    let bump = Bump::with_size_in(1024, &allocator);
 
     // allocate the entire remaining capacity
     let remaining = bump.stats().remaining();

--- a/tests/static_memory.rs
+++ b/tests/static_memory.rs
@@ -9,10 +9,7 @@ use core::{
 };
 use std::sync::{Mutex, PoisonError};
 
-use bump_scope::{
-    Bump,
-    alloc::{AllocError, Allocator},
-};
+use bump_scope::alloc::{AllocError, Allocator};
 
 #[repr(C, align(16))]
 struct StaticAllocator<const SIZE: usize> {
@@ -105,10 +102,12 @@ unsafe impl<const SIZE: usize> Allocator for StaticAllocator<SIZE> {
     }
 }
 
+type Bump<A> = bump_scope::Bump<A, 1, true, true>;
+
 fn on_stack() {
     let memory = StaticAllocator::<1024>::new();
 
-    let bump = Bump::<_, 1, true>::new_in(&memory);
+    let bump = Bump::new_in(&memory);
     assert_eq!(bump.stats().size(), 1024);
 
     let str = bump.alloc_str("It works!");
@@ -122,7 +121,7 @@ fn on_static() {
     let guard = MEMORY.lock().unwrap_or_else(PoisonError::into_inner);
     let memory = &*guard;
 
-    let bump = Bump::<_, 1, true>::new_in(memory);
+    let bump = Bump::new_in(memory);
     assert_eq!(bump.stats().size(), 1024);
 
     let str = bump.alloc_str("It works!");


### PR DESCRIPTION
It's useful to temporarily remove all default parameters to find bugs where a default parameter is used when it was unintentional. If we don't rely on the default parameters so much, then we can more clearly see such oversights.

Having aliases for `Bump` in tests is good actually because that's how `bump-scope` should be used.

If we add a new parameter like `DEALLOCATES` (#99) then we will need to be explicit about the `GUARANTEED_ALLOCATED` anyhow so this refactor helps with that.
