### PR TITLE
Rename `as_aligned_mut` to `as_mut_aligned`

### DIFF
--- a/crates/test-fallibility/src/lib.rs
+++ b/crates/test-fallibility/src/lib.rs
@@ -75,8 +75,8 @@ up_and_down! {
         bump.into_aligned()
     }
 
-    pub fn Bump_as_aligned_mut(bump: &mut Bump) -> &mut Bump<4> {
-        bump.as_aligned_mut()
+    pub fn Bump_as_mut_aligned(bump: &mut Bump) -> &mut Bump<4> {
+        bump.as_mut_aligned()
     }
 
     pub fn Bump_allocate(bump: &Bump, layout: Layout) -> Result<NonNull<[u8]>> {

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -77,7 +77,7 @@ macro_rules! make_type {
         /// - guaranteed allocated:
         ///   <code>{[as](Self::as_guaranteed_allocated), [as_mut](Self::as_mut_guaranteed_allocated), [into](Self::into_guaranteed_allocated)}_guaranteed_allocated</code>,
         ///   <code>{[as](Self::as_not_guaranteed_allocated), [into](Self::into_not_guaranteed_allocated)}_not_guaranteed_allocated</code>
-        /// - minimum alignment: [`aligned`], [`as_aligned_mut`], [`into_aligned`]
+        /// - minimum alignment: [`aligned`], [`as_mut_aligned`], [`into_aligned`]
         /// - deallocation:
         ///   <code>{[as](Self::as_with_dealloc), [as_mut](Self::as_mut_with_dealloc), [into](Self::into_with_dealloc)}_with_dealloc</code>
         ///   <code>{[as](Self::as_without_dealloc), [as_mut](Self::as_mut_without_dealloc), [into](Self::into_without_dealloc)}_without_dealloc</code>
@@ -172,7 +172,7 @@ macro_rules! make_type {
         /// [`reset`]: Self::reset
         ///
         /// [`aligned`]: Self::aligned
-        /// [`as_aligned_mut`]: Self::as_aligned_mut
+        /// [`as_mut_aligned`]: Self::as_mut_aligned
         /// [`into_aligned`]: Self::into_aligned
         ///
         /// [`into_with_dealloc`]: Self::into_with_dealloc
@@ -1079,7 +1079,7 @@ where
     /// When decreasing the alignment we need to make sure that the bump position is realigned to the original alignment.
     /// That can only be ensured by having a function that takes a closure, like the methods mentioned above do.
     #[inline(always)]
-    pub fn as_aligned_mut<const NEW_MIN_ALIGN: usize>(
+    pub fn as_mut_aligned<const NEW_MIN_ALIGN: usize>(
         &mut self,
     ) -> &mut Bump<A, NEW_MIN_ALIGN, UP, GUARANTEED_ALLOCATED, DEALLOCATES>
     where
@@ -1087,6 +1087,18 @@ where
     {
         self.as_scope().must_align_more::<NEW_MIN_ALIGN>();
         unsafe { self.cast_align_mut() }
+    }
+
+    #[doc(hidden)]
+    #[inline(always)]
+    #[deprecated = "renamed to `as_mut_aligned`"]
+    pub fn as_aligned_mut<const NEW_MIN_ALIGN: usize>(
+        &mut self,
+    ) -> &mut Bump<A, NEW_MIN_ALIGN, UP, GUARANTEED_ALLOCATED, DEALLOCATES>
+    where
+        MinimumAlignment<NEW_MIN_ALIGN>: SupportedMinimumAlignment,
+    {
+        self.as_mut_aligned()
     }
 
     #[inline(always)]

--- a/src/bump_scope.rs
+++ b/src/bump_scope.rs
@@ -584,7 +584,7 @@ where
         MinimumAlignment<NEW_MIN_ALIGN>: SupportedMinimumAlignment,
     {
         const_param_assert! {
-            (const MIN_ALIGN: usize, const NEW_MIN_ALIGN: usize) => NEW_MIN_ALIGN >= MIN_ALIGN, "`into_aligned` or `as_aligned_mut` can't decrease the minimum alignment"
+            (const MIN_ALIGN: usize, const NEW_MIN_ALIGN: usize) => NEW_MIN_ALIGN >= MIN_ALIGN, "`into_aligned` or `as_mut_aligned` can't decrease the minimum alignment"
         }
 
         self.align::<NEW_MIN_ALIGN>();
@@ -598,7 +598,7 @@ where
     /// When decreasing the alignment we need to make sure that the bump position is realigned to the original alignment.
     /// That can only be ensured by having a function that takes a closure, like the methods mentioned above do.
     #[inline(always)]
-    pub fn as_aligned_mut<const NEW_MIN_ALIGN: usize>(
+    pub fn as_mut_aligned<const NEW_MIN_ALIGN: usize>(
         &mut self,
     ) -> &mut BumpScope<'a, A, NEW_MIN_ALIGN, UP, GUARANTEED_ALLOCATED, DEALLOCATES>
     where
@@ -606,6 +606,18 @@ where
     {
         self.must_align_more::<NEW_MIN_ALIGN>();
         unsafe { self.cast_align_mut() }
+    }
+
+    #[doc(hidden)]
+    #[inline(always)]
+    #[deprecated = "renamed to `as_mut_aligned`"]
+    pub fn as_aligned_mut<const NEW_MIN_ALIGN: usize>(
+        &mut self,
+    ) -> &mut BumpScope<'a, A, NEW_MIN_ALIGN, UP, GUARANTEED_ALLOCATED, DEALLOCATES>
+    where
+        MinimumAlignment<NEW_MIN_ALIGN>: SupportedMinimumAlignment,
+    {
+        self.as_mut_aligned()
     }
 
     /// Returns `&self` as is. This is useful for macros that support both `Bump` and `BumpScope`.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -551,13 +551,13 @@ fn as_aligned<const UP: bool>() {
     let mut bump: Bump = Bump::new();
 
     {
-        let bump = bump.as_aligned_mut::<8>();
+        let bump = bump.as_mut_aligned::<8>();
         assert_eq!(bump.stats().allocated(), 0);
     }
 
     {
         bump.alloc(1u8);
-        let bump = bump.as_aligned_mut::<8>();
+        let bump = bump.as_mut_aligned::<8>();
         assert_eq!(bump.stats().allocated(), 8);
         bump.alloc(2u16);
         assert_eq!(bump.stats().allocated(), 16);
@@ -753,12 +753,12 @@ fn realign<const UP: bool>() {
         assert!(bump.stats().current_chunk().bump_position().cast::<AlignT>().is_aligned());
     }
 
-    // as_aligned_mut
+    // as_mut_aligned
     {
         let mut bump = Bump::<Global, 1, UP>::with_size(64);
         bump.alloc(0u8);
         assert!(!bump.stats().current_chunk().bump_position().cast::<AlignT>().is_aligned());
-        let bump = bump.as_aligned_mut::<ALIGN>();
+        let bump = bump.as_mut_aligned::<ALIGN>();
         assert!(bump.stats().current_chunk().bump_position().cast::<AlignT>().is_aligned());
     }
 


### PR DESCRIPTION
Fixes #105 