### PR TITLE
Remove `unchecked_mul` polyfill

### DIFF
--- a/src/bump_box.rs
+++ b/src/bump_box.rs
@@ -2830,7 +2830,7 @@ impl<'a, T, const N: usize> BumpBox<'a, [[T; N]]> {
             // the address space.
             // - Each `[T; N]` has `N` valid elements, so there are `len * N`
             // valid elements in the allocation.
-            unsafe { polyfill::usize::unchecked_mul(len, N) }
+            unsafe { len.unchecked_mul(N) }
         };
 
         unsafe { BumpBox::from_raw(NonNull::slice_from_raw_parts(ptr.cast(), new_len)) }

--- a/src/fixed_bump_vec.rs
+++ b/src/fixed_bump_vec.rs
@@ -2241,7 +2241,7 @@ impl<'a, T, const N: usize> FixedBumpVec<'a, [T; N]> {
             // the address space.
             // - Each `[T; N]` has `N` valid elements, so there are `len * N`
             // valid elements in the allocation.
-            unsafe { (polyfill::usize::unchecked_mul(len, N), polyfill::usize::unchecked_mul(cap, N)) }
+            unsafe { (len.unchecked_mul(N), cap.unchecked_mul(N)) }
         };
 
         // SAFETY:

--- a/src/mut_bump_vec_rev.rs
+++ b/src/mut_bump_vec_rev.rs
@@ -2552,7 +2552,7 @@ impl<T, A, const N: usize> MutBumpVecRev<[T; N], A> {
             // the address space.
             // - Each `[T; N]` has `N` valid elements, so there are `len * N`
             // valid elements in the allocation.
-            unsafe { (polyfill::usize::unchecked_mul(len, N), polyfill::usize::unchecked_mul(cap, N)) }
+            unsafe { (len.unchecked_mul(N), cap.unchecked_mul(N)) }
         };
 
         unsafe { MutBumpVecRev::from_raw_parts(end.cast(), new_len, new_cap, allocator) }

--- a/src/polyfill/mod.rs
+++ b/src/polyfill/mod.rs
@@ -10,7 +10,6 @@ pub(crate) mod layout;
 pub(crate) mod non_null;
 pub(crate) mod pointer;
 pub(crate) mod slice;
-pub(crate) mod usize;
 
 use core::mem::{ManuallyDrop, size_of};
 

--- a/src/polyfill/usize.rs
+++ b/src/polyfill/usize.rs
@@ -1,5 +1,0 @@
-/// See [`usize::unchecked_mul`].
-#[inline(always)]
-pub(crate) unsafe fn unchecked_mul(lhs: usize, rhs: usize) -> usize {
-    lhs * rhs
-}


### PR DESCRIPTION
The new MSRV (since 1.0) allows us to use the built-in one.