### PR TITLE
Make scopes work with a shared reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `claim` api that allows you to enter scopes with a shared reference
 - `alloc*` methods are now available for the `(Mut)BumpAllocatorTypedScope` traits
 - `reserve_bytes` method is now available for the `BumpAllocatorTyped` trait
 - Add new `BumpAllocator(Scope)` trait that allows you to be generic over `Bump` and `BumpScope`

--- a/crates/test-no-panic/src/lib.rs
+++ b/crates/test-no-panic/src/lib.rs
@@ -18,13 +18,12 @@ type Result<T = (), E = AllocError> = core::result::Result<T, E>;
 
 macro_rules! type_definitions {
     ($up:literal) => {
-        type Bump<const MIN_ALIGN: usize = 1> = bump_scope::Bump<Global, BumpSettings<MIN_ALIGN, $up, true, true>>;
-        type BumpScope<'a, const MIN_ALIGN: usize = 1> =
-            bump_scope::BumpScope<'a, Global, BumpSettings<MIN_ALIGN, $up, true, true>>;
-        type BumpScopeGuard<'a, const MIN_ALIGN: usize = 1> =
-            bump_scope::BumpScopeGuard<'a, Global, BumpSettings<MIN_ALIGN, $up>>;
+        type Settings<const MIN_ALIGN: usize> = BumpSettings<MIN_ALIGN, $up, true, false>;
+        type Bump<const MIN_ALIGN: usize = 1> = bump_scope::Bump<Global, Settings<MIN_ALIGN>>;
+        type BumpScope<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScope<'a, Global, Settings<MIN_ALIGN>>;
+        type BumpScopeGuard<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpScopeGuard<'a, Global, Settings<MIN_ALIGN>>;
         type BumpScopeGuardRoot<'a, const MIN_ALIGN: usize = 1> =
-            bump_scope::BumpScopeGuardRoot<'a, Global, BumpSettings<MIN_ALIGN, $up>>;
+            bump_scope::BumpScopeGuardRoot<'a, Global, Settings<MIN_ALIGN>>;
         type BumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::BumpVec<T, &'a Bump>;
         type BumpString<'a, const MIN_ALIGN: usize = 1> = bump_scope::BumpString<&'a Bump>;
         type MutBumpVec<'a, T, const MIN_ALIGN: usize = 1> = bump_scope::MutBumpVec<T, &'a mut Bump<MIN_ALIGN>>;

--- a/src/bump_claim_guard.rs
+++ b/src/bump_claim_guard.rs
@@ -1,0 +1,73 @@
+use core::ops::{Deref, DerefMut};
+
+use crate::{
+    BumpScope,
+    alloc::Allocator,
+    chunk::RawChunk,
+    settings::{BumpAllocatorSettings, BumpSettings, True},
+};
+
+// For docs.
+#[allow(unused_imports)]
+use crate::traits::*;
+
+/// Returned from [`BumpAllocatorScope::claim`].
+pub struct BumpClaimGuard<'b, 'a, A, S = BumpSettings>
+where
+    A: Allocator,
+    S: BumpAllocatorSettings,
+{
+    pub(crate) original: &'b BumpScope<'a, A, S>,
+    pub(crate) claimed: BumpScope<'a, A, S>,
+}
+
+impl<'b, 'a, A, S> BumpClaimGuard<'b, 'a, A, S>
+where
+    A: Allocator,
+    S: BumpAllocatorSettings,
+{
+    #[inline(always)]
+    pub(crate) fn new(original: &'b BumpScope<'a, A, S>) -> Self
+    where
+        S: BumpAllocatorSettings<Claimable = True>,
+    {
+        let chunk = original.chunk.replace(RawChunk::<A, S>::CLAIMED);
+        let claimed = unsafe { BumpScope::from_raw(chunk.header().cast()) };
+        Self { original, claimed }
+    }
+}
+
+impl<'a, A, S> Deref for BumpClaimGuard<'_, 'a, A, S>
+where
+    A: Allocator,
+    S: BumpAllocatorSettings,
+{
+    type Target = BumpScope<'a, A, S>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.claimed
+    }
+}
+
+impl<A, S> DerefMut for BumpClaimGuard<'_, '_, A, S>
+where
+    A: Allocator,
+    S: BumpAllocatorSettings,
+{
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.claimed
+    }
+}
+
+impl<A, S> Drop for BumpClaimGuard<'_, '_, A, S>
+where
+    A: Allocator,
+    S: BumpAllocatorSettings,
+{
+    #[inline(always)]
+    fn drop(&mut self) {
+        self.original.chunk.set(self.claimed.chunk.get());
+    }
+}

--- a/src/bump_scope_guard.rs
+++ b/src/bump_scope_guard.rs
@@ -8,7 +8,10 @@ use crate::{
     stats::{AnyStats, Stats},
 };
 
-/// This is returned from [`checkpoint`](Bump::checkpoint) and used for [`reset_to`](Bump::reset_to).
+/// This is returned from [`checkpoint`] and used for [`reset_to`].
+///
+/// [`checkpoint`]: crate::traits::BumpAllocatorCore::checkpoint
+/// [`reset_to`]: crate::traits::BumpAllocatorCore::reset_to
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Checkpoint {
     pub(crate) chunk: NonNull<ChunkHeader>,
@@ -33,7 +36,9 @@ impl Checkpoint {
     }
 }
 
-/// Returned from [`BumpScope::scope_guard`].
+/// Returned from [`BumpAllocator::scope_guard`].
+///
+/// [`BumpAllocator::scope_guard`]: crate::traits::BumpAllocator::scope_guard
 pub struct BumpScopeGuard<'a, A, S = BumpSettings>
 where
     S: BumpAllocatorSettings<GuaranteedAllocated = True>,

--- a/src/traits/bump_allocator_typed.rs
+++ b/src/traits/bump_allocator_typed.rs
@@ -315,6 +315,8 @@ pub unsafe trait BumpAllocatorTyped: BumpAllocatorCore {
     /// # Panics
     /// Panics if the allocation fails.
     ///
+    /// Panics if the bump allocator is currently [claimed].
+    ///
     /// # Examples
     /// ```
     /// # use bump_scope::Bump;
@@ -327,6 +329,7 @@ pub unsafe trait BumpAllocatorTyped: BumpAllocatorCore {
     ///
     /// [stats]: crate::traits::BumpAllocatorScope::stats
     /// [remaining]: Stats::remaining
+    /// [claimed]: crate::traits::BumpAllocatorScope::claim
     #[cfg(feature = "panic-on-alloc")]
     fn reserve_bytes(&self, additional: usize);
 
@@ -337,6 +340,9 @@ pub unsafe trait BumpAllocatorTyped: BumpAllocatorCore {
     ///
     /// # Errors
     /// Errors if the allocation fails.
+    ///
+    /// # Panics
+    /// Panics if the bump allocator is currently [claimed].
     ///
     /// # Examples
     /// ```
@@ -351,6 +357,7 @@ pub unsafe trait BumpAllocatorTyped: BumpAllocatorCore {
     ///
     /// [stats]: crate::traits::BumpAllocatorScope::stats
     /// [remaining]: Stats::remaining
+    /// [claimed]: crate::traits::BumpAllocatorScope::claim
     fn try_reserve_bytes(&self, additional: usize) -> Result<(), AllocError>;
 }
 

--- a/src/traits/macros.rs
+++ b/src/traits/macros.rs
@@ -12,6 +12,21 @@ macro_rules! forward_methods {
         access_mut: {$access_mut:expr}
         lifetime: $lifetime:lifetime
     ) => {
+        /// Forwards to [`BumpAllocatorScope::claim`].
+        #[inline(always)]
+        pub fn claim(&$self) -> BumpClaimGuard<'_, $lifetime, A, S>
+        where
+            S: BumpAllocatorSettings<Claimable = True>,
+        {
+            BumpAllocatorScope::claim($access)
+        }
+
+        /// Forwards to [`BumpAllocatorCore::is_claimed`].
+        #[inline(always)]
+        pub fn is_claimed(&self) -> bool {
+            BumpAllocatorCore::is_claimed(self)
+        }
+
         /// Forwards to [`BumpAllocator::scoped`].
         #[inline(always)]
         pub fn scoped<R>(&mut $self, f: impl FnOnce(BumpScope<A, S>) -> R) -> R

--- a/tests/claim.rs
+++ b/tests/claim.rs
@@ -1,0 +1,289 @@
+#![cfg(all(feature = "std", feature = "panic-on-alloc"))]
+
+use std::{
+    alloc::Layout,
+    panic,
+    panic::{AssertUnwindSafe, UnwindSafe},
+    ptr::NonNull,
+    string::String,
+};
+
+use bump_scope::{
+    BumpBox, BumpVec,
+    alloc::{AllocError, Allocator, Global},
+    bump_vec,
+    settings::BumpSettings,
+    traits::{BumpAllocatorCore, BumpAllocatorTyped},
+};
+
+macro_rules! either_way {
+    ($($(#[$attr:meta])* $ident:ident)*) => {
+        $(
+            mod $ident {
+                #[test]
+                $(#[$attr])*
+                fn up() {
+                    std::eprintln!("`UP` is `true`");
+                    super::$ident::<true>();
+                }
+
+                #[test]
+                $(#[$attr])*
+                fn down() {
+                    std::eprintln!("`UP` is `false`");
+                    super::$ident::<false>();
+                }
+            }
+        )*
+    };
+}
+
+either_way! {
+    api_fails_on_claimed_bump
+
+    scoped
+
+    scope_guard
+
+    alloc_mut
+}
+
+type Bump<const UP: bool, A = Global> = bump_scope::Bump<A, BumpSettings<1, UP>>;
+
+fn api_fails_on_claimed_bump<const UP: bool>() {
+    trait Whatever {}
+    impl<T: ?Sized> Whatever for T {}
+
+    trait IsDangling {
+        fn is_dangling(&self) -> bool;
+    }
+
+    impl<T> IsDangling for NonNull<T> {
+        fn is_dangling(&self) -> bool {
+            *self == NonNull::dangling()
+        }
+    }
+
+    impl<T> IsDangling for NonNull<[T]> {
+        fn is_dangling(&self) -> bool {
+            self.cast::<u8>().is_dangling()
+        }
+    }
+
+    impl<T> IsDangling for BumpBox<'_, T>
+    where
+        T: ?Sized,
+        NonNull<T>: IsDangling,
+    {
+        fn is_dangling(&self) -> bool {
+            BumpBox::as_raw(self).is_dangling()
+        }
+    }
+
+    fn expect_err(result: Result<impl Whatever, AllocError>) {
+        assert!(result.is_err());
+    }
+
+    fn expect_dangling(ptr: impl IsDangling) {
+        assert!(ptr.is_dangling());
+    }
+
+    fn expect_dangling_ok(result: Result<impl IsDangling, AllocError>) {
+        expect_dangling(result.unwrap());
+    }
+
+    fn expect_panic<R>(f: impl FnMut() -> R) {
+        match catch(AssertUnwindSafe(f)) {
+            Ok(_) => panic!("expected panic"),
+            Err(err) => {
+                if err != "bump allocator is claimed" && err != "bump allocator is already claimed" {
+                    panic!("wrong panic message: {err}");
+                }
+            }
+        }
+    }
+
+    let bump = <Bump<UP>>::new();
+    let boxed = bump.alloc::<[u8; 2]>([1, 2]);
+    let ptr = BumpBox::as_raw(&boxed).cast::<u8>();
+
+    let original_allocated = 2;
+    assert_eq!(bump.stats().allocated(), original_allocated);
+
+    let guard = bump.claim();
+
+    // Allocator
+    {
+        // allocate
+        expect_dangling_ok(bump.allocate(Layout::new::<()>()));
+        expect_err(bump.allocate(Layout::new::<u8>()));
+
+        // allocate_zeroed
+        expect_dangling_ok(bump.allocate_zeroed(Layout::new::<()>()));
+        expect_err(bump.allocate_zeroed(Layout::new::<u8>()));
+
+        // grow
+        expect_err(unsafe { bump.grow(ptr, Layout::new::<[u8; 2]>(), Layout::new::<[u8; 3]>()) });
+
+        // grow_zeroed
+        expect_err(unsafe { bump.grow_zeroed(ptr, Layout::new::<[u8; 2]>(), Layout::new::<[u8; 3]>()) });
+
+        // shrink
+        // doesn't error, but will just return the old ptr and len
+        let new_ptr = unsafe { bump.shrink(ptr, Layout::new::<[u8; 2]>(), Layout::new::<[u8; 1]>()).unwrap() };
+        assert_eq!(new_ptr.len(), 2);
+        assert_eq!(ptr, new_ptr.cast());
+        assert_eq!(guard.stats().allocated(), original_allocated);
+
+        // deallocate
+        // doesn't do anything
+        unsafe { bump.deallocate(ptr, Layout::new::<[u8; 2]>()) };
+        assert_eq!(guard.stats().allocated(), original_allocated);
+    }
+
+    // BumpAllocatorCore
+    {
+        // prepare_allocation
+        expect_err(bump.prepare_allocation(Layout::new::<()>()));
+    }
+
+    // BumpAllocatorCoreScope
+    {
+        // doesn't add any new api
+    }
+
+    // BumpAllocatorTyped
+    {
+        // allocate_layout
+        expect_dangling(bump.allocate_layout(Layout::new::<()>()));
+        expect_dangling_ok(bump.try_allocate_layout(Layout::new::<()>()));
+        expect_panic(|| bump.allocate_layout(Layout::new::<u8>()));
+        expect_err(bump.try_allocate_layout(Layout::new::<u8>()));
+
+        // allocate_sized
+        expect_dangling(bump.allocate_sized::<()>());
+        expect_dangling_ok(bump.try_allocate_sized::<()>());
+        expect_panic(|| bump.allocate_sized::<u8>());
+        expect_err(bump.try_allocate_sized::<u8>());
+
+        // allocate_slice
+        expect_dangling(bump.allocate_slice::<()>(123));
+        expect_dangling_ok(bump.try_allocate_slice::<()>(123));
+        expect_dangling(bump.allocate_slice::<u8>(0));
+        expect_dangling_ok(bump.try_allocate_slice::<u8>(0));
+        expect_panic(|| bump.allocate_slice::<u8>(1));
+        expect_err(bump.try_allocate_slice::<u8>(1));
+
+        // allocate_slice_for
+        expect_dangling(bump.allocate_slice_for::<()>(&[(), (), ()]));
+        expect_dangling_ok(bump.try_allocate_slice_for::<()>(&[(), (), ()]));
+        expect_dangling(bump.allocate_slice_for::<u8>(&[]));
+        expect_dangling_ok(bump.try_allocate_slice_for::<u8>(&[]));
+        expect_panic(|| bump.allocate_slice_for::<u8>(&[1]));
+        expect_err(bump.try_allocate_slice_for::<u8>(&[1]));
+
+        // shrink_slice
+        assert!(unsafe { bump.shrink_slice(ptr, 2, 1) }.is_none());
+
+        // prepare_slice_allocation
+        expect_panic(|| bump.prepare_slice_allocation::<()>(123));
+        expect_err(bump.try_prepare_slice_allocation::<()>(123));
+        expect_panic(|| bump.prepare_slice_allocation::<u8>(123));
+        expect_err(bump.try_prepare_slice_allocation::<u8>(123));
+
+        // dealloc
+        bump.dealloc(boxed);
+        assert_eq!(guard.stats().allocated(), original_allocated);
+
+        // reserve_bytes
+        expect_panic(|| bump.reserve_bytes(123));
+        expect_err(bump.try_reserve_bytes(123));
+    }
+
+    // BumpAllocatorTypedScope
+    {
+        // api is entirely implemented on top of BumpAllocatorTyped
+        // so no need to test it here
+    }
+
+    // BumpAllocator
+    {
+        // scope api is not available because it takes
+        // `&mut self` and `claim` borrows the allocator
+    }
+
+    // BumpAllocatorScope
+    {
+        expect_panic(|| bump.claim());
+    }
+
+    drop(guard);
+    _ = bump.alloc_str("okey dokey");
+    drop(bump);
+}
+
+fn catch<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R, String> {
+    match std::panic::catch_unwind(f) {
+        Ok(r) => Ok(r),
+        Err(err) => {
+            if let Some(&err) = err.downcast_ref::<&str>() {
+                return Err(err.into());
+            }
+
+            if let Some(err) = err.downcast_ref::<String>() {
+                return Err(err.into());
+            }
+
+            Err("panicked".into())
+        }
+    }
+}
+
+fn scoped<const UP: bool>() {
+    let bump = <Bump<UP>>::new();
+
+    let vec1: BumpVec<u8, _> = bump_vec![in &bump; 1, 2, 3];
+    let vec2: BumpVec<u8, _> = bump_vec![in &bump; 4, 5, 6];
+
+    assert_eq!(bump.stats().allocated(), 6);
+
+    bump.claim().scoped(|bump| {
+        let mut both = BumpVec::new_in(&bump);
+        both.extend(vec1.iter().copied());
+        both.extend(vec2.iter().copied());
+        assert_eq!(both, [1, 2, 3, 4, 5, 6]);
+        assert_eq!(bump.stats().allocated(), 6 + both.capacity());
+    });
+
+    assert_eq!(bump.stats().allocated(), 6);
+}
+
+fn scope_guard<const UP: bool>() {
+    let bump = <Bump<UP>>::new();
+
+    let vec1: BumpVec<u8, _> = bump_vec![in &bump; 1, 2, 3];
+    let vec2: BumpVec<u8, _> = bump_vec![in &bump; 4, 5, 6];
+
+    assert_eq!(bump.stats().allocated(), 6);
+
+    {
+        let mut guard = bump.claim();
+        let mut guard = guard.scope_guard();
+        let bump = guard.scope();
+
+        let mut both = BumpVec::new_in(&bump);
+        both.extend(vec1.iter().copied());
+        both.extend(vec2.iter().copied());
+        assert_eq!(both, [1, 2, 3, 4, 5, 6]);
+        assert_eq!(bump.stats().allocated(), 6 + both.capacity());
+    }
+
+    assert_eq!(bump.stats().allocated(), 6);
+}
+
+fn alloc_mut<const UP: bool>() {
+    let bump = <Bump<UP>>::new();
+
+    let uno_dos_tres = bump.claim().alloc_iter_mut([1, 2, 3]);
+    assert_eq!(uno_dos_tres, [1, 2, 3]);
+}

--- a/tests/trybuild/compile_fail/with_settings/bump/into/guaranteed_allocated_increase.stderr
+++ b/tests/trybuild/compile_fail/with_settings/bump/into/guaranteed_allocated_increase.stderr
@@ -22,5 +22,5 @@ note: erroneous constant encountered
 note: the above error was encountered while instantiating `fn BumpScope::<'_, bump_scope::alloc::Global, BumpSettings<1, true, false>>::with_settings::<BumpSettings>`
  --> src/bump.rs
   |
-  |         self.as_mut_scope().claim_mut().with_settings::<NewS>();
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |         unsafe { BumpScope::new_unchecked(self.chunk.get()).with_settings::<NewS>() };
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/trybuild/compile_fail/with_settings/bump/into/up_to_false.stderr
+++ b/tests/trybuild/compile_fail/with_settings/bump/into/up_to_false.stderr
@@ -19,5 +19,5 @@ note: erroneous constant encountered
 note: the above error was encountered while instantiating `fn BumpScope::<'_>::with_settings::<BumpSettings<1, false>>`
  --> src/bump.rs
   |
-  |         self.as_mut_scope().claim_mut().with_settings::<NewS>();
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |         unsafe { BumpScope::new_unchecked(self.chunk.get()).with_settings::<NewS>() };
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/trybuild/compile_fail/with_settings/bump/into/up_to_true.stderr
+++ b/tests/trybuild/compile_fail/with_settings/bump/into/up_to_true.stderr
@@ -19,5 +19,5 @@ note: erroneous constant encountered
 note: the above error was encountered while instantiating `fn BumpScope::<'_, bump_scope::alloc::Global, BumpSettings<1, false>>::with_settings::<BumpSettings>`
  --> src/bump.rs
   |
-  |         self.as_mut_scope().claim_mut().with_settings::<NewS>();
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |         unsafe { BumpScope::new_unchecked(self.chunk.get()).with_settings::<NewS>() };
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Related to #129

### Motivation

Currently allocation scopes and collections like the ones from std don't play well together, because the collections store a reference to the allocator and creating scopes requires that there are no other references to the allocator.

The `BumpVec`/`BumpString` collections work around this to some degree by providing a way to turn them into `Fixed*` collections (that don't store their allocator) and back again.

So to better support other collections and increase ergonomics overall it would be great if `scoped` and `scope_guard` were callable with a shared reference.

### Implementation

To makes scopes work with shared reference, the parent scopes chunk is temporarily replaced by a dummy chunk, so allocations on the parent scope will fail while the child scope is active.

Like with the "unallocated" dummy chunk, the "claimed" dummy chunk is valid for zero sized allocations. Once a non-zero sized allocation is made, `in_another_chunk` will be called which, if our chunk is the claimed dummy chunk, will error.

When a parent scope points at the dummy chunk it loses all knowledge what bump allocator it belongs to, so calling any api like `stats` will return garbage. The `*Guard` type will replace the dummy chunk with the original one on drop.

### Performance

This has no performance impact on the allocator api. The `scope_guard`, `scoped` and `reserve_bytes` methods will now have to check if its chunk is claimed and panic if so.

Those checks can be turned of with the `CLAIMED` setting which also disables the `claim` api.

[^1]: https://github.com/bluurryy/bump-scope/issues/129#issuecomment-3693925003