### PR TITLE
feat: add `Bump::reset_to_start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `Bump::reset_to_start` to reset the bump allocator without deallocating chunks
+
 ## [2.0.0] - 2026-02-09
 
 ### Added

--- a/src/bump.rs
+++ b/src/bump.rs
@@ -699,8 +699,14 @@ where
         })
     }
 
-    // This needs `&mut self` to make sure that no allocations are alive.
-    /// Deallocates every chunk but the newest, which is also the biggest.
+    /// Resets this bump allocator and deallocates all but the largest chunk.
+    ///
+    /// This deallocates all allocations at once by resetting
+    /// the bump pointer to the start of the retained chunk.
+    ///
+    /// For a version of this function that doesn't deallocate chunks, see [`reset_to_start`].
+    ///
+    /// [`reset_to_start`]: Self::reset_to_start
     ///
     /// ```
     /// use bump_scope::Bump;
@@ -727,6 +733,35 @@ where
     #[inline(always)]
     pub fn reset(&mut self) {
         self.raw.reset();
+    }
+
+    /// Resets this bump allocator.
+    ///
+    /// This deallocates all allocations at once by resetting
+    /// the bump pointer to the start of the first chunk.
+    ///
+    /// For a version of this function that also deallocates chunks, see [`reset`].
+    ///
+    /// [`reset`]: Self::reset
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bump_scope::Bump;
+    /// let mut bump: Bump = Bump::new();
+    ///
+    /// {
+    ///     let hello = bump.alloc_str("hello");
+    ///     assert_eq!(bump.stats().allocated(), 5);
+    ///     # _ = hello;
+    /// }
+    ///
+    /// unsafe { bump.reset_to_start(); }
+    /// assert_eq!(bump.stats().allocated(), 0);
+    /// ```
+    #[inline(always)]
+    pub fn reset_to_start(&mut self) {
+        self.raw.reset_to_start();
     }
 
     /// Returns a type which provides statistics about the memory usage of the bump allocator.

--- a/src/raw_bump.rs
+++ b/src/raw_bump.rs
@@ -103,6 +103,20 @@ where
         self.chunk.set(chunk.raw);
     }
 
+    /// Reset's the bump pointer to the very start.
+    #[inline]
+    pub(crate) fn reset_to_start(&self) {
+        if let Some(mut chunk) = self.chunk.get().as_non_dummy() {
+            while let Some(prev) = chunk.prev() {
+                chunk = prev;
+            }
+
+            chunk.reset();
+
+            self.chunk.set(chunk.raw);
+        }
+    }
+
     pub(crate) unsafe fn manually_drop(&mut self) {
         match self.chunk.get().classify() {
             ChunkClass::Claimed => {
@@ -209,20 +223,6 @@ where
                 header: checkpoint.chunk.cast(),
                 marker: PhantomData,
             });
-        }
-    }
-
-    /// Reset's the bump pointer to the very start.
-    #[inline]
-    pub(crate) fn reset_to_start(&self) {
-        if let Some(mut chunk) = self.chunk.get().as_non_dummy() {
-            while let Some(prev) = chunk.prev() {
-                chunk = prev;
-            }
-
-            chunk.reset();
-
-            self.chunk.set(chunk.raw);
         }
     }
 

--- a/src/traits/bump_allocator_core.rs
+++ b/src/traits/bump_allocator_core.rs
@@ -75,6 +75,7 @@ pub unsafe trait BumpAllocatorCore: Allocator + Sealed {
     fn checkpoint(&self) -> Checkpoint;
 
     /// Resets the bump position to a previously created checkpoint.
+    ///
     /// The memory that has been allocated since then will be reused by future allocations.
     ///
     /// # Safety


### PR DESCRIPTION
... to reset the bump allocator without deallocating chunks